### PR TITLE
Run jdbc tests on embedded PostgreSQL (replacing H2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ file:/
 # Cucumber/JUnit test output written outside target/
 cucumber.xml
 *.log
+
+# Local design specs & implementation plans (superpowers) — not committed
+docs/superpowers/

--- a/MIGRATION_NOTES.md
+++ b/MIGRATION_NOTES.md
@@ -115,3 +115,36 @@ test harness; `unipop-rest` has no direct ES source imports and is light):
 - drop the abandoned `io.searchbox:jest`.
 
 To re-enable, restore the three `<module>` entries in the root `pom.xml`.
+
+---
+
+# Follow-on: jdbc tests on embedded PostgreSQL (replacing H2)
+
+The jdbc test suites were switched from H2 to **embedded PostgreSQL** (zonky
+`io.zonky.test:embedded-postgres`, a real Postgres binary run in-process — no Docker), to test
+against the database Unipop targets in production. Test-only deps/config; production jOOQ is
+dialect-agnostic.
+
+- `EmbeddedPostgresServer` (test source) starts one Postgres per JVM on a fixed port (54329),
+  triggered from `JdbcGraphProvider`'s static initializer (annotation reflection does not run
+  suite static blocks, so the trigger lives where the provider is *instantiated*).
+- Config JSONs → `org.postgresql.Driver` / `jdbc:postgresql://localhost:54329/postgres` /
+  `sqlDialect: POSTGRES`; column refs lowercased (Postgres folds unquoted identifiers to lower,
+  and `FieldPropertySchema` looks up result columns case-sensitively); DDL `DOUBLE` → `DOUBLE PRECISION`.
+
+Postgres exposed several issues H2 had masked, now fixed:
+- **Infinite-retry hang**: `ContextManager.execute/render/batch` recursed unboundedly on persistent
+  failure (only `fetch` was capped) — now a shared bounded helper logs the cause and rethrows.
+- **Duplicate-key on insert**: plain `INSERT` re-inserting a PK now uses jOOQ `onDuplicateKeyIgnore()`
+  (portable `ON CONFLICT DO NOTHING`); updates still go through `RowController.update`.
+- **`varchar = bigint` on `g.V(id)`**: the predicate translator now stringifies values targeted at
+  the VARCHAR id column only (numeric value columns keep their type).
+
+**Results (Java 17, embedded Postgres):** feature suite at **H2 parity (~963 pass / 1913)**,
+structure suite clean of DB errors (**~508 pass, 31 fail = H2**). Both suites run with no hang.
+
+**Known residual:** ~13 feature scenarios hit `varchar = integer` on the test edges table's
+`year` VARCHAR column queried numerically — the same type-impedance class in a non-id column. A
+general fix needs accurate per-property type declarations in the configs (the test configs leave
+properties untyped, so text-vs-numeric columns can't be distinguished generically); these are in
+already-failing crew-graph scenarios and do not affect H2 parity.

--- a/unipop-jdbc/pom.xml
+++ b/unipop-jdbc/pom.xml
@@ -14,10 +14,23 @@
             <artifactId>commons-dbcp2</artifactId>
             <version>2.12.0</version>
         </dependency>
+        <!-- Embedded PostgreSQL for tests (real Postgres binary, no Docker). -->
         <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <version>2.3.232</version>
+            <groupId>io.zonky.test</groupId>
+            <artifactId>embedded-postgres</artifactId>
+            <version>2.0.7</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.zonky.test.postgres</groupId>
+            <artifactId>embedded-postgres-binaries-darwin-arm64v8</artifactId>
+            <version>16.4.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.7.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/unipop-jdbc/resources/configuration/basic/default/default.json
+++ b/unipop-jdbc/resources/configuration/basic/default/default.json
@@ -1,8 +1,9 @@
 {
   "class": "org.unipop.jdbc.JdbcSourceProvider",
-  "driver": "org.h2.Driver",
-  "address": ["jdbc:h2:mem:gremlin;NON_KEYWORDS=YEAR,TIME"],
-  "sqlDialect": "H2",
+  "driver": "org.postgresql.Driver",
+  "address": ["jdbc:postgresql://localhost:54329/postgres"],
+  "user": "postgres",
+  "sqlDialect": "POSTGRES",
   "vertices": [
     {
       "table": "vertices",

--- a/unipop-jdbc/resources/configuration/basic/default/default.json
+++ b/unipop-jdbc/resources/configuration/basic/default/default.json
@@ -7,17 +7,17 @@
   "vertices": [
     {
       "table": "vertices",
-      "id": "@ID",
-      "label": "@LABEL",
+      "id": "@id",
+      "label": "@label",
       "properties": {
-        "name": "@NAME",
-        "age": "@AGE",
-        "location": "@LOCATION",
-        "status": "@STATUS",
-        "lang": "@LANG",
-        "oid": "@OID",
-        "test": "@DATA",
-        "communityIndex": "@COMMUNITYINDEX"
+        "name": "@name",
+        "age": "@age",
+        "location": "@location",
+        "status": "@status",
+        "lang": "@lang",
+        "oid": "@oid",
+        "test": "@data",
+        "communityIndex": "@communityindex"
       },
       "dynamicProperties": false
     }
@@ -25,25 +25,25 @@
   "edges": [
     {
       "table": "edges",
-      "id": "@ID",
-      "label": "@LABEL",
+      "id": "@id",
+      "label": "@label",
       "properties": {
-        "year": "@YEAR",
-        "weight": "@WEIGHT",
-        "data": "@DATA",
-        "location": "@LOCATION"
+        "year": "@year",
+        "weight": "@weight",
+        "data": "@data",
+        "location": "@location"
       },
       "dynamicProperties": false,
       "outVertex": {
         "ref": "true",
-        "id": "@OUTID",
-        "label": "@OUTLABEL",
+        "id": "@outid",
+        "label": "@outlabel",
         "properties": {}
       },
       "inVertex": {
         "ref": "true",
-        "id": "@INID",
-        "label": "@INLABEL",
+        "id": "@inid",
+        "label": "@inlabel",
         "properties": {}
       }
 

--- a/unipop-jdbc/resources/configuration/basic/grateful/grateful.json
+++ b/unipop-jdbc/resources/configuration/basic/grateful/grateful.json
@@ -7,42 +7,42 @@
   "vertices": [
     {
       "table": "ARTIST_GRATEFUL_DEAD",
-      "id": "@ID",
+      "id": "@id",
       "label": "artist",
       "properties": {
-        "name": "@NAME"
+        "name": "@name"
       }
     },
     {
       "table": "SONG_GRATEFUL_DEAD",
-      "id": "@ID",
+      "id": "@id",
       "label": "song",
       "properties": {
-        "name": "@NAME",
-        "songType": "@SONGTYPE",
-        "performances": "@PERFORMANCES"
+        "name": "@name",
+        "songType": "@songtype",
+        "performances": "@performances"
       }
     }
   ],
   "edges": [
     {
       "table": "GRATEFUL_DEAD_EDGES",
-      "id": "@ID",
-      "label": "@LABEL",
+      "id": "@id",
+      "label": "@label",
       "properties": {
-        "weight": "@WEIGHT"
+        "weight": "@weight"
       },
       "dynamicProperties": false,
       "outVertex": {
         "ref": true,
-        "id": "@OUTID",
-        "label": "@OUTLABEL",
+        "id": "@outid",
+        "label": "@outlabel",
         "properties": {}
       },
       "inVertex": {
         "ref": true,
-        "id": "@INID",
-        "label": "@INLABEL",
+        "id": "@inid",
+        "label": "@inlabel",
         "properties": {}
       }
     }

--- a/unipop-jdbc/resources/configuration/basic/grateful/grateful.json
+++ b/unipop-jdbc/resources/configuration/basic/grateful/grateful.json
@@ -1,8 +1,9 @@
 {
   "class": "org.unipop.jdbc.JdbcSourceProvider",
-  "driver": "org.h2.Driver",
-  "address": ["jdbc:h2:mem:gremlin;NON_KEYWORDS=YEAR,TIME"],
-  "sqlDialect": "H2",
+  "driver": "org.postgresql.Driver",
+  "address": ["jdbc:postgresql://localhost:54329/postgres"],
+  "user": "postgres",
+  "sqlDialect": "POSTGRES",
   "vertices": [
     {
       "table": "ARTIST_GRATEFUL_DEAD",

--- a/unipop-jdbc/resources/configuration/basic/modern/modern.json
+++ b/unipop-jdbc/resources/configuration/basic/modern/modern.json
@@ -1,8 +1,9 @@
 {
   "class": "org.unipop.jdbc.JdbcSourceProvider",
-  "driver": "org.h2.Driver",
-  "address": ["jdbc:h2:mem:gremlin;NON_KEYWORDS=YEAR,TIME"],
-  "sqlDialect": "H2",
+  "driver": "org.postgresql.Driver",
+  "address": ["jdbc:postgresql://localhost:54329/postgres"],
+  "user": "postgres",
+  "sqlDialect": "POSTGRES",
   "vertices": [
     {
       "table": "vertices",

--- a/unipop-jdbc/resources/configuration/basic/modern/modern.json
+++ b/unipop-jdbc/resources/configuration/basic/modern/modern.json
@@ -7,17 +7,17 @@
   "vertices": [
     {
       "table": "vertices",
-      "id": "@ID",
-      "label": "@LABEL",
+      "id": "@id",
+      "label": "@label",
       "properties": {
-        "name": "@NAME",
-        "age": "@AGE",
-        "location": "@LOCATION",
-        "status": "@STATUS",
-        "lang": "@LANG",
-        "oid": "@OID",
-        "test": "@DATA",
-        "communityIndex": "@COMMUNITYINDEX"
+        "name": "@name",
+        "age": "@age",
+        "location": "@location",
+        "status": "@status",
+        "lang": "@lang",
+        "oid": "@oid",
+        "test": "@data",
+        "communityIndex": "@communityindex"
       },
       "dynamicProperties": false
     }
@@ -25,25 +25,25 @@
   "edges": [
     {
       "table": "edges",
-      "id": "@ID",
-      "label": "@LABEL",
+      "id": "@id",
+      "label": "@label",
       "properties": {
-        "year": "@YEAR",
-        "weight": "@WEIGHT",
-        "data": "@DATA",
-        "location": "@LOCATION"
+        "year": "@year",
+        "weight": "@weight",
+        "data": "@data",
+        "location": "@location"
       },
       "dynamicProperties": false,
       "outVertex": {
         "ref": "true",
-        "id": "@OUTID",
-        "label": "@OUTLABEL",
+        "id": "@outid",
+        "label": "@outlabel",
         "properties": {}
       },
       "inVertex": {
         "ref": "true",
-        "id": "@INID",
-        "label": "@INLABEL",
+        "id": "@inid",
+        "label": "@inlabel",
         "properties": {}
       }
 

--- a/unipop-jdbc/resources/configuration/inneredge/grateful/grateful.json
+++ b/unipop-jdbc/resources/configuration/inneredge/grateful/grateful.json
@@ -7,42 +7,42 @@
   "vertices": [
     {
       "table": "ARTIST_GRATEFUL_DEAD",
-      "id": "@ID",
+      "id": "@id",
       "label": "artist",
       "properties": {
-        "name": "@NAME"
+        "name": "@name"
       }
     },
     {
       "table": "SONG_GRATEFUL_DEAD",
-      "id": "@ID",
+      "id": "@id",
       "label": "song",
       "properties": {
-        "name": "@NAME",
-        "songType": "@SONGTYPE",
-        "performances": "@PERFORMANCES"
+        "name": "@name",
+        "songType": "@songtype",
+        "performances": "@performances"
       }
     }
   ],
   "edges": [
     {
       "table": "GRATEFUL_DEAD_EDGES",
-      "id": "@ID",
-      "label": "@LABEL",
+      "id": "@id",
+      "label": "@label",
       "properties": {
-        "weight": "@WEIGHT"
+        "weight": "@weight"
       },
       "dynamicProperties": false,
       "outVertex": {
         "ref": true,
-        "id": "@OUTID",
-        "label": "@OUTLABEL",
+        "id": "@outid",
+        "label": "@outlabel",
         "properties": {}
       },
       "inVertex": {
         "ref": true,
-        "id": "@INID",
-        "label": "@INLABEL",
+        "id": "@inid",
+        "label": "@inlabel",
         "properties": {}
       }
     }

--- a/unipop-jdbc/resources/configuration/inneredge/grateful/grateful.json
+++ b/unipop-jdbc/resources/configuration/inneredge/grateful/grateful.json
@@ -1,8 +1,9 @@
 {
   "class": "org.unipop.jdbc.JdbcSourceProvider",
-  "driver": "org.h2.Driver",
-  "address": ["jdbc:h2:mem:gremlin;NON_KEYWORDS=YEAR,TIME"],
-  "sqlDialect": "H2",
+  "driver": "org.postgresql.Driver",
+  "address": ["jdbc:postgresql://localhost:54329/postgres"],
+  "user": "postgres",
+  "sqlDialect": "POSTGRES",
   "vertices": [
     {
       "table": "ARTIST_GRATEFUL_DEAD",

--- a/unipop-jdbc/resources/configuration/inneredge/modern/modern.json
+++ b/unipop-jdbc/resources/configuration/inneredge/modern/modern.json
@@ -7,7 +7,7 @@
   "vertices": [
     {
       "table": "vertex_inner",
-      "id": "@ID",
+      "id": "@id",
       "label": {
         "field": "LABEL",
         "include": [
@@ -15,8 +15,8 @@
         ]
       },
       "properties":{
-        "name": "@NAME",
-        "age": "@AGE"
+        "name": "@name",
+        "age": "@age"
       },
       "dynamicProperties": {
         "excludeFields": [
@@ -29,12 +29,12 @@
       },
       "edges": [
         {
-          "id": "@EDGEID",
+          "id": "@edgeid",
           "label": "knows",
           "direction": "OUT",
           "properties": {
-            "weight": "@EDGEWEIGHT",
-            "name": "@EDGENAME"
+            "weight": "@edgeweight",
+            "name": "@edgename"
           },
           "vertex": {
             "ref": true,
@@ -49,7 +49,7 @@
     },
     {
       "table": "vertex_inner",
-      "id": "@ID",
+      "id": "@id",
       "label": {
         "field": "LABEL",
         "exclude": [
@@ -57,8 +57,8 @@
         ]
       },
       "properties": {
-        "name": "@NAME",
-        "lang": "@LANG"
+        "name": "@name",
+        "lang": "@lang"
       },
       "dynamicProperties": true
     }
@@ -66,7 +66,7 @@
   "edges": [
     {
       "table": "edges",
-      "id": "@ID",
+      "id": "@id",
       "label": {
         "field": "LABEL",
         "exclude": [
@@ -74,7 +74,7 @@
         ]
       },
       "properties": {
-        "weight": "@WEIGHT"
+        "weight": "@weight"
       },
       "dynamicProperties": {
         "excludeProperties":[
@@ -89,15 +89,15 @@
       },
       "outVertex": {
         "ref": true,
-        "id": "@OUTID",
-        "label": "@OUTLABEL",
+        "id": "@outid",
+        "label": "@outlabel",
         "properties":{
         }
       },
       "inVertex": {
         "ref": true,
-        "id": "@INID",
-        "label": "@INLABEL",
+        "id": "@inid",
+        "label": "@inlabel",
         "properties":{
         }
       }

--- a/unipop-jdbc/resources/configuration/inneredge/modern/modern.json
+++ b/unipop-jdbc/resources/configuration/inneredge/modern/modern.json
@@ -1,8 +1,9 @@
 {
   "class": "org.unipop.jdbc.JdbcSourceProvider",
-  "driver": "org.h2.Driver",
-  "address": ["jdbc:h2:mem:gremlin;NON_KEYWORDS=YEAR,TIME"],
-  "sqlDialect": "H2",
+  "driver": "org.postgresql.Driver",
+  "address": ["jdbc:postgresql://localhost:54329/postgres"],
+  "user": "postgres",
+  "sqlDialect": "POSTGRES",
   "vertices": [
     {
       "table": "vertex_inner",

--- a/unipop-jdbc/resources/configuration/inneredgenonref/grateful/grateful.json
+++ b/unipop-jdbc/resources/configuration/inneredgenonref/grateful/grateful.json
@@ -7,42 +7,42 @@
   "vertices": [
     {
       "table": "ARTIST_GRATEFUL_DEAD",
-      "id": "@ID",
+      "id": "@id",
       "label": "artist",
       "properties": {
-        "name": "@NAME"
+        "name": "@name"
       }
     },
     {
       "table": "SONG_GRATEFUL_DEAD",
-      "id": "@ID",
+      "id": "@id",
       "label": "song",
       "properties": {
-        "name": "@NAME",
-        "songType": "@SONGTYPE",
-        "performances": "@PERFORMANCES"
+        "name": "@name",
+        "songType": "@songtype",
+        "performances": "@performances"
       }
     }
   ],
   "edges": [
     {
       "table": "GRATEFUL_DEAD_EDGES",
-      "id": "@ID",
-      "label": "@LABEL",
+      "id": "@id",
+      "label": "@label",
       "properties": {
-        "weight": "@WEIGHT"
+        "weight": "@weight"
       },
       "dynamicProperties": false,
       "outVertex": {
         "ref": true,
-        "id": "@OUTID",
-        "label": "@OUTLABEL",
+        "id": "@outid",
+        "label": "@outlabel",
         "properties": {}
       },
       "inVertex": {
         "ref": true,
-        "id": "@INID",
-        "label": "@INLABEL",
+        "id": "@inid",
+        "label": "@inlabel",
         "properties": {}
       }
     }

--- a/unipop-jdbc/resources/configuration/inneredgenonref/grateful/grateful.json
+++ b/unipop-jdbc/resources/configuration/inneredgenonref/grateful/grateful.json
@@ -1,8 +1,9 @@
 {
   "class": "org.unipop.jdbc.JdbcSourceProvider",
-  "driver": "org.h2.Driver",
-  "address": ["jdbc:h2:mem:gremlin;NON_KEYWORDS=YEAR,TIME"],
-  "sqlDialect": "H2",
+  "driver": "org.postgresql.Driver",
+  "address": ["jdbc:postgresql://localhost:54329/postgres"],
+  "user": "postgres",
+  "sqlDialect": "POSTGRES",
   "vertices": [
     {
       "table": "ARTIST_GRATEFUL_DEAD",

--- a/unipop-jdbc/resources/configuration/inneredgenonref/modern/modern.json
+++ b/unipop-jdbc/resources/configuration/inneredgenonref/modern/modern.json
@@ -7,7 +7,7 @@
   "vertices": [
     {
       "table": "vertex_inner",
-      "id": "@ID",
+      "id": "@id",
       "label": {
         "field": "LABEL",
         "exclude": [
@@ -15,14 +15,14 @@
         ]
       },
       "properties": {
-        "name": "@NAME",
-        "lang": "@LANG"
+        "name": "@name",
+        "lang": "@lang"
       },
       "dynamicProperties": true
     },
     {
       "table": "vertex_inner",
-      "id": "@ID",
+      "id": "@id",
       "label": {
         "field": "LABEL",
         "include": [
@@ -30,8 +30,8 @@
         ]
       },
       "properties":{
-        "name": "@NAME",
-        "age": "@AGE"
+        "name": "@name",
+        "age": "@age"
       },
       "dynamicProperties": {
         "excludeFields": [
@@ -44,11 +44,11 @@
       },
       "edges": [
         {
-          "id": "@EDGEID",
+          "id": "@edgeid",
           "label": "created",
           "direction": "OUT",
           "properties": {
-            "weight": "@EDGEWEIGHT"
+            "weight": "@edgeweight"
           },
           "vertex": {
             "ref": false,
@@ -58,8 +58,8 @@
             },
             "label": "software",
             "properties":{
-              "name": "@EDGENAME",
-              "lang": "@EDGELANG"
+              "name": "@edgename",
+              "lang": "@edgelang"
             }
           }
         }
@@ -69,7 +69,7 @@
   "edges": [
     {
       "table": "edges",
-      "id": "@ID",
+      "id": "@id",
       "label": {
         "field": "LABEL",
         "exclude": [
@@ -77,7 +77,7 @@
         ]
       },
       "properties": {
-        "weight": "@WEIGHT"
+        "weight": "@weight"
       },
       "dynamicProperties": {
         "excludeProperties":[
@@ -92,15 +92,15 @@
       },
       "outVertex": {
         "ref": true,
-        "id": "@OUTID",
-        "label": "@OUTLABEL",
+        "id": "@outid",
+        "label": "@outlabel",
         "properties":{
         }
       },
       "inVertex": {
         "ref": true,
-        "id": "@INID",
-        "label": "@INLABEL",
+        "id": "@inid",
+        "label": "@inlabel",
         "properties":{
         }
       }

--- a/unipop-jdbc/resources/configuration/inneredgenonref/modern/modern.json
+++ b/unipop-jdbc/resources/configuration/inneredgenonref/modern/modern.json
@@ -1,8 +1,9 @@
 {
   "class": "org.unipop.jdbc.JdbcSourceProvider",
-  "driver": "org.h2.Driver",
-  "address": ["jdbc:h2:mem:gremlin;NON_KEYWORDS=YEAR,TIME"],
-  "sqlDialect": "H2",
+  "driver": "org.postgresql.Driver",
+  "address": ["jdbc:postgresql://localhost:54329/postgres"],
+  "user": "postgres",
+  "sqlDialect": "POSTGRES",
   "vertices": [
     {
       "table": "vertex_inner",

--- a/unipop-jdbc/src/org/unipop/jdbc/schemas/AbstractRowSchema.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/schemas/AbstractRowSchema.java
@@ -3,6 +3,7 @@ package org.unipop.jdbc.schemas;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.tinkerpop.gremlin.process.traversal.Order;
 import org.apache.tinkerpop.gremlin.structure.Element;
+import org.apache.tinkerpop.gremlin.structure.T;
 import org.javatuples.Pair;
 import org.jooq.*;
 import org.jooq.Record;
@@ -52,9 +53,14 @@ public abstract class AbstractRowSchema<E extends Element> extends AbstractEleme
         JdbcSchema.Row row = toRow(element);
         if (row == null) return null;
 
+        // ON CONFLICT DO NOTHING (dialect-portable via jOOQ): inserting an already-present
+        // primary key must be idempotent. A plain INSERT throws a duplicate-key error on
+        // strict databases like PostgreSQL (H2 tolerated the re-insert pattern); updates to
+        // existing rows go through the separate update path in RowController.
         return DSL.insertInto(table(getTable()),
                     CollectionUtils.collect(row.getFields().keySet(), DSL::field))
-                    .values(row.getFields().values());
+                    .values(row.getFields().values())
+                    .onDuplicateKeyIgnore();
     }
 
     @Override
@@ -76,7 +82,11 @@ public abstract class AbstractRowSchema<E extends Element> extends AbstractEleme
             return null;
         }
 
-        Condition conditions = new JdbcPredicatesTranslator().translate(predicatesHolder);
+        // The id column is VARCHAR; tell the translator so it stringifies numeric Gremlin ids
+        // (PostgreSQL won't compare varchar = bigint the way H2 did).
+        String idField = getFieldByPropertyKey(T.id.getAccessor());
+        Set<String> idFields = idField == null ? Collections.emptySet() : Collections.singleton(idField);
+        Condition conditions = new JdbcPredicatesTranslator(idFields).translate(predicatesHolder);
         int finalLimit = query.getLimit() < 0 ? Integer.MAX_VALUE : query.getLimit();
 
         SelectConditionStep<Record> where = createSqlQuery(query.getPropertyKeys())

--- a/unipop-jdbc/src/org/unipop/jdbc/schemas/InnerRowEdgeSchema.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/schemas/InnerRowEdgeSchema.java
@@ -82,6 +82,6 @@ public class InnerRowEdgeSchema extends RowEdgeSchema {
         Map<Field<Object>, Object> fields = row.getFields().entrySet().stream()
                 .collect(Collectors.toMap((entry) -> field(entry.getKey()), Map.Entry::getValue));
 //        return DSL.update(table(getTable())).set(fields).where(field(this.getFieldByPropertyKey(T.id.getAccessor())).eq(row.getId()));
-        return DSL.insertInto(table(getTable())).set(fields);
+        return DSL.insertInto(table(getTable())).set(fields).onDuplicateKeyIgnore();
     }
 }

--- a/unipop-jdbc/src/org/unipop/jdbc/utils/ContextManager.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/utils/ContextManager.java
@@ -55,52 +55,41 @@ public class ContextManager {
     }
 
     public List<Map<String, Object>> fetch(ResultQuery query) {
-        return fetch(query, 0);
+        return withRetry("fetch", () -> context.fetch(query).intoMaps());
     }
 
-    private List<Map<String, Object>> fetch(ResultQuery query, int count) {
-        if (count > 3) {
-            throw new IllegalArgumentException("query can't be fetched");
+    /**
+     * Run a jOOQ operation, transparently closing and rebuilding the context on failure.
+     * Retries are BOUNDED: execute/render/batch were previously unbounded recursions that
+     * spin forever when an operation persistently fails (e.g. an incompatible statement),
+     * so the original cause is logged each attempt and rethrown after the cap rather than
+     * hanging.
+     */
+    private <T> T withRetry(final String op, final java.util.function.Supplier<T> action) {
+        Exception last = null;
+        for (int attempt = 1; attempt <= 4; attempt++) {
+            try {
+                return action.get();
+            } catch (final Exception e) {
+                last = e;
+                logger.warn("jOOQ {} failed (attempt {}/4), reconnecting", op, attempt, e);
+                closeQuietly();
+                try {
+                    reloadContexts();
+                } catch (final IOException re) {
+                    logger.error("Failed to reload jOOQ context", re);
+                }
+            }
         }
-        try {
-            return context.fetch(query).intoMaps();
-        } catch (Exception e) {
-            closeQuietly();
-        }
-        try {
-            reloadContexts();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-        return fetch(query, ++count);
+        throw new IllegalStateException("jOOQ " + op + " failed after 4 attempts", last);
     }
 
     public int execute(Query query) {
-        try {
-            return context.execute(query);
-        } catch (Exception e) {
-            closeQuietly();
-        }
-        try {
-            reloadContexts();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-        return execute(query);
+        return withRetry("execute", () -> context.execute(query));
     }
 
     public int execute(String query) {
-        try {
-            return context.execute(query);
-        } catch (Exception e) {
-            closeQuietly();
-        }
-        try {
-            reloadContexts();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-        return execute(query);
+        return withRetry("execute", () -> context.execute(query));
     }
 
     public void close() {
@@ -122,31 +111,13 @@ public class ContextManager {
     }
 
     public Object render(Query query) {
-        try {
-            return context.render(query);
-        } catch (Exception e) {
-            closeQuietly();
-        }
-        try {
-            reloadContexts();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-        return render(query);
+        return withRetry("render", () -> context.render(query));
     }
 
     public void batch(List<Query> bulk) {
-        try {
+        withRetry("batch", () -> {
             context.batch(bulk).execute();
-            return;
-        } catch (Exception e) {
-            closeQuietly();
-        }
-        try {
-            reloadContexts();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-        batch(bulk);
+            return null;
+        });
     }
 }

--- a/unipop-jdbc/src/org/unipop/jdbc/utils/JdbcPredicatesTranslator.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/utils/JdbcPredicatesTranslator.java
@@ -30,6 +30,31 @@ import static org.jooq.impl.DSL.field;
  */
 public class JdbcPredicatesTranslator implements PredicatesTranslator<Condition> {
 
+    private final Set<String> idFields;
+
+    public JdbcPredicatesTranslator() {
+        this(Collections.emptySet());
+    }
+
+    public JdbcPredicatesTranslator(Set<String> idFields) {
+        this.idFields = idFields == null ? Collections.emptySet() : idFields;
+    }
+
+    /**
+     * Coerce id-column predicate values to String. The id column is VARCHAR but Gremlin ids
+     * arrive as numbers (e.g. g.V(1)); PostgreSQL refuses to compare {@code varchar = bigint}
+     * (H2 coerced implicitly). Only id-column values are stringified — numeric value columns
+     * such as age/weight must keep their type.
+     */
+    private static Object stringifyValue(Object value) {
+        if (value instanceof Collection) {
+            return ((Collection<?>) value).stream()
+                    .map(v -> v == null ? null : v.toString())
+                    .collect(Collectors.toList());
+        }
+        return value == null ? null : value.toString();
+    }
+
     @Override
     public Condition translate(PredicatesHolder predicatesHolder) {
         Set<Condition> predicateFilters = predicatesHolder.getPredicates().stream()
@@ -61,7 +86,10 @@ public class JdbcPredicatesTranslator implements PredicatesTranslator<Condition>
         }
         else if (predicate instanceof ExistsP) {
             return field.isNotNull();
-        } else return predicateToQuery(key, value, biPredicate);
+        } else {
+            if (idFields.contains(key)) value = stringifyValue(value);
+            return predicateToQuery(key, value, biPredicate);
+        }
     }
 
     private Condition handleConnectiveP(String key, ConnectiveP predicate) {

--- a/unipop-jdbc/src/test/JdbcGraphProvider.java
+++ b/unipop-jdbc/src/test/JdbcGraphProvider.java
@@ -19,9 +19,11 @@ public class JdbcGraphProvider extends UnipopGraphProvider {
     private final Connection jdbcConnection;
 
     public JdbcGraphProvider() throws SQLException, ClassNotFoundException {
-        Class.forName("org.h2.Driver");
-        // H2 2.x made YEAR/TIME reserved keywords; the test schema uses them as column names.
-        this.jdbcConnection = DriverManager.getConnection("jdbc:h2:mem:gremlin;NON_KEYWORDS=YEAR,TIME");
+        Class.forName("org.postgresql.Driver");
+        // Embedded PostgreSQL is started (fixed port) by the test suites / JdbcWorld before any
+        // provider is constructed (see EmbeddedPostgresServer). Connect with java.sql only.
+        this.jdbcConnection = DriverManager.getConnection(
+                "jdbc:postgresql://localhost:54329/postgres", "postgres", "");
 
         createTables();
     }
@@ -77,7 +79,7 @@ public class JdbcGraphProvider extends UnipopGraphProvider {
                         "CREATEDBY VARCHAR (100)," +
                         "EDGEID VARCHAR (100)," +
                         "EDGELANG VARCHAR (100)," +
-                        "EDGEWEIGHT DOUBLE," +
+                        "EDGEWEIGHT DOUBLE PRECISION," +
                         "EDGENAME VARCHAR(100))"
         );
 
@@ -108,7 +110,7 @@ public class JdbcGraphProvider extends UnipopGraphProvider {
                         "time VARCHAR(100)," +
                         "location VARCHAR(100)," +
                         "data VARCHAR(100)," +
-                        "weight DOUBLE)");
+                        "weight DOUBLE PRECISION)");
         //endregion
 
         //region modern tables
@@ -139,7 +141,7 @@ public class JdbcGraphProvider extends UnipopGraphProvider {
                         "inId VARCHAR(100), " +
                         "inLabel VARCHAR(100)," +
                         "year int," +
-                        "weight DOUBLE)");
+                        "weight DOUBLE PRECISION)");
         //endregion
 
         //region crew tables
@@ -197,7 +199,7 @@ public class JdbcGraphProvider extends UnipopGraphProvider {
                         "outLabel VARCHAR(100), " +
                         "inId VARCHAR(100), " +
                         "inLabel VARCHAR(100)," +
-                        "weight DOUBLE)"
+                        "weight DOUBLE PRECISION)"
         );
         //endregion
     }

--- a/unipop-jdbc/src/test/JdbcGraphProvider.java
+++ b/unipop-jdbc/src/test/JdbcGraphProvider.java
@@ -16,12 +16,24 @@ import java.util.Map;
  * @since 6/20/2016
  */
 public class JdbcGraphProvider extends UnipopGraphProvider {
+    static {
+        // This provider is test-only but lives in main source, while the embedded PostgreSQL
+        // server lives in test source (it needs the test-scope zonky dependency). Start it
+        // reflectively here so there is no main->test/zonky compile dependency. A static
+        // initializer runs on first instantiation, before this constructor body and before any
+        // caller (suite runner / JdbcWorld) connects — so Postgres is always up in time.
+        try {
+            Class.forName("org.unipop.jdbc.suite.EmbeddedPostgresServer")
+                    .getMethod("ensureStarted").invoke(null);
+        } catch (final ReflectiveOperationException e) {
+            throw new IllegalStateException("Could not start embedded PostgreSQL for tests", e);
+        }
+    }
+
     private final Connection jdbcConnection;
 
     public JdbcGraphProvider() throws SQLException, ClassNotFoundException {
         Class.forName("org.postgresql.Driver");
-        // Embedded PostgreSQL is started (fixed port) by the test suites / JdbcWorld before any
-        // provider is constructed (see EmbeddedPostgresServer). Connect with java.sql only.
         this.jdbcConnection = DriverManager.getConnection(
                 "jdbc:postgresql://localhost:54329/postgres", "postgres", "");
 

--- a/unipop-jdbc/test/org/unipop/jdbc/suite/EmbeddedPostgresServer.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/suite/EmbeddedPostgresServer.java
@@ -1,0 +1,43 @@
+package org.unipop.jdbc.suite;
+
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
+
+/**
+ * Starts a single embedded PostgreSQL instance per JVM (on a fixed port) for the JDBC test
+ * suites. Triggered from test sources only, so {@code test.JdbcGraphProvider} (main source)
+ * stays {@code java.sql}-only and {@code embedded-postgres} remains a test-scope dependency.
+ */
+public final class EmbeddedPostgresServer {
+
+    public static final int PORT = 54329;
+    public static final String USER = "postgres";
+    public static final String URL = "jdbc:postgresql://localhost:" + PORT + "/postgres";
+
+    private static volatile EmbeddedPostgres instance;
+
+    private EmbeddedPostgresServer() {
+    }
+
+    /** Idempotently start the embedded PostgreSQL server (once per JVM). */
+    public static synchronized void ensureStarted() {
+        if (instance != null) {
+            return;
+        }
+        try {
+            instance = EmbeddedPostgres.builder().setPort(PORT).start();
+            Runtime.getRuntime().addShutdownHook(new Thread(EmbeddedPostgresServer::stop));
+        } catch (final Exception e) {
+            throw new IllegalStateException("Failed to start embedded PostgreSQL on port " + PORT, e);
+        }
+    }
+
+    private static synchronized void stop() {
+        if (instance != null) {
+            try {
+                instance.close();
+            } catch (final Exception ignored) {
+            }
+            instance = null;
+        }
+    }
+}

--- a/unipop-jdbc/test/org/unipop/jdbc/suite/JdbcFeatureTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/suite/JdbcFeatureTest.java
@@ -38,10 +38,6 @@ import org.junit.runner.RunWith;
         plugin = { "progress", "junit:target/cucumber.xml" })
 public class JdbcFeatureTest {
 
-    static {
-        EmbeddedPostgresServer.ensureStarted();
-    }
-
     public static final class JdbcGuiceFactory extends AbstractGuiceFactory {
         public JdbcGuiceFactory() {
             super(Guice.createInjector(Stage.PRODUCTION, CucumberModules.createScenarioModule(), new ServiceModule()));

--- a/unipop-jdbc/test/org/unipop/jdbc/suite/JdbcFeatureTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/suite/JdbcFeatureTest.java
@@ -12,7 +12,7 @@ import org.junit.runner.RunWith;
 
 /**
  * Cucumber runner for the TinkerPop 3.8 process-compliance feature suite, executed against the
- * JDBC (H2) Unipop provider. Replaces the removed {@code ProcessStandardSuite} JUnit process tests.
+ * JDBC (PostgreSQL) Unipop provider. Replaces the removed {@code ProcessStandardSuite} JUnit process tests.
  *
  * <p>Tags are excluded for capabilities Unipop's JDBC federation provider does not support:
  * graph computer, null/list/set/map/uuid/date-time property values, meta/multi-properties,
@@ -37,6 +37,10 @@ import org.junit.runner.RunWith;
         features = { "classpath:/org/apache/tinkerpop/gremlin/test/features" },
         plugin = { "progress", "junit:target/cucumber.xml" })
 public class JdbcFeatureTest {
+
+    static {
+        EmbeddedPostgresServer.ensureStarted();
+    }
 
     public static final class JdbcGuiceFactory extends AbstractGuiceFactory {
         public JdbcGuiceFactory() {

--- a/unipop-jdbc/test/org/unipop/jdbc/suite/JdbcStructureSuite.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/suite/JdbcStructureSuite.java
@@ -14,4 +14,7 @@ import org.unipop.test.UnipopStructureSuite;
 @RunWith(UnipopStructureSuite.class)
 @GraphProviderClass(provider = JdbcGraphProvider.class, graph = UniGraph.class)
 public class JdbcStructureSuite {
+    static {
+        EmbeddedPostgresServer.ensureStarted();
+    }
 }

--- a/unipop-jdbc/test/org/unipop/jdbc/suite/JdbcStructureSuite.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/suite/JdbcStructureSuite.java
@@ -14,7 +14,4 @@ import org.unipop.test.UnipopStructureSuite;
 @RunWith(UnipopStructureSuite.class)
 @GraphProviderClass(provider = JdbcGraphProvider.class, graph = UniGraph.class)
 public class JdbcStructureSuite {
-    static {
-        EmbeddedPostgresServer.ensureStarted();
-    }
 }

--- a/unipop-jdbc/test/org/unipop/jdbc/suite/JdbcWorld.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/suite/JdbcWorld.java
@@ -13,12 +13,12 @@ import java.lang.annotation.Annotation;
 import java.util.Map;
 
 /**
- * TinkerPop 3.8 Gherkin/Cucumber {@link World} for the JDBC (H2-backed) Unipop provider.
+ * TinkerPop 3.8 Gherkin/Cucumber {@link World} for the JDBC (PostgreSQL-backed) Unipop provider.
  *
  * <p>The old JUnit {@code ProcessStandardSuite} process tests were removed in TinkerPop 3.8;
  * the process compliance suite is now driven by the shared {@code .feature} files in
  * {@code gremlin-test}. This World reuses Unipop's existing {@link JdbcGraphProvider}
- * machinery to build a {@code UniGraph} federated over H2 and to load the standard test
+ * machinery to build a {@code UniGraph} federated over PostgreSQL and to load the standard test
  * graph data (modern/grateful) for each scenario.</p>
  */
 public class JdbcWorld implements World {
@@ -27,6 +27,7 @@ public class JdbcWorld implements World {
 
     @Override
     public GraphTraversalSource getGraphTraversalSource(final LoadGraphWith.GraphData graphData) {
+        EmbeddedPostgresServer.ensureStarted();
         try {
             final JdbcGraphProvider provider = new JdbcGraphProvider();
             final Map<String, Object> baseConf =
@@ -34,8 +35,8 @@ public class JdbcWorld implements World {
             final Configuration configuration = new MapConfiguration(baseConf);
             final Graph graph = provider.openTestGraph(configuration);
 
-            // The H2 in-memory database is shared per-JVM; clear any state left by a prior
-            // scenario before loading this scenario's data.
+            // The embedded PostgreSQL database is shared per-JVM; clear any state left by a
+            // prior scenario before loading this scenario's data.
             provider.truncateTables();
             if (graphData != null) {
                 provider.loadGraphData(graph, loadGraphWith(graphData), this.getClass(), "feature");

--- a/unipop-jdbc/test/org/unipop/jdbc/suite/JdbcWorld.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/suite/JdbcWorld.java
@@ -27,7 +27,6 @@ public class JdbcWorld implements World {
 
     @Override
     public GraphTraversalSource getGraphTraversalSource(final LoadGraphWith.GraphData graphData) {
-        EmbeddedPostgresServer.ensureStarted();
         try {
             final JdbcGraphProvider provider = new JdbcGraphProvider();
             final Map<String, Object> baseConf =


### PR DESCRIPTION
## Summary

Switches the **`unipop-jdbc` test suites from H2 to embedded PostgreSQL** (zonky
`io.zonky.test:embedded-postgres` — a real Postgres binary run in-process, no Docker), so the
JDBC backend is exercised against the database it targets in production. Test deps/config only;
production jOOQ code is dialect-agnostic.

Postgres is stricter than H2 and surfaced several latent issues, fixed here.

## Test harness

- `EmbeddedPostgresServer` (test source) starts **one** Postgres per JVM on a fixed port (54329),
  with a shutdown hook. It's triggered from `JdbcGraphProvider`'s **static initializer** —
  annotation reflection (how `@GraphProviderClass` is read) does *not* run a suite class's static
  block, so the trigger must live where the provider is actually *instantiated*. `JdbcGraphProvider`
  stays `java.sql`-only and calls it reflectively (no main→test/zonky compile dependency).
- Config JSONs → `org.postgresql.Driver`, `jdbc:postgresql://localhost:54329/postgres`,
  `sqlDialect: POSTGRES`, `user: postgres`.
- Column refs lowercased — Postgres folds unquoted identifiers to lowercase and
  `FieldPropertySchema` looks up result columns case-sensitively (H2 folded to upper).
- DDL `DOUBLE` → `DOUBLE PRECISION`.

## Production fixes (Postgres-strictness issues H2 masked)

- **Infinite-retry hang** (`ContextManager`): `execute`/`render`/`batch` recursed **unboundedly**
  on persistent failure — only `fetch` was capped — so a batch that always fails span forever and
  swallowed the cause. Replaced with a shared **bounded** retry helper that logs the cause each
  attempt and rethrows after the cap.
- **Duplicate-key on insert**: plain `INSERT` re-inserting an existing PK threw on Postgres; now
  uses jOOQ `onDuplicateKeyIgnore()` (portable `ON CONFLICT DO NOTHING`). Updates to existing rows
  still go through `RowController.update`.
- **`varchar = bigint`** on `g.V(id)`: numeric Gremlin ids were bound against the VARCHAR id
  column; the predicate translator now stringifies values **targeted at the id column only**
  (numeric value columns like `age` keep their type).

## Verification (Java 17 + embedded Postgres)

- **Feature suite** (`JdbcFeatureTest`, Gherkin): **1913 scenarios, ~963 pass — exact H2 parity**,
  no regression from the production changes. `duplicate key` / `varchar = bigint`: **0**.
- **Structure suite** (`JdbcStructureSuite`): **~508 pass, 31 fail (= H2)**, clean of DB errors, no
  hang (fork isolation + the retry cap).

## Known residual

~13 feature scenarios hit `varchar = integer` on the test edges table's **`year` VARCHAR** column
queried numerically — the same type-impedance class, but a non-id column. A general fix needs
accurate per-property type declarations in the configs (they're currently untyped, so
text-vs-numeric columns can't be told apart generically). These are in already-failing crew-graph
scenarios and don't affect H2 parity.

See `MIGRATION_NOTES.md` for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
