### PR TITLE
Support PostgreSQL enum columns in the jdbc backend

### DIFF
--- a/unipop-jdbc/pom.xml
+++ b/unipop-jdbc/pom.xml
@@ -117,6 +117,7 @@
                     <includes>
                         <include>**/JdbcFeatureTest.java</include>
                         <include>**/JdbcStructureSuite.java</include>
+                        <include>**/JdbcEnumTest.java</include>
                     </includes>
                     <environmentVariables>
                         <conf>basic</conf>

--- a/unipop-jdbc/resources/configuration/enums/people.json
+++ b/unipop-jdbc/resources/configuration/enums/people.json
@@ -1,0 +1,21 @@
+{
+  "class": "org.unipop.jdbc.JdbcSourceProvider",
+  "driver": "org.postgresql.Driver",
+  "address": ["jdbc:postgresql://localhost:54329/postgres"],
+  "user": "postgres",
+  "sqlDialect": "POSTGRES",
+  "vertices": [
+    {
+      "table": "people",
+      "id": "@id",
+      "label": "@label",
+      "properties": {
+        "name": "@name",
+        "status": "@status"
+      },
+      "enums": { "status": "mood" },
+      "dynamicProperties": false
+    }
+  ],
+  "edges": []
+}

--- a/unipop-jdbc/src/org/unipop/jdbc/schemas/AbstractRowSchema.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/schemas/AbstractRowSchema.java
@@ -32,15 +32,38 @@ import static org.jooq.impl.DSL.table;
  */
 public abstract class AbstractRowSchema<E extends Element> extends AbstractElementSchema<E> implements JdbcSchema<E> {
     protected String table;
+    // column -> PostgreSQL enum type name, declared via the "enums" config object.
+    private final Map<String, String> enumTypes;
 
     public AbstractRowSchema(JSONObject configuration, UniGraph graph) {
         super(configuration, graph);
         this.table = configuration.optString("table");
+        final JSONObject enumsJson = configuration.optJSONObject("enums");
+        final Map<String, String> enums = new HashMap<>();
+        if (enumsJson != null) {
+            for (String column : enumsJson.keySet()) {
+                final String enumType = enumsJson.getString(column);
+                if (!enumType.matches("^[A-Za-z_][A-Za-z0-9_]*$"))
+                    throw new IllegalArgumentException("Invalid enum type name in config: " + enumType);
+                enums.put(column, enumType);
+            }
+        }
+        this.enumTypes = Collections.unmodifiableMap(enums);
     }
 
     @Override
     public String getTable() {
         return this.table;
+    }
+
+    /** @return the PostgreSQL enum type name for the given column, or {@code null} if not an enum column. */
+    public String getEnumType(String column) {
+        return enumTypes.get(column);
+    }
+
+    /** @return the set of column names declared as PostgreSQL enum columns. */
+    public Set<String> getEnumColumns() {
+        return enumTypes.keySet();
     }
 
     @Override
@@ -86,7 +109,7 @@ public abstract class AbstractRowSchema<E extends Element> extends AbstractEleme
         // (PostgreSQL won't compare varchar = bigint the way H2 did).
         String idField = getFieldByPropertyKey(T.id.getAccessor());
         Set<String> idFields = idField == null ? Collections.emptySet() : Collections.singleton(idField);
-        Condition conditions = new JdbcPredicatesTranslator(idFields).translate(predicatesHolder);
+        Condition conditions = new JdbcPredicatesTranslator(idFields, getEnumColumns()).translate(predicatesHolder);
         int finalLimit = query.getLimit() < 0 ? Integer.MAX_VALUE : query.getLimit();
 
         SelectConditionStep<Record> where = createSqlQuery(query.getPropertyKeys())

--- a/unipop-jdbc/src/org/unipop/jdbc/utils/JdbcPredicatesTranslator.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/utils/JdbcPredicatesTranslator.java
@@ -31,13 +31,29 @@ import static org.jooq.impl.DSL.field;
 public class JdbcPredicatesTranslator implements PredicatesTranslator<Condition> {
 
     private final Set<String> idFields;
+    private final Set<String> enumColumns;
 
     public JdbcPredicatesTranslator() {
-        this(Collections.emptySet());
+        this(Collections.emptySet(), Collections.emptySet());
     }
 
     public JdbcPredicatesTranslator(Set<String> idFields) {
+        this(idFields, Collections.emptySet());
+    }
+
+    public JdbcPredicatesTranslator(Set<String> idFields, Set<String> enumColumns) {
         this.idFields = idFields == null ? Collections.emptySet() : idFields;
+        this.enumColumns = enumColumns == null ? Collections.emptySet() : enumColumns;
+    }
+
+    /**
+     * The jOOQ field for a column. PostgreSQL enum columns are cast to text so they compare
+     * against the (String) predicate value — Postgres won't apply {@code enum = varchar}.
+     */
+    private Field<Object> columnField(String key) {
+        return enumColumns.contains(key)
+                ? DSL.field("{0}::text", Object.class, DSL.field(DSL.name(key)))
+                : field(key);
     }
 
     /**
@@ -80,7 +96,7 @@ public class JdbcPredicatesTranslator implements PredicatesTranslator<Condition>
 
         BiPredicate<?, ?> biPredicate = predicate.getBiPredicate();
 
-        Field<Object> field = field(key);
+        Field<Object> field = columnField(key);
         if (predicate instanceof ConnectiveP){
             return handleConnectiveP(key, (ConnectiveP) predicate);
         }
@@ -88,17 +104,18 @@ public class JdbcPredicatesTranslator implements PredicatesTranslator<Condition>
             return field.isNotNull();
         } else {
             if (idFields.contains(key)) value = stringifyValue(value);
-            return predicateToQuery(key, value, biPredicate);
+            return predicateToQuery(field, value, biPredicate);
         }
     }
 
     private Condition handleConnectiveP(String key, ConnectiveP predicate) {
+        Field<Object> field = columnField(key);
         List<P> predicates = predicate.getPredicates();
         List<Condition> queries = predicates.stream().map(p -> {
             if (p instanceof ConnectiveP) return handleConnectiveP(key, (ConnectiveP) p);
             Object pValue = p.getValue();
             BiPredicate pBiPredicate = p.getBiPredicate();
-            return predicateToQuery(key, pValue, pBiPredicate);
+            return predicateToQuery(field, pValue, pBiPredicate);
         }).collect(Collectors.toList());
         Condition condition = queries.get(0);
         if (predicate instanceof AndP){
@@ -115,18 +132,18 @@ public class JdbcPredicatesTranslator implements PredicatesTranslator<Condition>
         return condition;
     }
 
-    private Condition predicateToQuery(String field, Object value, BiPredicate<?, ?> biPredicate) {
+    private Condition predicateToQuery(Field<Object> field, Object value, BiPredicate<?, ?> biPredicate) {
         if (biPredicate instanceof Compare) {
-            return getCompareCondition(value, biPredicate, field(field));
+            return getCompareCondition(value, biPredicate, field);
         } else if (biPredicate instanceof Contains) {
-            Condition x = getContainsCondition(value, biPredicate, field(field));
+            Condition x = getContainsCondition(value, biPredicate, field);
             if (x != null) return x;
         }
         else if (biPredicate instanceof Text.TextPredicate) {
-            return getTextCondition(value, biPredicate, field(field));
+            return getTextCondition(value, biPredicate, field);
         } else if (biPredicate instanceof Date.DatePredicate) {
             try {
-                return getDateCondition(value, biPredicate, field(field));
+                return getDateCondition(value, biPredicate, field);
             } catch (ParseException e) {
                 throw new IllegalArgumentException("cant convert to date");
             }

--- a/unipop-jdbc/test/org/unipop/jdbc/enums/JdbcEnumTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/enums/JdbcEnumTest.java
@@ -1,0 +1,65 @@
+package org.unipop.jdbc.enums;
+
+import org.apache.commons.configuration2.BaseConfiguration;
+import org.apache.commons.configuration2.Configuration;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.unipop.jdbc.suite.EmbeddedPostgresServer;
+import org.unipop.structure.UniGraph;
+
+import java.io.File;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Exercises a property backed by a PostgreSQL native enum column (write + query + read + update)
+ * against embedded PostgreSQL.
+ */
+public class JdbcEnumTest {
+
+    private static GraphTraversalSource g;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        EmbeddedPostgresServer.ensureStarted();
+        Class.forName("org.postgresql.Driver");
+        try (Connection c = DriverManager.getConnection(EmbeddedPostgresServer.URL, EmbeddedPostgresServer.USER, "");
+             Statement s = c.createStatement()) {
+            s.execute("DROP TABLE IF EXISTS people");
+            s.execute("DROP TYPE IF EXISTS mood");
+            s.execute("CREATE TYPE mood AS ENUM ('active','inactive')");
+            s.execute("CREATE TABLE people (id varchar(100) primary key, label varchar(100), name varchar(100), status mood)");
+        }
+        String dir = new File(JdbcEnumTest.class.getResource("/configuration/enums/people.json").toURI()).getParent();
+        Configuration conf = new BaseConfiguration();
+        conf.setProperty(Graph.GRAPH, UniGraph.class.getName());
+        conf.setProperty("graphName", "enumtest");
+        conf.setProperty("providers", dir);
+        g = UniGraph.open(conf).traversal();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        if (g != null) g.close();
+    }
+
+    @Test
+    public void shouldWriteQueryReadAndUpdateEnumColumn() {
+        // write
+        g.addV("person").property(T.id, "1").property("name", "marko").property("status", "active").next();
+        // query + read
+        assertEquals(1L, (long) g.V().has("status", "active").count().next());
+        assertEquals("active", g.V("1").values("status").next());
+        // update
+        g.V("1").property("status", "inactive").next();
+        assertEquals("inactive", g.V("1").values("status").next());
+        assertEquals(0L, (long) g.V().has("status", "active").count().next());
+    }
+}


### PR DESCRIPTION
## Summary

Adds support for mapping a Unipop jdbc property to a **PostgreSQL native `enum` column** —
read, write (insert/update), and query. jdbc-local; no core or other-backend changes.

## How

- **Declare** enum columns per vertex/edge config via a dedicated map:
  ```json
  "enums": { "status": "mood" }
  ```
  (column → Postgres enum type name). Parsed in `AbstractRowSchema`; the type name is validated
  as a SQL identifier (`^[A-Za-z_][A-Za-z0-9_]*$`) before use.
- **Query:** enum columns are cast to text in the predicate translator — `status::text = ?` —
  so they compare against the String value (Postgres won't apply `enum = varchar`). The
  translator gained an `enumColumns` parameter alongside the existing `idFields`.
- **Write:** no cast needed — Postgres coerces the bound string on assignment for INSERT/UPDATE.
- **Read:** unchanged — Postgres returns enum values as `String`.

Enum handling is **inert unless `enums` is declared** (`enumColumns.contains(col)`), so non-enum
columns, other dialects, and existing behavior are untouched. (Enum types are Postgres-only, so the
`::text` cast is Postgres-specific by design.)

## Verification (Java 17 + embedded PostgreSQL)

- New `JdbcEnumTest`: creates a `mood` enum type + table, configures a `UniGraph` with the `enums`
  declaration, and asserts `addV().property('status','active')` → `has('status','active')` →
  `values('status')` → update to `'inactive'` → re-query. **Passes.**
- Feature suite (`JdbcFeatureTest`): **~964 pass, 0 `PSQLException`** — exact parity, no regression.

## Note

The original design assumed insert/update would also need `?::enum` casts, but testing showed
Postgres coerces the unknown-typed parameter on assignment — so only the query comparison needed a
cast. The implementation is just the config parse + the query-path text cast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
