### PR TITLE
Remove active development status note from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-_**`This project is in active development. A stable version will be released soon.`**_
-
 # <img src="https://raw.githubusercontent.com/rmagen/unipop/master/docs/images/unipop-logo.png" width=70 style="vertical-align:middle;"> <span style="vertical-align:middle;">Unipop</span>
 [![Build Status](https://travis-ci.org/unipop-graph/unipop.svg?branch=master)](https://travis-ci.org/unipop-graph/unipop)
 


### PR DESCRIPTION
Removes
> _**`This project is in active development. A stable version will be released soon.`**_

Considering the repository has been untouched for 8 years this no longer seems applicable.