### PR TITLE
Fix jdbc test edges.year column type (resolve varchar=integer on Postgres)

### DIFF
--- a/unipop-jdbc/src/test/JdbcGraphProvider.java
+++ b/unipop-jdbc/src/test/JdbcGraphProvider.java
@@ -117,7 +117,7 @@ public class JdbcGraphProvider extends UnipopGraphProvider {
                         "outLabel VARCHAR(100), " +
                         "inId VARCHAR(100), " +
                         "inLabel VARCHAR(100)," +
-                        "year VARCHAR(100)," +
+                        "year INT," +
                         "acl VARCHAR(100)," +
                         "time VARCHAR(100)," +
                         "location VARCHAR(100)," +


### PR DESCRIPTION
## Summary

Follow-up to #145. Resolves the one documented Postgres residual: the test `edges` table
declared `year VARCHAR(100)`, but scenarios query/store `year` as an **integer**, producing
`operator does not exist: character varying = integer` on PostgreSQL (H2 coerced implicitly).

Change: `edges.year` `VARCHAR(100)` → `INT` in `JdbcGraphProvider` (test schema), matching how the
column is used and consistent with the existing `MODERN_EDGES.year int`.

This is the **minimal, test-only** fix. We deliberately did **not** take the broader
"make core `PropertyType`s coerce + declare per-property types in the configs" route — it touches
shared core used by the deferred elastic/rest modules, with regression risk disproportionate to a
single test-schema mismatch.

## Verification (Java 17, embedded PostgreSQL)

Feature suite (`JdbcFeatureTest`): **1913 scenarios, ~964 pass — at/above H2 parity**, and now
**zero `PSQLException` of any kind** (previously 13 `varchar = integer`). The remaining failures
are genuine partial-provider behaviors (`AssertionError`, `UnsupportedOperationException`), not DB
errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
