### PR TITLE
refactor(jdbc): enum as a keyed property schema

### DIFF
--- a/MIGRATION_NOTES.md
+++ b/MIGRATION_NOTES.md
@@ -148,3 +148,22 @@ structure suite clean of DB errors (**~508 pass, 31 fail = H2**). Both suites ru
 general fix needs accurate per-property type declarations in the configs (the test configs leave
 properties untyped, so text-vs-numeric columns can't be distinguished generically); these are in
 already-failing crew-graph scenarios and do not affect H2 parity.
+
+# Provider property-schema types (jdbc)
+
+Provider-specific PostgreSQL column behaviors are declared as **keyed property schemas** under a
+vertex/edge's `properties`, contributed through `SourceProvider.providerBuilders()` (so they live in
+`unipop-jdbc`, not core):
+
+- **Enum column** — `"<col>": {"type": "enum"}` (optional `"enumType": "<name>"`, validated but
+  metadata-only; optional `"field"` to alias the column). Backed by `EnumPropertySchema` (extends
+  `FieldPropertySchema`); the query comparison renders `col::text = ?`.
+- **JSONB column** — `"<col>": {"type": "jsonb"}`. Schemaless catch-all addressed `<col>.<path>`
+  (any key, nested paths, text comparison). Backed by `JsonbPropertySchema`.
+
+**Breaking change (enum):** the earlier element-level `"enums": {column: typeName}` object is
+**removed** and no longer parsed. Migrate each entry to a keyed declaration on that column, e.g.
+`"status": "@status"` + `"enums": {"status": "mood"}` → `"status": {"type": "enum", "enumType": "mood"}`.
+A stale `"enums"` key is now silently ignored: the column falls back to a plain text column, so an
+enum comparison fails at **query time** with a `PSQLException` (enum vs varchar) rather than at config
+load — update configs when upgrading.

--- a/unipop-jdbc/pom.xml
+++ b/unipop-jdbc/pom.xml
@@ -120,6 +120,7 @@
                         <include>**/JdbcEnumTest.java</include>
                         <include>**/JdbcJsonbTest.java</include>
                         <include>**/JdbcMultiJsonbTest.java</include>
+                        <include>**/EnumPropertySchemaTest.java</include>
                     </includes>
                     <environmentVariables>
                         <conf>basic</conf>

--- a/unipop-jdbc/resources/configuration/enums/people.json
+++ b/unipop-jdbc/resources/configuration/enums/people.json
@@ -11,9 +11,8 @@
       "label": "@label",
       "properties": {
         "name": "@name",
-        "status": "@status"
+        "status": { "type": "enum", "enumType": "mood" }
       },
-      "enums": { "status": "mood" },
       "dynamicProperties": false
     }
   ],

--- a/unipop-jdbc/src/org/unipop/jdbc/JdbcSourceProvider.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/JdbcSourceProvider.java
@@ -8,6 +8,7 @@ import org.unipop.jdbc.controller.simple.RowController;
 import org.unipop.jdbc.schemas.RowEdgeSchema;
 import org.unipop.jdbc.schemas.RowVertexSchema;
 import org.unipop.jdbc.schemas.jdbc.JdbcSchema;
+import org.unipop.jdbc.schemas.property.EnumPropertySchema;
 import org.unipop.jdbc.schemas.property.JsonbPropertySchema;
 import org.unipop.jdbc.utils.ContextManager;
 import org.unipop.jdbc.utils.JdbcPredicatesTranslator;
@@ -17,7 +18,7 @@ import org.unipop.schema.property.PropertySchema;
 import org.unipop.structure.traversalfilter.TraversalFilter;
 import org.unipop.structure.UniGraph;
 
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -57,7 +58,7 @@ public class JdbcSourceProvider implements SourceProvider {
 
     @Override
     public List<PropertySchema.PropertySchemaBuilder> providerBuilders() {
-        return Collections.singletonList(new JsonbPropertySchema.Builder());
+        return Arrays.asList(new JsonbPropertySchema.Builder(), new EnumPropertySchema.Builder());
     }
 
     @Override

--- a/unipop-jdbc/src/org/unipop/jdbc/schemas/AbstractRowSchema.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/schemas/AbstractRowSchema.java
@@ -10,6 +10,7 @@ import org.jooq.Record;
 import org.jooq.impl.DSL;
 import org.json.JSONObject;
 import org.unipop.jdbc.schemas.jdbc.JdbcSchema;
+import org.unipop.jdbc.schemas.property.EnumColumnSchema;
 import org.unipop.jdbc.schemas.property.JsonbColumnSchema;
 import org.unipop.jdbc.utils.ContextManager;
 import org.unipop.jdbc.utils.JdbcPredicatesTranslator;
@@ -33,38 +34,15 @@ import static org.jooq.impl.DSL.table;
  */
 public abstract class AbstractRowSchema<E extends Element> extends AbstractElementSchema<E> implements JdbcSchema<E> {
     protected String table;
-    // column -> PostgreSQL enum type name, declared via the "enums" config object.
-    private final Map<String, String> enumTypes;
 
     public AbstractRowSchema(JSONObject configuration, UniGraph graph) {
         super(configuration, graph);
         this.table = configuration.optString("table");
-        final JSONObject enumsJson = configuration.optJSONObject("enums");
-        final Map<String, String> enums = new HashMap<>();
-        if (enumsJson != null) {
-            for (String column : enumsJson.keySet()) {
-                final String enumType = enumsJson.getString(column);
-                if (!enumType.matches("^[A-Za-z_][A-Za-z0-9_]*$"))
-                    throw new IllegalArgumentException("Invalid enum type name in config: " + enumType);
-                enums.put(column, enumType);
-            }
-        }
-        this.enumTypes = Collections.unmodifiableMap(enums);
     }
 
     @Override
     public String getTable() {
         return this.table;
-    }
-
-    /** @return the PostgreSQL enum type name for the given column, or {@code null} if not an enum column. */
-    public String getEnumType(String column) {
-        return enumTypes.get(column);
-    }
-
-    /** @return the set of column names declared as PostgreSQL enum columns. */
-    public Set<String> getEnumColumns() {
-        return enumTypes.keySet();
     }
 
     @Override
@@ -114,7 +92,11 @@ public abstract class AbstractRowSchema<E extends Element> extends AbstractEleme
                 .filter(s -> s instanceof JsonbColumnSchema)
                 .map(s -> ((JsonbColumnSchema) s).getJsonbColumn())
                 .collect(Collectors.toSet());
-        Condition conditions = new JdbcPredicatesTranslator(idFields, getEnumColumns(), jsonbColumns).translate(predicatesHolder);
+        Set<String> enumColumns = getPropertySchemas().stream()
+                .filter(s -> s instanceof EnumColumnSchema)
+                .map(s -> ((EnumColumnSchema) s).getEnumColumn())
+                .collect(Collectors.toSet());
+        Condition conditions = new JdbcPredicatesTranslator(idFields, enumColumns, jsonbColumns).translate(predicatesHolder);
         int finalLimit = query.getLimit() < 0 ? Integer.MAX_VALUE : query.getLimit();
 
         SelectConditionStep<Record> where = createSqlQuery(query.getPropertyKeys())

--- a/unipop-jdbc/src/org/unipop/jdbc/schemas/property/EnumColumnSchema.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/schemas/property/EnumColumnSchema.java
@@ -1,0 +1,10 @@
+package org.unipop.jdbc.schemas.property;
+
+/**
+ * Implemented by property schemas backed by a PostgreSQL native enum column, so the row schema can
+ * tell the predicates translator which columns to compare as text (col::text = ?).
+ */
+public interface EnumColumnSchema {
+    /** @return the enum column name this schema is backed by. */
+    String getEnumColumn();
+}

--- a/unipop-jdbc/src/org/unipop/jdbc/schemas/property/EnumPropertySchema.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/schemas/property/EnumPropertySchema.java
@@ -1,0 +1,48 @@
+package org.unipop.jdbc.schemas.property;
+
+import org.json.JSONObject;
+import org.unipop.schema.property.AbstractPropertyContainer;
+import org.unipop.schema.property.FieldPropertySchema;
+import org.unipop.schema.property.PropertySchema;
+
+/**
+ * A keyed property schema backing a PostgreSQL native enum column. Extends {@link FieldPropertySchema}
+ * for the column&lt;-&gt;property mapping (read/write/predicate); the column is reported via
+ * {@link EnumColumnSchema} so the jdbc translator compares it as text (col::text = ?). Declare:
+ * {@code "status": {"type":"enum"}}. An optional {@code "enumType"} name is retained as metadata
+ * (validated when present) but is unused at runtime.
+ */
+public class EnumPropertySchema extends FieldPropertySchema implements EnumColumnSchema {
+    private final String enumType;
+
+    public EnumPropertySchema(String key, String field, boolean nullable, String enumType) {
+        super(key, field, nullable);
+        this.enumType = enumType;
+    }
+
+    @Override
+    public String getEnumColumn() {
+        return field;
+    }
+
+    /** @return the optional declared PostgreSQL enum type name (metadata; may be null). */
+    public String getEnumType() {
+        return enumType;
+    }
+
+    public static class Builder implements PropertySchemaBuilder {
+        @Override
+        public PropertySchema build(String key, Object conf, AbstractPropertyContainer container) {
+            if (!(conf instanceof JSONObject)) return null;
+            JSONObject config = (JSONObject) conf;
+            if (!"enum".equalsIgnoreCase(config.optString("type", ""))) return null;
+            String field = config.optString("field", key);
+            if (field.startsWith("@")) field = field.substring(1);
+            String enumType = config.optString("enumType", null);
+            if (enumType != null && !enumType.matches("^[A-Za-z_][A-Za-z0-9_]*$"))
+                throw new IllegalArgumentException("Invalid enum type name in config: " + enumType);
+            boolean nullable = config.optBoolean("nullable", true);
+            return new EnumPropertySchema(key, field, nullable, enumType);
+        }
+    }
+}

--- a/unipop-jdbc/test/org/unipop/jdbc/enums/EnumPropertySchemaTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/enums/EnumPropertySchemaTest.java
@@ -1,0 +1,84 @@
+package org.unipop.jdbc.enums;
+
+import org.json.JSONObject;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.unipop.jdbc.schemas.property.EnumPropertySchema;
+import org.unipop.schema.property.PropertySchema;
+import org.unipop.schema.property.type.DateType;
+import org.unipop.schema.property.type.DoubleType;
+import org.unipop.schema.property.type.FloatType;
+import org.unipop.schema.property.type.IntType;
+import org.unipop.schema.property.type.LongType;
+import org.unipop.schema.property.type.NumberType;
+import org.unipop.schema.property.type.TextType;
+import org.unipop.util.PropertyTypeFactory;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link EnumPropertySchema.Builder} — no database needed. Locks in the config-claim
+ * and enum-type-name validation behavior carried over from the old AbstractRowSchema parsing.
+ */
+public class EnumPropertySchemaTest {
+
+    private final EnumPropertySchema.Builder builder = new EnumPropertySchema.Builder();
+
+    @BeforeClass
+    public static void initPropertyTypes() {
+        // FieldPropertySchema's constructor resolves its PropertyType from PropertyTypeFactory, which
+        // UniGraph populates at graph bootstrap. Replicate that init so the builder works standalone.
+        PropertyTypeFactory.init(Arrays.asList(
+                TextType.class.getCanonicalName(),
+                DateType.class.getCanonicalName(),
+                NumberType.class.getCanonicalName(),
+                DoubleType.class.getCanonicalName(),
+                FloatType.class.getCanonicalName(),
+                IntType.class.getCanonicalName(),
+                LongType.class.getCanonicalName()));
+    }
+
+    @Test
+    public void buildsWithValidEnumType() {
+        PropertySchema schema = builder.build("status",
+                new JSONObject().put("type", "enum").put("enumType", "mood"), null);
+        assertNotNull(schema);
+        assertTrue(schema instanceof EnumPropertySchema);
+        EnumPropertySchema enumSchema = (EnumPropertySchema) schema;
+        assertEquals("status", enumSchema.getKey());
+        assertEquals("status", enumSchema.getEnumColumn());
+        assertEquals("mood", enumSchema.getEnumType());
+    }
+
+    @Test
+    public void buildsWithoutEnumType() {
+        PropertySchema schema = builder.build("status", new JSONObject().put("type", "enum"), null);
+        assertNotNull(schema);
+        assertNull(((EnumPropertySchema) schema).getEnumType());
+    }
+
+    @Test
+    public void stripsLeadingAtFromFieldOverride() {
+        PropertySchema schema = builder.build("status",
+                new JSONObject().put("type", "enum").put("field", "@mood_col"), null);
+        assertEquals("mood_col", ((EnumPropertySchema) schema).getEnumColumn());
+        assertEquals("status", ((EnumPropertySchema) schema).getKey());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsInvalidEnumTypeName() {
+        builder.build("status", new JSONObject().put("type", "enum").put("enumType", "bad name!"), null);
+    }
+
+    @Test
+    public void returnsNullForNonEnumConfig() {
+        assertNull(builder.build("status", new JSONObject().put("type", "jsonb"), null));
+        assertNull(builder.build("status", new JSONObject().put("field", "status"), null));
+        assertNull(builder.build("status", "@status", null));
+    }
+}


### PR DESCRIPTION
## Summary

Re-models PostgreSQL **enum** support as a keyed property schema — consistent with the JSONB support — instead of the ad-hoc element-level `"enums"` map parsed in `AbstractRowSchema`.

Declare an enum column once, under `properties`:
```json
"properties": {
  "name": "@name",
  "status": { "type": "enum", "enumType": "mood" }
}
```
This replaces the old **double declaration** (`"status": "@status"` + a separate `"enums": {"status": "mood"}` object).

## Design

- **`EnumPropertySchema extends `FieldPropertySchema` implements `EnumColumnSchema`** (in `unipop-jdbc`). It inherits all column↔property read/write/predicate mapping; the only additions are the `getEnumColumn()` marker and an optional `enumType` (validated `^[A-Za-z_][A-Za-z0-9_]*$` when present, but **metadata-only** — the query cast is the generic `col::text`).
- Registered through the existing `JdbcSourceProvider.providerBuilders()` chain (now returns both the JSONB and enum builders).
- `AbstractRowSchema.getSearch` collects enum columns from the keyed schemas via the `EnumColumnSchema` marker — the same shape already used for JSONB — and feeds them to `JdbcPredicatesTranslator` (which renders `col::text = ?`). The translator is **unchanged**.
- Removes the `enums` parsing, `enumTypes` map, `getEnumType`, and `getEnumColumns` from `AbstractRowSchema` (net −30 lines there).

## ⚠️ Breaking config change

The element-level `"enums": {column: typeName}` key is **no longer parsed**. A stale config using it won't error at load — the column degrades to a plain text column, so an enum comparison fails at **query time** with a `PSQLException` (enum vs varchar). Migrate each entry to the keyed form. Documented in `MIGRATION_NOTES.md`.

## Testing

On embedded PostgreSQL (zonky):

| Test | Result |
|---|---|
| `JdbcEnumTest` — write / query (`status::text`) / read-back / update | 1/1 green |
| `EnumPropertySchemaTest` — Builder claim + enumType validation (no DB) | 5/5 green |
| `JdbcJsonbTest`, `JdbcMultiJsonbTest` (shared `getSearch`/`providerBuilders`) | green |
| `JdbcFeatureTest` (TinkerPop Gherkin compliance) | baseline, **0 PSQLException** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
