### PR TITLE
Port unipop-elastic to ES 8 + Java 17 (Phase 1 of #143)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,9 +45,8 @@
     <modules>
         <module>unipop-core</module>
         <module>unipop-jdbc</module>
-        <!-- Deferred to the Elasticsearch (ES 8 + Java API Client + Testcontainers) follow-up:
-             ES 5.3.1 + Lucene 6 cannot run on Java 17. unipop-test spans both backends.
         <module>unipop-elastic</module>
+        <!-- Deferred to later #143 phases:
         <module>unipop-rest</module>
         <module>unipop-test</module>
         -->

--- a/unipop-elastic/pom.xml
+++ b/unipop-elastic/pom.xml
@@ -132,6 +132,13 @@
                         </excludes>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <configuration>
+                        <excludePackageNames>test</excludePackageNames>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>

--- a/unipop-elastic/pom.xml
+++ b/unipop-elastic/pom.xml
@@ -127,6 +127,9 @@
                     <version>3.13.0</version>
                     <configuration>
                         <release>17</release>
+                        <excludes>
+                            <exclude>test/**</exclude>
+                        </excludes>
                     </configuration>
                 </plugin>
             </plugins>

--- a/unipop-elastic/pom.xml
+++ b/unipop-elastic/pom.xml
@@ -9,44 +9,23 @@
     <artifactId>unipop-elastic</artifactId>
     <name>Unipop :: Elasticsearch Controllers</name>
     <properties>
-        <elasticsearch.version>5.3.1</elasticsearch.version>
+        <elasticsearch.version>8.15.3</elasticsearch.version>
     </properties>
     <dependencies>
         <dependency>
-            <groupId>pl.allegro.tech</groupId>
-            <artifactId>embedded-elasticsearch</artifactId>
-            <version>2.1.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.elasticsearch.client</groupId>
-            <artifactId>transport</artifactId>
+            <groupId>co.elastic.clients</groupId>
+            <artifactId>elasticsearch-java</artifactId>
             <version>${elasticsearch.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <version>2.9.1</version>
-        </dependency>
-        <dependency><!-- required by elasticsearch -->
-            <groupId>org.elasticsearch.plugin</groupId>
-            <artifactId>transport-netty4-client</artifactId>
-            <version>5.3.1</version>
+            <groupId>org.elasticsearch.client</groupId>
+            <artifactId>elasticsearch-rest-client</artifactId>
+            <version>${elasticsearch.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.esotericsoftware.yamlbeans</groupId>
-            <artifactId>yamlbeans</artifactId>
-            <version>1.09</version>
-        </dependency>
-        <dependency>
-            <groupId>com.googlecode.json-simple</groupId>
-            <artifactId>json-simple</artifactId>
-            <version>1.1.1</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
+            <version>2.1.3</version>
         </dependency>
         <dependency>
             <groupId>com.github.unipop-graph</groupId>
@@ -58,21 +37,6 @@
                     <artifactId>snakeyaml</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.elasticsearch</groupId>
-            <artifactId>elasticsearch</artifactId>
-            <version>${elasticsearch.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.searchbox</groupId>
-            <artifactId>jest</artifactId>
-            <version>5.3.3</version>
-        </dependency>
-        <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <version>20090211</version>
         </dependency>
     </dependencies>
     <build>
@@ -160,10 +124,9 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.1</version>
+                    <version>3.13.0</version>
                     <configuration>
-                        <source>1.8</source>
-                        <target>1.8</target>
+                        <release>17</release>
                     </configuration>
                 </plugin>
             </plugins>

--- a/unipop-elastic/resources/configuration/basic/default/default.json
+++ b/unipop-elastic/resources/configuration/basic/default/default.json
@@ -1,12 +1,11 @@
 {
   "class": "org.unipop.elastic.ElasticSourceProvider",
-  "clusterName": "unipop",
   "addresses": "http://localhost:9200",
   "vertices": [
     {
-      "index": "vertex",
+      "index": "@label",
       "id": "@_id",
-      "label": "@_type",
+      "label": "@label",
       "properties": {
         "gremlin.partitionGraphStrategy.partition": "@partition"
       },
@@ -15,9 +14,9 @@
   ],
   "edges": [
     {
-      "index": "edge",
+      "index": "@label",
       "id": "@_id",
-      "label": "@_type",
+      "label": "@label",
       "properties": {
         "gremlin.partitionGraphStrategy.partition": "@partition"
       },

--- a/unipop-elastic/resources/configuration/basic/grateful/grateful.json
+++ b/unipop-elastic/resources/configuration/basic/grateful/grateful.json
@@ -1,41 +1,24 @@
 {
   "class": "org.unipop.elastic.ElasticSourceProvider",
-  "clusterName": "unipop",
   "addresses": "http://localhost:9200",
   "vertices": [
     {
-      "index": "vertex",
+      "index": "@label",
       "id": "@_id",
-      "label": "@_type",
-      "properties": {
-        "gremlin.partitionGraphStrategy.partition": "@partition"
-      },
+      "label": "@label",
+      "properties": { "gremlin.partitionGraphStrategy.partition": "@partition" },
       "dynamicProperties": true
     }
   ],
   "edges": [
     {
-      "index": "edge",
+      "index": "@label",
       "id": "@_id",
-      "label": "@_type",
-      "properties": {
-        "gremlin.partitionGraphStrategy.partition": "@partition"
-      },
-      "dynamicProperties": {
-        "excludeFields": ["outId", "inId", "outLabel", "inLabel"]
-      },
-      "outVertex": {
-        "ref": true,
-        "id": "@outId",
-        "label": "@outLabel",
-        "properties": {}
-      },
-      "inVertex": {
-        "ref": true,
-        "id": "@inId",
-        "label": "@inLabel",
-        "properties": {}
-      }
+      "label": "@label",
+      "properties": { "gremlin.partitionGraphStrategy.partition": "@partition" },
+      "dynamicProperties": { "excludeFields": ["outId", "inId", "outLabel", "inLabel"] },
+      "outVertex": { "ref": true, "id": "@outId", "label": "@outLabel", "properties": {} },
+      "inVertex":  { "ref": true, "id": "@inId",  "label": "@inLabel",  "properties": {} }
     }
   ]
 }

--- a/unipop-elastic/resources/configuration/basic/modern/modern.json
+++ b/unipop-elastic/resources/configuration/basic/modern/modern.json
@@ -1,42 +1,12 @@
 {
   "class": "org.unipop.elastic.ElasticSourceProvider",
-  "clusterName": "unipop",
   "addresses": "http://localhost:9200",
   "vertices": [
     {
-      "index": "vertex",
+      "index": "@label",
       "id": "@_id",
-      "label": {
-        "field": "_type",
-        "include": "person"
-      },
-      "properties": {
-        "gremlin.partitionGraphStrategy.partition": "@partition"
-      },
-      "dynamicProperties": true
-    },
-    {
-      "index": "vertex",
-      "id": "@_id",
-      "label": {
-        "field": "_type",
-        "include": "software"
-      },
-      "properties": {
-        "gremlin.partitionGraphStrategy.partition": "@partition"
-      },
-      "dynamicProperties": true
-    },
-    {
-      "index": "animal",
-      "id": "@_id",
-      "label": {
-        "field": "_type",
-        "include": ["animal", "dog", "vertex"]
-      },
-      "properties": {
-        "gremlin.partitionGraphStrategy.partition": "@partition"
-      },
+      "label": "@label",
+      "properties": { "gremlin.partitionGraphStrategy.partition": "@partition" },
       "dynamicProperties": true
     }
   ]

--- a/unipop-elastic/resources/configuration/basic/modern/test.json
+++ b/unipop-elastic/resources/configuration/basic/modern/test.json
@@ -1,12 +1,11 @@
 {
   "class": "org.unipop.elastic.ElasticSourceProvider",
-  "clusterName": "unipop",
   "addresses": "http://localhost:9200",
   "edges": [
     {
-      "index": "edge",
+      "index": "@label",
       "id": "@_id",
-      "label": "@_type",
+      "label": "@label",
       "properties": {
         "gremlin.partitionGraphStrategy.partition": "@partition"
       },

--- a/unipop-elastic/resources/configuration/inner/grateful/grateful.json
+++ b/unipop-elastic/resources/configuration/inner/grateful/grateful.json
@@ -1,12 +1,11 @@
 {
   "class": "org.unipop.elastic.ElasticSourceProvider",
-  "clusterName": "unipop",
   "addresses": "http://localhost:9200",
   "vertices": [
     {
-      "index": "vertex",
+      "index": "@label",
       "id": "@_id",
-      "label": "@_type",
+      "label": "@label",
       "properties": {
         "gremlin.partitionGraphStrategy.partition": "@partition"
       },
@@ -15,9 +14,9 @@
   ],
   "edges": [
     {
-      "index": "edge",
+      "index": "@label",
       "id": "@_id",
-      "label": "@_type",
+      "label": "@label",
       "properties": {
         "gremlin.partitionGraphStrategy.partition": "@partition"
       },

--- a/unipop-elastic/resources/configuration/inner/modern/modern.json
+++ b/unipop-elastic/resources/configuration/inner/modern/modern.json
@@ -1,15 +1,14 @@
 {
   "class": "org.unipop.elastic.ElasticSourceProvider",
-  "clusterName": "unipop",
   "addresses": ["http://localhost:9200"],
   "vertices": [
     {
-      "index": "vertex",
+      "index": "@label",
       "type": "person",
       "id": "@_id",
       "label": "person",
       "dynamicProperties": {
-        "excludeFields": ["edgeId", "knownBy", "edgeWeight", "edgeName", "_type"]
+        "excludeFields": ["edgeId", "knownBy", "edgeWeight", "edgeName"]
       },
       "edges": [{
         "id": "@edgeId",
@@ -27,10 +26,10 @@
       }]
     },
     {
-      "index": "vertex",
+      "index": "@label",
       "id": "@_id",
       "label": {
-        "field": "_type",
+        "field": "label",
         "exclude": ["person"]
       },
       "properties": {},
@@ -39,10 +38,10 @@
   ],
   "edges": [
     {
-      "index": "edge",
+      "index": "@label",
       "id": "@_id",
       "label": {
-        "field": "_type",
+        "field": "label",
         "exclude": ["knows"]
       },
       "properties": {},

--- a/unipop-elastic/resources/configuration/nestededge/grateful/grateful.json
+++ b/unipop-elastic/resources/configuration/nestededge/grateful/grateful.json
@@ -1,12 +1,11 @@
 {
   "class": "org.unipop.elastic.ElasticSourceProvider",
-  "clusterName": "unipop",
   "addresses": "http://localhost:9200",
   "vertices": [
     {
-      "index": "vertex",
+      "index": "@label",
       "id": "@_id",
-      "label": "@_type",
+      "label": "@label",
       "properties": {
         "gremlin.partitionGraphStrategy.partition": "@partition"
       },
@@ -15,9 +14,9 @@
   ],
   "edges": [
     {
-      "index": "edge",
+      "index": "@label",
       "id": "@_id",
-      "label": "@_type",
+      "label": "@label",
       "properties": {
         "gremlin.partitionGraphStrategy.partition": "@partition"
       },

--- a/unipop-elastic/resources/configuration/nestededge/modern/modern.json
+++ b/unipop-elastic/resources/configuration/nestededge/modern/modern.json
@@ -1,31 +1,27 @@
 {
   "class": "org.unipop.elastic.ElasticSourceProvider",
-  "clusterName": "unipop",
   "addresses": [
     "http://localhost:9200"
   ],
   "vertices": [
     {
-      "index": "vertex",
+      "index": "@label",
       "id": "@_id",
       "label": {
-        "field": "_type",
+        "field": "label",
         "include": ["animal", "dog", "vertex"]
       },
       "dynamicProperties": {
-        "excludeFields":[
-          "_type"
-        ]
+        "excludeFields": []
       }
     },
     {
-      "index": "vertex",
+      "index": "@label",
       "type": "person",
       "id": "@_id",
       "label": "person",
       "dynamicProperties": {
-        "excludeFields":[
-          "_type",
+        "excludeFields": [
           "creations"
         ]
       },
@@ -54,10 +50,10 @@
   ],
   "edges": [
     {
-      "index": "edge",
+      "index": "@label",
       "id": "@_id",
       "label": {
-        "field": "_type",
+        "field": "label",
         "exclude": [
           "created"
         ]

--- a/unipop-elastic/resources/configuration/nestededgeref/grateful/grateful.json
+++ b/unipop-elastic/resources/configuration/nestededgeref/grateful/grateful.json
@@ -1,12 +1,11 @@
 {
   "class": "org.unipop.elastic.ElasticSourceProvider",
-  "clusterName": "unipop",
   "addresses": "http://localhost:9200",
   "vertices": [
     {
-      "index": "vertex",
+      "index": "@label",
       "id": "@_id",
-      "label": "@_type",
+      "label": "@label",
       "properties": {
         "gremlin.partitionGraphStrategy.partition": "@partition"
       },
@@ -15,9 +14,9 @@
   ],
   "edges": [
     {
-      "index": "edge",
+      "index": "@label",
       "id": "@_id",
-      "label": "@_type",
+      "label": "@label",
       "properties": {
         "gremlin.partitionGraphStrategy.partition": "@partition"
       },

--- a/unipop-elastic/resources/configuration/nestededgeref/modern/modern.json
+++ b/unipop-elastic/resources/configuration/nestededgeref/modern/modern.json
@@ -1,31 +1,27 @@
 {
   "class": "org.unipop.elastic.ElasticSourceProvider",
-  "clusterName": "unipop",
   "addresses": [
     "http://localhost:9200"
   ],
   "vertices": [
     {
-      "index": "vertex",
+      "index": "@label",
       "id": "@_id",
       "label": {
-        "field": "_type",
+        "field": "label",
         "include": ["animal", "dog", "vertex"]
       },
       "dynamicProperties": {
-        "excludeFields":[
-          "_type"
-        ]
+        "excludeFields": []
       }
     },
     {
-      "index": "vertex",
+      "index": "@label",
       "type": "person",
       "id": "@_id",
       "label": "person",
       "dynamicProperties": {
-        "excludeFields":[
-          "_type",
+        "excludeFields": [
           "creations"
         ]
       },
@@ -48,23 +44,21 @@
       ]
     },
     {
-      "index": "vertex",
+      "index": "@label",
       "type": "software",
       "id": "@_id",
       "label": "software",
       "dynamicProperties": {
-        "excludeFields": [
-          "_type"
-        ]
+        "excludeFields": []
       }
     }
   ],
   "edges": [
     {
-      "index": "edge",
+      "index": "@label",
       "id": "@_id",
       "label": {
-        "field": "_type",
+        "field": "label",
         "exclude": [
           "created"
         ]

--- a/unipop-elastic/src/org/unipop/elastic/common/ElasticClient.java
+++ b/unipop-elastic/src/org/unipop/elastic/common/ElasticClient.java
@@ -151,7 +151,7 @@ public class ElasticClient {
 
         @Override
         public int hashCode() {
-            return element.id().hashCode();
+            return 31 * element.id().hashCode() + opHash;
         }
     }
 }

--- a/unipop-elastic/src/org/unipop/elastic/common/ElasticClient.java
+++ b/unipop-elastic/src/org/unipop/elastic/common/ElasticClient.java
@@ -7,6 +7,7 @@ import co.elastic.clients.elasticsearch.core.BulkRequest;
 import co.elastic.clients.elasticsearch.core.BulkResponse;
 import co.elastic.clients.elasticsearch.core.ClearScrollRequest;
 import co.elastic.clients.elasticsearch.core.ScrollRequest;
+import co.elastic.clients.elasticsearch.core.ScrollResponse;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
@@ -104,7 +105,7 @@ public class ElasticClient {
         }
     }
 
-    public SearchResponse<Map> scroll(String scrollId) {
+    public ScrollResponse<Map> scroll(String scrollId) {
         try {
             ScrollRequest request = ScrollRequest.of(s -> s.scrollId(scrollId).scroll(Time.of(t -> t.time("6m"))));
             return client.scroll(request, Map.class);

--- a/unipop-elastic/src/org/unipop/elastic/common/ElasticClient.java
+++ b/unipop-elastic/src/org/unipop/elastic/common/ElasticClient.java
@@ -1,141 +1,157 @@
 package org.unipop.elastic.common;
 
-import com.google.gson.Gson;
-import io.searchbox.action.Action;
-import io.searchbox.action.BulkableAction;
-import io.searchbox.client.JestClient;
-import io.searchbox.client.JestClientFactory;
-import io.searchbox.client.JestResult;
-import io.searchbox.client.config.HttpClientConfig;
-import io.searchbox.core.Bulk;
-import io.searchbox.indices.CreateIndex;
-import io.searchbox.indices.IndicesExists;
-import io.searchbox.indices.mapping.PutMapping;
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.Refresh;
+import co.elastic.clients.elasticsearch._types.Time;
+import co.elastic.clients.elasticsearch.core.BulkRequest;
+import co.elastic.clients.elasticsearch.core.BulkResponse;
+import co.elastic.clients.elasticsearch.core.ClearScrollRequest;
+import co.elastic.clients.elasticsearch.core.ScrollRequest;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+import co.elastic.clients.elasticsearch.indices.CreateIndexRequest;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import org.apache.http.HttpHost;
 import org.apache.tinkerpop.gremlin.structure.Element;
-import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.client.RestClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class ElasticClient {
 
-    Gson gson = new Gson();
     private final static Logger logger = LoggerFactory.getLogger(ElasticClient.class);
 
-    private Map<DocumentIdentifier, BulkableAction> bulk;
-    String STRING_NOT_ANALYZED = "{\"dynamic_templates\" : [{\"not_analyzed\" : {\"match\" : \"*\",\"match_mapping_type\" : \"string\", \"mapping\" : {\"type\" : \"keyword\",\"index\" : \"not_analyzed\", \"fielddata\": true}}}]}";
+    /** Dynamic template that maps every string field as a non-analyzed keyword (ES 8 form). */
+    private static final String KEYWORD_DYNAMIC_TEMPLATE =
+            "{\"dynamic_templates\":[{\"strings_as_keyword\":{\"match_mapping_type\":\"string\"," +
+            "\"mapping\":{\"type\":\"keyword\"}}}]}";
 
-    private final JestClient client;
+    private final RestClient restClient;
+    private final ElasticsearchTransport transport;
+    private final ElasticsearchClient client;
+
+    /** Pending bulk operations keyed by a per-document identity, flushed on refresh() or at 500. */
+    private Map<DocumentIdentifier, BulkOperation> bulk;
 
     public ElasticClient(List<String> addresses) {
-        JestClientFactory factory = new JestClientFactory();
-        factory.setHttpClientConfig(new HttpClientConfig.Builder(addresses).multiThreaded(true).build());
-        this.client = factory.getObject();
+        HttpHost[] hosts = addresses.stream().map(HttpHost::create).toArray(HttpHost[]::new);
+        this.restClient = RestClient.builder(hosts).build();
+        this.transport = new RestClientTransport(restClient, new JacksonJsonpMapper());
+        this.client = new ElasticsearchClient(transport);
+    }
+
+    public ElasticsearchClient getClient() {
+        return client;
     }
 
     public void validateIndex(String indexName) {
         try {
-            IndicesExists indicesExistsRequest = new IndicesExists.Builder(indexName).build();
-            logger.debug("created indexExistsRequests: {}", indicesExistsRequest);
-            JestResult existsResult = client.execute(indicesExistsRequest);
-            logger.debug("indexExistsRequests result: {}", existsResult);
-            if (!existsResult.isSucceeded()) {
-                Settings settings = Settings.builder()
-//                        .put("index.analysis.analyzer.default.type", "keyword")
-                        .put("index.store.type", "mmapfs")
-                        .build();
-                CreateIndex createIndexRequest = new CreateIndex.Builder(indexName).settings(settings).build();
-                execute(createIndexRequest);
-                //TODO: Make this work. Using the above "keyword" configuration in the meantime.
-                PutMapping putMapping = new PutMapping.Builder(indexName, "_default_", STRING_NOT_ANALYZED).build();
-                execute(putMapping);
-                logger.info("created index with settings: {}, indexName: {}, putMapping: {}", settings, indexName, putMapping);
+            boolean exists = client.indices().exists(e -> e.index(indexName)).value();
+            if (!exists) {
+                CreateIndexRequest request = CreateIndexRequest.of(c -> c
+                        .index(indexName)
+                        .mappings(m -> m.withJson(new StringReader(KEYWORD_DYNAMIC_TEMPLATE))));
+                client.indices().create(request);
+                logger.info("created index {}", indexName);
             }
         } catch (IOException e) {
-            logger.error("failed to connect to elastic cluster", e);
+            logger.error("failed to validate/create index {}", indexName, e);
         }
     }
 
-    public JestResult validateNested(String index, String type, String path) {
-        PutMapping putMapping = new PutMapping.Builder(
-                index,
-                type,
-                "{ \"" + type + "\" : { \"properties\" : { \"" + path + "\" : {\"type\" : \"nested\"} } } }"
-        ).build();
-        logger.info("putting mapping for nested, mapping: {}", putMapping);
-        return execute(putMapping);
-    }
-
-    public void bulk(Element element, BulkableAction action) {
-        if(bulk != null && bulk.size() >= 500) refresh();
-        if(bulk == null) bulk = new HashMap<>();
-        DocumentIdentifier documentIdentifier = new DocumentIdentifier(element, action.getId(), action.getType(), action.getIndex());
-        bulk.put(documentIdentifier, action);
+    public void bulk(Element element, BulkOperation op) {
+        if (bulk != null && bulk.size() >= 500) refresh();
+        if (bulk == null) bulk = new HashMap<>();
+        bulk.put(new DocumentIdentifier(element, op), op);
     }
 
     public void refresh() {
-        if(bulk != null) {
-            Bulk bulkAction = new Bulk.Builder().addAction(this.bulk.values()).refresh(true).build();
-            JestResult res = execute(bulkAction);
+        if (bulk == null || bulk.isEmpty()) {
+            bulk = null;
+            return;
+        }
+        List<BulkOperation> ops = new ArrayList<>(bulk.values());
+        try {
+            BulkResponse response = client.bulk(BulkRequest.of(b -> b.operations(ops).refresh(Refresh.True)));
+            if (response.errors()) {
+                response.items().forEach(item -> {
+                    if (item.error() != null) logger.error("bulk item error: {}", item.error().reason());
+                });
+            }
+        } catch (IOException e) {
+            logger.error("failed executing bulk", e);
+        } finally {
             bulk = null;
         }
-//        Refresh refresh = new Refresh.Builder().refresh(true).allowNoIndices(true).build();
-//        execute(refresh);
     }
 
-    public <T extends JestResult> T execute(Action<T> action) {
+    public SearchResponse<Map> search(SearchRequest request) {
         try {
-            logger.debug("executing action: {}, payload: {}", action, action.getData(gson));
-            T result = client.execute(action);
-            if (!result.isSucceeded())
-                logger.error(result.getErrorMessage());
-            return result;
+            return client.search(request, Map.class);
         } catch (IOException e) {
-            logger.error("failed executing action: {},  error: {}, payload: {}", action, e, action.getData(gson));
+            logger.error("failed executing search: {}", request, e);
             return null;
         }
     }
 
-    public void close() {
-        logger.info("shutting down client, client: {}", client);
-        client.shutdownClient();
+    public SearchResponse<Map> scroll(String scrollId) {
+        try {
+            ScrollRequest request = ScrollRequest.of(s -> s.scrollId(scrollId).scroll(Time.of(t -> t.time("6m"))));
+            return client.scroll(request, Map.class);
+        } catch (IOException e) {
+            logger.error("failed executing scroll", e);
+            return null;
+        }
     }
 
+    public void clearScroll(String scrollId) {
+        try {
+            client.clearScroll(ClearScrollRequest.of(c -> c.scrollId(scrollId)));
+        } catch (IOException e) {
+            logger.warn("failed clearing scroll", e);
+        }
+    }
 
-    public class DocumentIdentifier {
-        private Element element;
-        private final String id;
-        private final String type;
-        private final String index;
+    public void close() {
+        try {
+            transport.close();
+            restClient.close();
+        } catch (IOException e) {
+            logger.warn("failed closing client", e);
+        }
+    }
 
-        public DocumentIdentifier(Element element, String id, String type, String index) {
+    /** Identity for de-duplicating pending bulk ops for the same logical document. */
+    public static class DocumentIdentifier {
+        private final Element element;
+        private final int opHash;
+
+        public DocumentIdentifier(Element element, BulkOperation op) {
             this.element = element;
-            this.id = id;
-            this.type = type;
-            this.index = index;
+            this.opHash = op.hashCode();
         }
 
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
-
             DocumentIdentifier that = (DocumentIdentifier) o;
-
-            if (!element.equals(that.element)) return false;
-            if (!id.equals(that.id)) return false;
-            if (!type.equals(that.type)) return false;
-            return index.equals(that.index);
-
+            return opHash == that.opHash && element.equals(that.element);
         }
 
         @Override
         public int hashCode() {
-            return id.hashCode();
+            return element.id().hashCode();
         }
     }
 }

--- a/unipop-elastic/src/org/unipop/elastic/common/FilterHelper.java
+++ b/unipop-elastic/src/org/unipop/elastic/common/FilterHelper.java
@@ -1,5 +1,20 @@
 package org.unipop.elastic.common;
 
+import co.elastic.clients.elasticsearch._types.FieldValue;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.ConstantScoreQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.ExistsQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.FuzzyQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.IdsQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.MatchAllQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.PrefixQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.RangeQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.RegexpQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermsQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.WildcardQuery;
+import co.elastic.clients.json.JsonData;
 import org.apache.tinkerpop.gremlin.process.traversal.Compare;
 import org.apache.tinkerpop.gremlin.process.traversal.Contains;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
@@ -7,14 +22,11 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer;
 import org.apache.tinkerpop.gremlin.process.traversal.util.AndP;
 import org.apache.tinkerpop.gremlin.process.traversal.util.ConnectiveP;
 import org.apache.tinkerpop.gremlin.process.traversal.util.OrP;
-import org.elasticsearch.common.geo.builders.ShapeBuilder;
-import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.json.JsonXContent;
-import org.elasticsearch.index.query.*;
 import org.unipop.process.predicate.ExistsP;
 import org.unipop.process.predicate.Text;
 import org.unipop.query.predicates.PredicatesHolder;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -25,64 +37,68 @@ import java.util.stream.Collectors;
  * TODO: Cleanup and create implementation of PredicatesTranslator with logs.
  */
 public class FilterHelper {
-    public static QueryBuilder createFilterBuilder(PredicatesHolder predicatesHolder) {
+    public static Query createFilterBuilder(PredicatesHolder predicatesHolder) {
 
-        Set<QueryBuilder> predicateFilters = predicatesHolder.getPredicates().stream()
+        Set<Query> predicateFilters = predicatesHolder.getPredicates().stream()
                 .map(FilterHelper::createFilter).collect(Collectors.toSet());
-        Set<QueryBuilder> childFilters = predicatesHolder.getChildren().stream()
+        Set<Query> childFilters = predicatesHolder.getChildren().stream()
                 .map(FilterHelper::createFilterBuilder).collect(Collectors.toSet());
         predicateFilters.addAll(childFilters);
 
 
-        if (predicateFilters.size() == 0) return QueryBuilders.matchAllQuery();
+        if (predicateFilters.size() == 0) return MatchAllQuery.of(m -> m)._toQuery();
         if (predicateFilters.size() == 1) return predicateFilters.iterator().next();
 
 
-        BoolQueryBuilder predicatesQuery = QueryBuilders.boolQuery();
+        List<Query> must = new ArrayList<>();
+        List<Query> should = new ArrayList<>();
         if (predicatesHolder.getClause().equals(PredicatesHolder.Clause.And)) {
-            predicateFilters.forEach(predicatesQuery::must);
+            must.addAll(predicateFilters);
         } else if (predicatesHolder.getClause().equals(PredicatesHolder.Clause.Or)) {
-            predicateFilters.forEach(predicatesQuery::should);
+            should.addAll(predicateFilters);
         } else throw new IllegalArgumentException("Unexpected clause in predicatesHolder: " + predicatesHolder);
 
-        return QueryBuilders.constantScoreQuery(predicatesQuery);
+        Query boolQuery = BoolQuery.of(b -> b.must(must).should(should))._toQuery();
+        return ConstantScoreQuery.of(c -> c.filter(boolQuery))._toQuery();
     }
 
-    public static QueryBuilder createFilter(HasContainer container) {
+    public static Query createFilter(HasContainer container) {
         String key = container.getKey();
         P predicate = container.getPredicate();
         Object value = predicate.getValue();
         BiPredicate<?, ?> biPredicate = predicate.getBiPredicate();
         if (key.equals("_id")) return getIdsFilter(value);
-        else if (key.equals("_type")) return getTypeFilter(container);
+        // _type queries are removed in ES 8 — type discrimination is by index
+        else if (key.equals("_type")) return MatchAllQuery.of(m -> m)._toQuery();
         else if (predicate instanceof ConnectiveP) {
             return handleConnectiveP(key, (ConnectiveP) predicate);
         } else if (biPredicate != null) {
             return predicateToQuery(key, value, biPredicate);
-        } else if (predicate instanceof ExistsP) return QueryBuilders.existsQuery(key);
+        } else if (predicate instanceof ExistsP) return ExistsQuery.of(e -> e.field(key))._toQuery();
         else throw new IllegalArgumentException("HasContainer not supported by unipop");
     }
 
-    private static QueryBuilder handleConnectiveP(String key, ConnectiveP predicate){
+    private static Query handleConnectiveP(String key, ConnectiveP predicate) {
         List<P> predicates = predicate.getPredicates();
-        List<QueryBuilder> queries = predicates.stream().map(p -> {
+        List<Query> queries = predicates.stream().map(p -> {
             if (p instanceof ConnectiveP) return handleConnectiveP(key, (ConnectiveP) p);
             Object pValue = p.getValue();
             BiPredicate pBiPredicate = p.getBiPredicate();
             return predicateToQuery(key, pValue, pBiPredicate);
         }).collect(Collectors.toList());
 
-        BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
+        List<Query> must = new ArrayList<>();
+        List<Query> should = new ArrayList<>();
         if (predicate instanceof AndP)
-            queries.forEach(boolQueryBuilder::must);
+            must.addAll(queries);
         else if (predicate instanceof OrP)
-            queries.forEach(boolQueryBuilder::should);
+            should.addAll(queries);
         else throw new IllegalArgumentException("Connective predicate not supported by unipop");
 
-        return boolQueryBuilder;
+        return BoolQuery.of(b -> b.must(must).should(should))._toQuery();
     }
 
-    private static QueryBuilder predicateToQuery(String key, Object value, BiPredicate<?, ?> biPredicate) {
+    private static Query predicateToQuery(String key, Object value, BiPredicate<?, ?> biPredicate) {
         if (biPredicate instanceof Compare) return getCompareFilter(key, value, biPredicate.toString());
         else if (biPredicate instanceof Contains) return getContainsFilter(key, value, biPredicate);
 //        else if (biPredicate instanceof Geo) return getGeoFilter(key, value, (Geo) biPredicate);
@@ -91,95 +107,91 @@ public class FilterHelper {
         else throw new IllegalArgumentException("predicate not supported by unipop: " + biPredicate.toString());
     }
 
-    private static QueryBuilder getTextFilter(String key, Object value, Text.TextPredicate biPredicate) {
+    private static Query getTextFilter(String key, Object value, Text.TextPredicate biPredicate) {
         String predicate = biPredicate.toString();
         switch (predicate) {
             case "LIKE":
-                return QueryBuilders.wildcardQuery(key, value.toString());
+                return WildcardQuery.of(w -> w.field(key).value(value.toString()))._toQuery();
             case "UNLIKE":
-                return QueryBuilders.boolQuery().mustNot(QueryBuilders.wildcardQuery(key, value.toString()));
+                Query likeQ = WildcardQuery.of(w -> w.field(key).value(value.toString()))._toQuery();
+                return BoolQuery.of(b -> b.mustNot(likeQ))._toQuery();
             case "PREFIX":
-                return QueryBuilders.prefixQuery(key, value.toString());
+                return PrefixQuery.of(p -> p.field(key).value(value.toString()))._toQuery();
             case "UNPREFIX":
-                return QueryBuilders.boolQuery().mustNot(QueryBuilders.prefixQuery(key, value.toString()));
+                Query prefixQ = PrefixQuery.of(p -> p.field(key).value(value.toString()))._toQuery();
+                return BoolQuery.of(b -> b.mustNot(prefixQ))._toQuery();
             case "REGEXP":
-                return QueryBuilders.regexpQuery(key, value.toString());
+                return RegexpQuery.of(r -> r.field(key).value(value.toString()))._toQuery();
             case "UNREGEXP":
-                return QueryBuilders.boolQuery().mustNot(QueryBuilders.regexpQuery(key, value.toString()));
+                Query regexpQ = RegexpQuery.of(r -> r.field(key).value(value.toString()))._toQuery();
+                return BoolQuery.of(b -> b.mustNot(regexpQ))._toQuery();
             case "FUZZY":
-                return QueryBuilders.fuzzyQuery(key, value.toString());
+                return FuzzyQuery.of(f -> f.field(key).value(FieldValue.of(value.toString())))._toQuery();
             case "UNFUZZY":
-                return QueryBuilders.boolQuery().mustNot(QueryBuilders.fuzzyQuery(key, value.toString()));
+                Query fuzzyQ = FuzzyQuery.of(f -> f.field(key).value(FieldValue.of(value.toString())))._toQuery();
+                return BoolQuery.of(b -> b.mustNot(fuzzyQ))._toQuery();
             default:
                 throw new IllegalArgumentException("predicate not supported in has step: " + predicate);
         }
     }
 
-    private static QueryBuilder getTypeFilter(HasContainer has) {
-        BiPredicate<?, ?> biPredicate = has.getBiPredicate();
-        if (biPredicate instanceof Compare) {
-            QueryBuilder query = QueryBuilders.typeQuery(has.getValue().toString());
-            if (biPredicate.equals(Compare.eq)) return query;
-            return QueryBuilders.boolQuery().mustNot(query);
-        } else if (biPredicate instanceof Contains) {
-            Collection values = (Collection) has.getValue();
-            BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
-            boolean within = biPredicate.equals(Contains.within);
-            values.forEach(label -> {
-                TypeQueryBuilder typeQueryBuilder = QueryBuilders.typeQuery(label.toString());
-                if (within) boolQueryBuilder.should(typeQueryBuilder);
-                else boolQueryBuilder.mustNot(typeQueryBuilder);
-            });
-            return boolQueryBuilder;
-        } else throw new IllegalArgumentException("predicate not supported by unipop: " + biPredicate.toString());
-    }
-
-    private static QueryBuilder getIdsFilter(Object value) {
-        IdsQueryBuilder idsQueryBuilder = QueryBuilders.idsQuery();
+    private static Query getIdsFilter(Object value) {
+        List<String> idList = new ArrayList<>();
         if (value instanceof Iterable) {
             for (Object id : (Iterable) value)
-                idsQueryBuilder.addIds(id.toString());
-        } else idsQueryBuilder.addIds(value.toString());
-        return idsQueryBuilder;
+                idList.add(id.toString());
+        } else idList.add(value.toString());
+        return IdsQuery.of(i -> i.values(idList))._toQuery();
     }
 
-    private static QueryBuilder getCompareFilter(String key, Object value, String predicateString) {
+    private static Query getCompareFilter(String key, Object value, String predicateString) {
         switch (predicateString) {
             case ("eq"):
-                return QueryBuilders.termQuery(key, value);
+                return TermQuery.of(t -> t.field(key).value(FieldValue.of(value)))._toQuery();
             case ("neq"):
-                return QueryBuilders.boolQuery().mustNot(QueryBuilders.termQuery(key, value));
+                Query termQ = TermQuery.of(t -> t.field(key).value(FieldValue.of(value)))._toQuery();
+                return BoolQuery.of(b -> b.mustNot(termQ))._toQuery();
             case ("gt"):
-                return QueryBuilders.rangeQuery(key).gt(value);
+                return RangeQuery.of(r -> r.untyped(u -> u.field(key).gt(JsonData.of(value))))._toQuery();
             case ("gte"):
-                return QueryBuilders.rangeQuery(key).gte(value);
+                return RangeQuery.of(r -> r.untyped(u -> u.field(key).gte(JsonData.of(value))))._toQuery();
             case ("lt"):
-                return QueryBuilders.rangeQuery(key).lt(value);
+                return RangeQuery.of(r -> r.untyped(u -> u.field(key).lt(JsonData.of(value))))._toQuery();
             case ("lte"):
-                return QueryBuilders.rangeQuery(key).lte(value);
+                return RangeQuery.of(r -> r.untyped(u -> u.field(key).lte(JsonData.of(value))))._toQuery();
             case ("inside"):
                 List items = (List) value;
                 Object firstItem = items.get(0);
                 Object secondItem = items.get(1);
-                return QueryBuilders.rangeQuery(key).from(firstItem).to(secondItem);
+                return RangeQuery.of(r -> r.untyped(u -> u.field(key).from(JsonData.of(firstItem)).to(JsonData.of(secondItem))))._toQuery();
             default:
                 throw new IllegalArgumentException("predicate not supported in has step: " + predicateString);
         }
     }
 
-    private static QueryBuilder getContainsFilter(String key, Object value, BiPredicate<?, ?> biPredicate) {
-        if (biPredicate == Contains.without) return QueryBuilders.boolQuery().mustNot(QueryBuilders.existsQuery(key));
+    private static Query getContainsFilter(String key, Object value, BiPredicate<?, ?> biPredicate) {
+        if (biPredicate == Contains.without)
+            return BoolQuery.of(b -> b.mustNot(ExistsQuery.of(e -> e.field(key))._toQuery()))._toQuery();
         else if (biPredicate == Contains.within) {
-            if (value == null) return QueryBuilders.existsQuery(key);
-            else if (value instanceof Collection<?>)
-                return QueryBuilders.termsQuery(key, (Collection<?>) value);
-            else if (value.getClass().isArray())
-                return QueryBuilders.termsQuery(key, (Object[]) value);
-            else return QueryBuilders.termsQuery(key, value);
+            if (value == null) return ExistsQuery.of(e -> e.field(key))._toQuery();
+            else if (value instanceof Collection<?>) {
+                List<FieldValue> fieldValues = ((Collection<?>) value).stream()
+                        .map(FieldValue::of)
+                        .collect(Collectors.toList());
+                return TermsQuery.of(t -> t.field(key).terms(tt -> tt.value(fieldValues)))._toQuery();
+            } else if (value.getClass().isArray()) {
+                Object[] arr = (Object[]) value;
+                List<FieldValue> fieldValues = new ArrayList<>();
+                for (Object v : arr) fieldValues.add(FieldValue.of(v));
+                return TermsQuery.of(t -> t.field(key).terms(tt -> tt.value(fieldValues)))._toQuery();
+            } else {
+                List<FieldValue> fieldValues = List.of(FieldValue.of(value));
+                return TermsQuery.of(t -> t.field(key).terms(tt -> tt.value(fieldValues)))._toQuery();
+            }
         } else throw new IllegalArgumentException("predicate not supported by unipop: " + biPredicate.toString());
     }
 
-//    private static QueryBuilder getGeoFilter(String key, Object value, Geo biPredicate) {
+//    private static Query getGeoFilter(String key, Object value, Geo biPredicate) {
 //        try {
 //            String geoJson = value.toString();
 //            XContentParser parser = JsonXContent.jsonXContent.createParser(geoJson);

--- a/unipop-elastic/src/org/unipop/elastic/document/Document.java
+++ b/unipop-elastic/src/org/unipop/elastic/document/Document.java
@@ -4,30 +4,21 @@ import java.util.Map;
 
 public class Document {
     private final String index;
-    private final String type;
     private final String id;
     private final Map<String, Object> fields;
 
-    public Document(String index, String type, String id, Map<String, Object> fields) {
+    public Document(String index, String id, Map<String, Object> fields) {
         this.index = index;
-        this.type = type;
         this.id = id;
         this.fields = fields;
     }
 
-    public String getIndex() {
-        return index;
-    }
+    public String getIndex() { return index; }
+    public String getId() { return id; }
+    public Map<String, Object> getFields() { return fields; }
 
-    public String getType() {
-        return type;
-    }
-
-    public String getId() {
-        return id;
-    }
-
-    public Map<String, Object> getFields() {
-        return fields;
+    @Override
+    public String toString() {
+        return "Document{index='" + index + "', id='" + id + "', fields=" + fields + '}';
     }
 }

--- a/unipop-elastic/src/org/unipop/elastic/document/DocumentController.java
+++ b/unipop-elastic/src/org/unipop/elastic/document/DocumentController.java
@@ -1,22 +1,15 @@
 package org.unipop.elastic.document;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import io.searchbox.action.BulkableAction;
-import io.searchbox.client.JestResult;
-import io.searchbox.core.*;
-import io.searchbox.params.Parameters;
-import org.apache.tinkerpop.gremlin.process.traversal.Order;
-import org.apache.tinkerpop.gremlin.process.traversal.util.MutableMetrics;
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalMetrics;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch.core.ScrollResponse;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+import co.elastic.clients.elasticsearch.core.search.Hit;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.util.iterator.EmptyIterator;
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.search.builder.SearchSourceBuilder;
-import org.elasticsearch.search.sort.SortOrder;
-import org.javatuples.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.unipop.elastic.common.ElasticClient;
@@ -37,16 +30,12 @@ import org.unipop.structure.UniVertex;
 import org.unipop.structure.traversalfilter.TraversalFilter;
 
 import java.util.*;
-import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-//import org.elasticsearch.index.engine.DocumentAlreadyExistsException;
 
 
 public class DocumentController implements SimpleController {
@@ -101,21 +90,20 @@ public class DocumentController implements SimpleController {
 
     //region Query Controller
 
-
     @Override
     public <E extends Element> Iterator<E> search(SearchQuery<E> uniQuery) {
         Set<? extends DocumentSchema<E>> schemas = getSchemas(uniQuery.getReturnType())
                 .stream().filter(schema -> this.traversalFilter.filter(schema, uniQuery.getTraversal()))
                 .map(schema -> ((DocumentSchema<E>) schema))
                 .collect(Collectors.toSet());
-        Map<DocumentSchema<E>, QueryBuilder> searches = schemas.stream()
+        Map<DocumentSchema<E>, Query> searches = schemas.stream()
                 .collect(new SearchCollector<>((schema) -> schema.getSearch(uniQuery)));
         return search(uniQuery, searches);
     }
 
     @Override
     public Iterator<Edge> search(SearchVertexQuery uniQuery) {
-        Map<DocumentEdgeSchema, QueryBuilder> schemas = edgeSchemas.stream()
+        Map<DocumentEdgeSchema, Query> schemas = edgeSchemas.stream()
                 .filter(schema -> this.traversalFilter.filter(schema, uniQuery.getTraversal()))
                 .collect(new SearchCollector<>((schema) -> schema.getSearch(uniQuery)));
         return search(uniQuery, schemas);
@@ -123,7 +111,7 @@ public class DocumentController implements SimpleController {
 
     @Override
     public void fetchProperties(DeferredVertexQuery uniQuery) {
-        Map<DocumentVertexSchema, QueryBuilder> schemas = vertexSchemas.stream()
+        Map<DocumentVertexSchema, Query> schemas = vertexSchemas.stream()
                 .filter(schema -> this.traversalFilter.filter(schema, uniQuery.getTraversal()))
                 .collect(new SearchCollector<>((schema) -> schema.getSearch(uniQuery)));
         Iterator<Vertex> search = search(uniQuery, schemas);
@@ -139,31 +127,20 @@ public class DocumentController implements SimpleController {
     @Override
     public Edge addEdge(AddEdgeQuery uniQuery) {
         UniEdge edge = new UniEdge(uniQuery.getProperties(), uniQuery.getOutVertex(), uniQuery.getInVertex(), null, graph);
-//        try {
         if (index(this.edgeSchemas, edge, true)) return edge;
-//        } catch (DocumentAlreadyExistsException ex) {
-//            logger.warn("Document already exists in elastic", ex);
-//            throw Graph.Exceptions.edgeWithIdAlreadyExists(edge.id());
-//        }
         return null;
     }
 
     @Override
     public Vertex addVertex(AddVertexQuery uniQuery) {
         UniVertex vertex = new UniVertex(uniQuery.getProperties(), null, graph);
-//        try {
         if (index(this.vertexSchemas, vertex, true)) return vertex;
-//        } catch (DocumentAlreadyExistsException ex) {
-//            logger.warn("Document already exists in elastic", ex);
-//            throw Graph.Exceptions.vertexWithIdAlreadyExists(vertex.id());
-//        }
         return null;
     }
 
     @Override
     public <E extends Element> void property(PropertyQuery<E> uniQuery) {
         Set<? extends DocumentSchema<E>> schemas = getSchemas(uniQuery.getElement().getClass());
-        //updates
         index(schemas, uniQuery.getElement(), false);
     }
 
@@ -185,110 +162,65 @@ public class DocumentController implements SimpleController {
 
     //region Elastic Queries
 
-    private void fillChildren(List<MutableMetrics> childMetrics, SearchResult result) {
-        if (childMetrics.size() > 0) {
-            MutableMetrics child = childMetrics.get(0);
-            child.setCount(TraversalMetrics.ELEMENT_COUNT_ID, result.getTotal());
-            child.setDuration(Long.parseLong(result.getJsonObject().get("took").toString()), TimeUnit.MILLISECONDS);
+    /**
+     * Unchecked cast helper: ES client returns Hit<Map> (raw) from search/scroll,
+     * but parseResults expects Hit<Map<String,Object>>. The runtime type is the same;
+     * we suppress the warning and cast the list element-by-element into a new list.
+     */
+    @SuppressWarnings("unchecked")
+    private List<Hit<Map<String, Object>>> castHits(List<? extends Hit<?>> raw) {
+        List<Hit<Map<String, Object>>> result = new ArrayList<>(raw.size());
+        for (Hit<?> h : raw) {
+            result.add((Hit<Map<String, Object>>) h);
         }
+        return result;
     }
 
-    private <E extends Element, S extends DocumentSchema<E>> Pair<S, SearchSourceBuilder> createSearchBuilder(Map.Entry<S, QueryBuilder> kv, SearchQuery<E> query) {
-        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().query(kv.getValue())
-                .size(query.getLimit() == -1 || query.getLimit() > 10000 ? maxLimit : query.getLimit());
-        if (query.getPropertyKeys() == null) searchSourceBuilder.fetchSource(true);
-        else {
-            Set<String> fields = kv.getKey().toFields(query.getPropertyKeys());
-
-            if (fields.size() == 0) searchSourceBuilder.fetchSource(false);
-            else searchSourceBuilder.fetchSource(fields.toArray(new String[fields.size()]), null);
-        }
-        List<Pair<String, Order>> orders = query.getOrders();
-        if (orders != null) {
-            orders.forEach(order -> {
-                Order orderValue = order.getValue1();
-                switch (orderValue) {
-                    case decr:
-                        searchSourceBuilder.sort(kv.getKey()
-                                .getFieldByPropertyKey(order.getValue0()), SortOrder.DESC);
-                        break;
-                    case incr:
-                        searchSourceBuilder.sort(kv.getKey()
-                                .getFieldByPropertyKey(order.getValue0()), SortOrder.ASC);
-                        break;
-                    case shuffle:
-                        break;
-                }
-            });
-        }
-        return Pair.with(kv.getKey(), searchSourceBuilder);
-    }
-
-    private <E extends Element, S extends DocumentSchema<E>> Pair<S, Search> createSearch(Pair<S, SearchSourceBuilder> kv, SearchQuery<E> query) {
-        Search.Builder builder = new Search.Builder(kv.getValue1().toString().replace("\n", ""))
-                .ignoreUnavailable(true).allowNoIndices(true).setParameter(Parameters.SCROLL, "6m");
-        kv.getValue0().getIndex().getIndex(query.getPredicates()).forEach(builder::addIndex);
-        return Pair.with(kv.getValue0(), builder.build());
-    }
-
-    private <E extends Element, S extends DocumentSchema<E>> Iterator<E> search(SearchQuery<E> query, Map<S, QueryBuilder> schemas) {
-//        MetricsRunner metrics = new MetricsRunner(this, query,
-//                schemas.keySet().stream().map(s -> ((ElementSchema) s)).collect(Collectors.toList()));
-
-        //https://www.elastic.co/guide/en/elasticsearch/client/java-rest/master/java-rest-high-search-scroll.html
-
-        if (schemas.size() == 0) return EmptyIterator.instance();
+    private <E extends Element, S extends DocumentSchema<E>> Iterator<E> search(SearchQuery<E> query, Map<S, Query> schemas) {
+        if (schemas.isEmpty()) return EmptyIterator.instance();
         logger.debug("Preparing search. Schemas: {}", schemas);
 
         client.refresh();
 
+        List<E> all = new ArrayList<>();
+        for (Map.Entry<S, Query> entry : schemas.entrySet()) {
+            S schema = entry.getKey();
+            List<String> indices = schema.getIndex().getIndex(query.getPredicates());
+            SearchRequest request = schema.buildSearch(query, entry.getValue())
+                    .index(indices)
+                    .scroll(t -> t.time("6m"))
+                    .build();
 
-        Map<Search, List<Pair<S, Search>>> groupedQueries = schemas.entrySet().parallelStream().filter(Objects::nonNull)
-                .map(kv -> createSearchBuilder(kv, query))
-                .map(kv -> createSearch(kv, query))
-                .collect(Collectors.groupingBy(Pair::getValue1
-                ));
+            SearchResponse<Map> response = client.search(request);
+            if (response == null) continue;
 
-        return groupedQueries.entrySet().stream().flatMap(entry -> {
-            Search search = entry.getKey();
-            List<S> searchSchemas = entry.getValue().stream().map(Pair::getValue0).collect(Collectors.toList());
-            JestResult results = client.execute(search);
-            if (results == null || !results.isSucceeded()) return Stream.empty();
-            JsonElement scroll_id = results.getJsonObject().get("_scroll_id");
-            List<JsonElement> resultsList = new LinkedList<>();
-            results.getJsonObject().get("hits").getAsJsonObject().get("hits").getAsJsonArray().forEach(hit->((LinkedList) resultsList).add(hit));
+            List<Hit<Map<String, Object>>> hits = new ArrayList<>(castHits(response.hits().hits()));
+            String scrollId = response.scrollId();
+            boolean lastBatchWasFull = (response.hits().hits().size() == maxLimit);
 
-            if(scroll_id != null && resultsList.size() > 0 && resultsList.size() == maxLimit) {
-                while (resultsList.size() < query.getLimit() || query.getLimit() == -1) {
-                    results = client.execute(new SearchScroll.Builder(scroll_id.getAsString(), "6m").build());
-                    scroll_id = results.getJsonObject().get("_scroll_id");
-                    JsonArray thisResultAsJsonArray = results.getJsonObject().get("hits").getAsJsonObject().get("hits").getAsJsonArray();
-                    thisResultAsJsonArray.forEach(hit-> ((LinkedList) resultsList).add(hit));
-
-                    if(thisResultAsJsonArray.size() != maxLimit)
-                        break;
-
-                }
+            while (scrollId != null
+                    && lastBatchWasFull
+                    && (query.getLimit() == -1 || hits.size() < query.getLimit())) {
+                ScrollResponse<Map> sr = client.scroll(scrollId);
+                if (sr == null) break;
+                scrollId = sr.scrollId();
+                List<Hit<Map<String, Object>>> batch = castHits(sr.hits().hits());
+                hits.addAll(batch);
+                lastBatchWasFull = (batch.size() == maxLimit);
             }
-            return searchSchemas.stream().map(s -> s.parseResultsOptimized(resultsList, query));
-        }).flatMap(Collection::stream).iterator();
 
-    }
-
-    private boolean valid(MultiSearchResult.MultiSearchResponse multiSearchResponse) {
-        if (multiSearchResponse.isError) {
-            logger.error("failed to execute multiSearch: {}", multiSearchResponse);
-            return false;
+            if (scrollId != null) client.clearScroll(scrollId);
+            all.addAll(schema.parseResults(hits, query));
         }
-        return true;
+        return all.iterator();
     }
 
     private <E extends Element> boolean index(Set<? extends DocumentSchema<E>> schemas, E element, boolean create) {
         for (DocumentSchema<E> schema : schemas) {
-            BulkableAction<DocumentResult> action = schema.addElement(element, create);
-            if (action != null) {
-                logger.debug("indexing element with schema: {}, element: {}, index: {}, client: {}", schema, element, action, client);
-                client.bulk(element, action);
+            BulkOperation op = schema.addElement(element, create);
+            if (op != null) {
+                logger.debug("indexing element with schema: {}, element: {}, client: {}", schema, element, client);
+                client.bulk(element, op);
                 return true;
             }
         }
@@ -297,17 +229,17 @@ public class DocumentController implements SimpleController {
 
     private <E extends Element> void delete(Set<? extends DocumentSchema<E>> schemas, E element) {
         for (DocumentSchema<E> schema : schemas) {
-            Delete.Builder delete = schema.delete(element);
-            if (delete != null) {
+            BulkOperation op = schema.delete(element);
+            if (op != null) {
                 logger.debug("deleting element with schema: {}, element: {}, client: {}", schema, element, client);
-                client.bulk(element, delete.build());
+                client.bulk(element, op);
             }
         }
     }
 
     //endregion
 
-    private class SearchCollector<K extends DocumentSchema, V extends QueryBuilder> implements Collector<K, Map<K, V>, Map<K, V>> {
+    private class SearchCollector<K extends DocumentSchema, V extends Query> implements Collector<K, Map<K, V>, Map<K, V>> {
 
         private final Function<? super K, ? extends V> valueMapper;
 

--- a/unipop-elastic/src/org/unipop/elastic/document/DocumentEdgeSchema.java
+++ b/unipop-elastic/src/org/unipop/elastic/document/DocumentEdgeSchema.java
@@ -1,7 +1,7 @@
 package org.unipop.elastic.document;
 
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import org.apache.tinkerpop.gremlin.structure.Edge;
-import org.elasticsearch.index.query.QueryBuilder;
 import org.unipop.query.search.SearchVertexQuery;
 import org.unipop.schema.element.EdgeSchema;
 
@@ -11,9 +11,9 @@ import org.unipop.schema.element.EdgeSchema;
 public interface DocumentEdgeSchema extends DocumentSchema<Edge>, EdgeSchema {
 
     /**
-     * Converts a Search vertex query to a query builder
+     * Converts a Search vertex query to a Query
      * @param query The search vertex query
-     * @return A query builder
+     * @return A Query
      */
-    QueryBuilder getSearch(SearchVertexQuery query);
+    Query getSearch(SearchVertexQuery query);
 }

--- a/unipop-elastic/src/org/unipop/elastic/document/DocumentSchema.java
+++ b/unipop-elastic/src/org/unipop/elastic/document/DocumentSchema.java
@@ -1,6 +1,7 @@
 package org.unipop.elastic.document;
 
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import org.apache.tinkerpop.gremlin.structure.Element;
@@ -32,12 +33,21 @@ public interface DocumentSchema<E extends Element> extends ElementSchema<E> {
     Query getSearch(SearchQuery<E> query);
 
     /**
+     * Builds an ES 8 SearchRequest.Builder for the given query and ES query.
+     * Handles size, source filtering, and sort ordering.
+     * @param query The search query
+     * @param q     The ES query (from getSearch)
+     * @return A SearchRequest.Builder ready for index/routing configuration by the controller
+     */
+    SearchRequest.Builder buildSearch(SearchQuery<E> query, Query q);
+
+    /**
      * Return a list of elements from ES 8 search hits
      * @param hits  The hits returned by the ES query
      * @param query The UniQuery itself
      * @return A list of elements
      */
-    List<E> parseResults(List<Hit<Map>> hits, PredicateQuery query);
+    List<E> parseResults(List<Hit<Map<String, Object>>> hits, PredicateQuery query);
 
     /**
      * Returns a BulkOperation to insert or update a document

--- a/unipop-elastic/src/org/unipop/elastic/document/DocumentSchema.java
+++ b/unipop-elastic/src/org/unipop/elastic/document/DocumentSchema.java
@@ -1,23 +1,22 @@
 package org.unipop.elastic.document;
 
-import com.google.gson.JsonElement;
-import io.searchbox.action.BulkableAction;
-import io.searchbox.core.Delete;
-import io.searchbox.core.DocumentResult;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+import co.elastic.clients.elasticsearch.core.search.Hit;
 import org.apache.tinkerpop.gremlin.structure.Element;
-import org.elasticsearch.index.query.QueryBuilder;
 import org.unipop.elastic.document.schema.property.IndexPropertySchema;
 import org.unipop.query.predicates.PredicateQuery;
 import org.unipop.query.search.SearchQuery;
 import org.unipop.schema.element.ElementSchema;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * A schema that is represented by a document in ES.
  * @param <E> Element
  */
-public interface DocumentSchema<E extends Element> extends ElementSchema<E>{
+public interface DocumentSchema<E extends Element> extends ElementSchema<E> {
 
     /**
      * Returns the index property schema of the document schema
@@ -26,33 +25,32 @@ public interface DocumentSchema<E extends Element> extends ElementSchema<E>{
     IndexPropertySchema getIndex();
 
     /**
-     * Converts a Search query to a Query builder
+     * Converts a Search query to an ES 8 Query
      * @param query A search query
-     * @return A query builder
+     * @return A Query
      */
-    QueryBuilder getSearch(SearchQuery<E> query);
+    Query getSearch(SearchQuery<E> query);
 
     /**
-     * Return a list of elements
-     * @param result The result of the ES query
+     * Return a list of elements from ES 8 search hits
+     * @param hits  The hits returned by the ES query
      * @param query The UniQuery itself
      * @return A list of elements
      */
-    List<E> parseResults(List<String> result, PredicateQuery query);
-    List<E> parseResultsOptimized(List<JsonElement> hits, PredicateQuery query);
+    List<E> parseResults(List<Hit<Map>> hits, PredicateQuery query);
 
     /**
-     * Returns an action to insert or update a document
+     * Returns a BulkOperation to insert or update a document
      * @param element The element to add or update
-     * @param create Whether to create or update
-     * @return An action
+     * @param create  Whether to create or update
+     * @return A BulkOperation
      */
-    BulkableAction<DocumentResult> addElement(E element, boolean create);
+    BulkOperation addElement(E element, boolean create);
 
     /**
-     * Deletes a document from ES
+     * Returns a BulkOperation to delete a document from ES
      * @param element The element to delete
-     * @return A delete builder
+     * @return A BulkOperation
      */
-    Delete.Builder delete(E element);
+    BulkOperation delete(E element);
 }

--- a/unipop-elastic/src/org/unipop/elastic/document/DocumentVertexSchema.java
+++ b/unipop-elastic/src/org/unipop/elastic/document/DocumentVertexSchema.java
@@ -1,7 +1,7 @@
 package org.unipop.elastic.document;
 
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.elasticsearch.index.query.QueryBuilder;
 import org.unipop.query.search.DeferredVertexQuery;
 import org.unipop.schema.element.VertexSchema;
 
@@ -11,9 +11,9 @@ import org.unipop.schema.element.VertexSchema;
 public interface DocumentVertexSchema extends DocumentSchema<Vertex>, VertexSchema {
 
     /**
-     * Converts a Deferred vertex query to a query builder
+     * Converts a Deferred vertex query to a Query
      * @param query The deferred vertex query
-     * @return A query builder
+     * @return A Query
      */
-    QueryBuilder getSearch(DeferredVertexQuery query);
+    Query getSearch(DeferredVertexQuery query);
 }

--- a/unipop-elastic/src/org/unipop/elastic/document/schema/AbstractDocSchema.java
+++ b/unipop-elastic/src/org/unipop/elastic/document/schema/AbstractDocSchema.java
@@ -1,19 +1,13 @@
 package org.unipop.elastic.document.schema;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import io.searchbox.action.BulkableAction;
-import io.searchbox.core.Delete;
-import io.searchbox.core.DocumentResult;
-import io.searchbox.core.Index;
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+import co.elastic.clients.elasticsearch.core.search.Hit;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.tinkerpop.gremlin.process.traversal.Order;
 import org.apache.tinkerpop.gremlin.structure.Element;
-import org.apache.tinkerpop.shaded.jackson.databind.JsonNode;
-import org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper;
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.search.builder.SearchSourceBuilder;
-import org.elasticsearch.search.sort.SortOrder;
 import org.javatuples.Pair;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -29,158 +23,101 @@ import org.unipop.schema.element.AbstractElementSchema;
 import org.unipop.structure.UniGraph;
 import org.unipop.util.PropertySchemaFactory;
 
-import java.io.IOException;
 import java.util.*;
 
 public abstract class AbstractDocSchema<E extends Element> extends AbstractElementSchema<E> implements DocumentSchema<E> {
     protected final ElasticClient client;
-    protected String type;
     protected IndexPropertySchema index;
-    protected ObjectMapper mapper = new ObjectMapper();
 
     public AbstractDocSchema(JSONObject configuration, ElasticClient client, UniGraph graph) throws JSONException {
         super(configuration, graph);
         this.client = client;
         this.index = (IndexPropertySchema) PropertySchemaFactory.createPropertySchema("index", json.opt("index"), this);
         if (index != null) index.addValidation(client::validateIndex);
-        this.type = json.optString("type", null);
     }
 
     @Override
-    public QueryBuilder getSearch(SearchQuery<E> query) {
+    public Query getSearch(SearchQuery<E> query) {
         PredicatesHolder predicatesHolder = this.toPredicates(query.getPredicates());
         if (predicatesHolder.getClause().equals(PredicatesHolder.Clause.Abort)) return null;
-        QueryBuilder queryBuilder = createQueryBuilder(predicatesHolder);
-        return queryBuilder;
-//        return createSearch(query, queryBuilder);
-    }
-
-    protected QueryBuilder createQueryBuilder(PredicatesHolder predicatesHolder) {
-        if (predicatesHolder.isAborted()) return null;
         return FilterHelper.createFilterBuilder(predicatesHolder);
     }
 
-    protected SearchSourceBuilder createSearch(SearchQuery<E> query, QueryBuilder queryBuilder) {
-        if(queryBuilder == null) return null;
-        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().query(queryBuilder)
+    @Override
+    public SearchRequest.Builder buildSearch(SearchQuery<E> query, Query q) {
+        SearchRequest.Builder b = new SearchRequest.Builder()
+                .query(q)
                 .size(query.getLimit() == -1 ? 10000 : query.getLimit());
-
-        if(query.getPropertyKeys() == null) searchSourceBuilder.fetchSource(true);
-        else {
+        if (query.getPropertyKeys() == null) {
+            b.source(s -> s.fetch(true));
+        } else {
             Set<String> fields = toFields(query.getPropertyKeys());
-            if(fields.size() == 0) searchSourceBuilder.fetchSource(false);
-            else searchSourceBuilder.fetchSource(fields.toArray(new String[fields.size()]), null);
+            if (fields.isEmpty()) b.source(s -> s.fetch(false));
+            else b.source(s -> s.filter(f -> f.includes(new ArrayList<>(fields))));
         }
         List<Pair<String, Order>> orders = query.getOrders();
-        if (orders != null){
-            orders.forEach(order -> {
+        if (orders != null) {
+            for (Pair<String, Order> order : orders) {
+                String field = getFieldByPropertyKey(order.getValue0());
                 Order orderValue = order.getValue1();
-                switch (orderValue){
-                    case decr:
-                        searchSourceBuilder.sort(getFieldByPropertyKey(order.getValue0()), SortOrder.DESC);
-                        break;
-                    case incr:
-                        searchSourceBuilder.sort(getFieldByPropertyKey(order.getValue0()), SortOrder.ASC);
-                        break;
-                    case shuffle:
-                        break;
+                if (orderValue == Order.desc) {
+                    b.sort(so -> so.field(fb -> fb.field(field).order(SortOrder.Desc)));
+                } else if (orderValue == Order.asc) {
+                    b.sort(so -> so.field(fb -> fb.field(field).order(SortOrder.Asc)));
                 }
-            });
+                // shuffle: no sort applied
+            }
         }
-
-        return searchSourceBuilder;
+        return b;
     }
 
     @Override
-    public List<E> parseResults(List<String> resultList, PredicateQuery query) {
+    public List<E> parseResults(List<Hit<Map<String, Object>>> hits, PredicateQuery query) {
         List<E> results = new ArrayList<>();
-        for( String result : resultList)
-            try {
-                JsonNode hits = mapper.readTree(result).get("hits").get("hits");
-                for (JsonNode hit : hits) {
-                    Map<String, Object> source = hit.has("_source") ? mapper.readValue(hit.get("_source").toString(), Map.class) : new HashMap<>();
-                    Document document = new Document(hit.get("_index").asText(), hit.get("_type").asText(), hit.get("_id").asText(), source);
-                    Collection<E> elements = fromDocument(document);
-                    if(elements != null) {
-                        elements.forEach(element -> {
-                            if(element != null && query.test(element, query.getPredicates()))
-                                results.add(element);
-                        });
-                    }
-                }
-            }
-            catch (IOException e) {
-                e.printStackTrace();
-            }
-        return results;
-    }
-    public List<E> parseResultsOptimized(List<JsonElement> hits, PredicateQuery query) {
-        List<E> results = new ArrayList<>();
-        Map<String, Object> source;
-
-        try {
-
-            for (JsonElement hit : hits) {
-                JsonObject hitJson = hit.getAsJsonObject();
-                JsonElement tempSource = hitJson.get("_source");
-                if (tempSource != null) {
-                    String sTempSource = tempSource.toString();
-                    source = mapper.readValue(sTempSource, Map.class);
-                }
-                else
-                    source = new HashMap<>();
-                Document document = new Document(hitJson.get("_index").getAsString(),hitJson.get("_type").getAsString(),hitJson.get("_id").getAsString(),source);
-                Collection<E> elements = fromDocument(document);
-                if(elements != null) {
-                    elements.forEach(element -> {
-                        if(element != null && query.test(element, query.getPredicates()))
-                            results.add(element);
-                    });
-                }
+        for (Hit<Map<String, Object>> hit : hits) {
+            Map<String, Object> source = hit.source() != null ? new HashMap<>(hit.source()) : new HashMap<>();
+            Document document = new Document(hit.index(), hit.id(), source);
+            Collection<E> elements = fromDocument(document);
+            if (elements != null) {
+                elements.forEach(element -> {
+                    if (element != null && query.test(element, query.getPredicates())) results.add(element);
+                });
             }
         }
-        catch (IOException e) {
-            e.printStackTrace();
-        }
-
-
         return results;
-    }
-
-    @Override
-    public BulkableAction<DocumentResult> addElement(E element, boolean create) {
-        Document document = toDocument(element);
-        if (document == null) return null;
-        Index.Builder builder = new Index.Builder(document.getFields())
-                .index(document.getIndex())
-                .type(document.getType())
-                .id(document.getId());
-        return builder.build();
-    }
-
-    @Override
-    public Delete.Builder delete(E element) {
-        Document document = toDocument(element);
-        if (document == null) return null;
-        return new Delete.Builder(document.getId()).index(document.getIndex()).type(document.getType());
     }
 
     public Document toDocument(E element) {
         Map<String, Object> fields = this.toFields(element);
-        if(fields == null) return null;
-        String type = ObjectUtils.firstNonNull(fields.remove("_type"), this.type).toString();
-        if (!checkType(type)) return null;
+        if (fields == null) return null;
         String id = ObjectUtils.firstNonNull(fields.remove("_id"), fields.remove("id"), element.id()).toString();
-        return new Document(index.getIndex(fields), type, id, fields);
+        return new Document(index.getIndex(fields), id, fields);
     }
 
-    protected Collection<E> fromDocument(Document document){
-        if(!checkType(document.getType())) return null;
-        if(!checkIndex(document.getIndex())) return null;
+    protected Collection<E> fromDocument(Document document) {
+        if (!checkIndex(document.getIndex())) return null;
         Map<String, Object> fields = document.getFields();
         fields.put("_id", document.getId());
-        fields.put("_type", document.getType());
         return this.fromFields(fields);
+    }
+
+    @Override
+    public BulkOperation addElement(E element, boolean create) {
+        Document document = toDocument(element);
+        if (document == null) return null;
+        return BulkOperation.of(op -> op.index(idx -> idx
+                .index(document.getIndex())
+                .id(document.getId())
+                .document(document.getFields())));
+    }
+
+    @Override
+    public BulkOperation delete(E element) {
+        Document document = toDocument(element);
+        if (document == null) return null;
+        return BulkOperation.of(op -> op.delete(d -> d
+                .index(document.getIndex())
+                .id(document.getId())));
     }
 
     @Override
@@ -191,9 +128,4 @@ public abstract class AbstractDocSchema<E extends Element> extends AbstractEleme
     protected boolean checkIndex(String index) {
         return this.index.validateIndex(index);
     }
-
-    protected boolean checkType(String type) {
-        return type != null && (this.type == null || this.type.equals(type));
-    }
-
 }

--- a/unipop-elastic/src/org/unipop/elastic/document/schema/DocEdgeSchema.java
+++ b/unipop-elastic/src/org/unipop/elastic/document/schema/DocEdgeSchema.java
@@ -99,7 +99,7 @@ public class DocEdgeSchema extends AbstractDocSchema<Edge> implements DocumentEd
     @Override
     public String toString() {
         return "DocEdgeSchema{" +
-                "index='" + null + '\'' +
+                "index='" + index + '\'' +
                 '}';
     }
 }

--- a/unipop-elastic/src/org/unipop/elastic/document/schema/DocEdgeSchema.java
+++ b/unipop-elastic/src/org/unipop/elastic/document/schema/DocEdgeSchema.java
@@ -1,14 +1,15 @@
 package org.unipop.elastic.document.schema;
 
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.elasticsearch.index.query.QueryBuilder;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.unipop.elastic.common.ElasticClient;
+import org.unipop.elastic.common.FilterHelper;
 import org.unipop.elastic.document.DocumentEdgeSchema;
 import org.unipop.query.predicates.PredicatesHolder;
 import org.unipop.query.predicates.PredicatesHolderFactory;
@@ -75,14 +76,12 @@ public class DocEdgeSchema extends AbstractDocSchema<Edge> implements DocumentEd
     }
 
     @Override
-    public QueryBuilder getSearch(SearchVertexQuery query) {
+    public Query getSearch(SearchVertexQuery query) {
         PredicatesHolder edgePredicates = this.toPredicates(query.getPredicates());
         PredicatesHolder vertexPredicates = this.getVertexPredicates(query.getVertices(), query.getDirection());
         PredicatesHolder predicatesHolder = PredicatesHolderFactory.and(edgePredicates, vertexPredicates);
         if (predicatesHolder.isAborted()) return null;
-        QueryBuilder queryBuilder = createQueryBuilder(predicatesHolder);
-        return queryBuilder;
-//        return createSearch(query, queryBuilder);
+        return FilterHelper.createFilterBuilder(predicatesHolder);
     }
 
     protected PredicatesHolder getVertexPredicates(List<Vertex> vertices, Direction direction) {
@@ -101,8 +100,6 @@ public class DocEdgeSchema extends AbstractDocSchema<Edge> implements DocumentEd
     public String toString() {
         return "DocEdgeSchema{" +
                 "index='" + null + '\'' +
-                ", type='" + type + '\'' +
                 '}';
     }
-
 }

--- a/unipop-elastic/src/org/unipop/elastic/document/schema/DocVertexSchema.java
+++ b/unipop-elastic/src/org/unipop/elastic/document/schema/DocVertexSchema.java
@@ -51,7 +51,7 @@ public class DocVertexSchema extends AbstractDocSchema<Vertex> implements Docume
         Direction direction = Direction.valueOf(edgeJson.optString("direction"));
 
         if(path == null) return new InnerEdgeSchema(this, direction, index, edgeJson, client, graph);
-        return new NestedEdgeSchema(this, direction, index, null, path, edgeJson, client, graph);
+        return new NestedEdgeSchema(this, direction, index, path, edgeJson, client, graph);
     }
 
     @Override

--- a/unipop-elastic/src/org/unipop/elastic/document/schema/DocVertexSchema.java
+++ b/unipop-elastic/src/org/unipop/elastic/document/schema/DocVertexSchema.java
@@ -1,11 +1,12 @@
 package org.unipop.elastic.document.schema;
 
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.elasticsearch.index.query.QueryBuilder;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.unipop.elastic.common.ElasticClient;
+import org.unipop.elastic.common.FilterHelper;
 import org.unipop.elastic.document.DocumentVertexSchema;
 import org.unipop.elastic.document.schema.nested.NestedEdgeSchema;
 import org.unipop.elastic.document.schema.property.IndexPropertySchema;
@@ -49,15 +50,15 @@ public class DocVertexSchema extends AbstractDocSchema<Vertex> implements Docume
         String path = edgeJson.optString("path", null);
         Direction direction = Direction.valueOf(edgeJson.optString("direction"));
 
-        if(path == null) return new InnerEdgeSchema(this, direction, index, type, edgeJson, client, graph);
-        return new NestedEdgeSchema(this, direction, index, type, path, edgeJson, client, graph);
+        if(path == null) return new InnerEdgeSchema(this, direction, index, edgeJson, client, graph);
+        return new NestedEdgeSchema(this, direction, index, null, path, edgeJson, client, graph);
     }
 
     @Override
-    public QueryBuilder getSearch(DeferredVertexQuery query) {
+    public Query getSearch(DeferredVertexQuery query) {
         PredicatesHolder predicatesHolder = this.toPredicates(query.getVertices());
-        QueryBuilder queryBuilder = createQueryBuilder(predicatesHolder);
-        return queryBuilder;
+        if (predicatesHolder.isAborted()) return null;
+        return FilterHelper.createFilterBuilder(predicatesHolder);
     }
 
     @Override
@@ -76,7 +77,6 @@ public class DocVertexSchema extends AbstractDocSchema<Vertex> implements Docume
     public String toString() {
         return "DocVertexSchema{" +
                 "index='" + index + '\'' +
-                ", type='" + type + '\'' +
                 '}';
     }
 }

--- a/unipop-elastic/src/org/unipop/elastic/document/schema/InnerEdgeSchema.java
+++ b/unipop-elastic/src/org/unipop/elastic/document/schema/InnerEdgeSchema.java
@@ -15,10 +15,9 @@ import java.util.Set;
 public class InnerEdgeSchema extends DocEdgeSchema {
     private final VertexSchema childVertexSchema;
 
-    public InnerEdgeSchema(VertexSchema parentVertexSchema, Direction parentDirection, IndexPropertySchema index, String type, JSONObject edgeJson, ElasticClient client, UniGraph graph) throws JSONException {
+    public InnerEdgeSchema(VertexSchema parentVertexSchema, Direction parentDirection, IndexPropertySchema index, JSONObject edgeJson, ElasticClient client, UniGraph graph) throws JSONException {
         super(edgeJson, client, graph);
         this.index = index;
-        this.type = type;
 
         this.childVertexSchema = createVertexSchema("vertex");
         this.outVertexSchema = parentDirection.equals(Direction.OUT) ? parentVertexSchema : childVertexSchema;

--- a/unipop-elastic/src/org/unipop/elastic/document/schema/nested/NestedEdgeSchema.java
+++ b/unipop-elastic/src/org/unipop/elastic/document/schema/nested/NestedEdgeSchema.java
@@ -1,23 +1,20 @@
 package org.unipop.elastic.document.schema.nested;
 
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.ChildScoreMode;
+import co.elastic.clients.elasticsearch._types.query_dsl.NestedQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import io.searchbox.action.BulkableAction;
-import io.searchbox.core.DocumentResult;
-import io.searchbox.core.Update;
-import org.apache.lucene.search.join.ScoreMode;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
-import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.apache.tinkerpop.shaded.jackson.core.JsonProcessingException;
-import org.elasticsearch.index.query.NestedQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryBuilders;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.unipop.elastic.common.ElasticClient;
+import org.unipop.elastic.common.FilterHelper;
 import org.unipop.elastic.document.Document;
 import org.unipop.elastic.document.DocumentEdgeSchema;
 import org.unipop.elastic.document.schema.AbstractDocSchema;
@@ -42,23 +39,20 @@ public class NestedEdgeSchema extends AbstractDocSchema<Edge> implements Documen
     private final VertexSchema childVertexSchema;
     private final Direction parentDirection;
 
-    public NestedEdgeSchema(DocVertexSchema parentVertexSchema, Direction parentDirection, IndexPropertySchema index, String type, String path, JSONObject configuration, ElasticClient client, UniGraph graph) throws JSONException {
+    public NestedEdgeSchema(DocVertexSchema parentVertexSchema, Direction parentDirection, IndexPropertySchema index, String path, JSONObject configuration, ElasticClient client, UniGraph graph) throws JSONException {
         super(configuration, client, graph);
         this.index = index;
-        this.type = type;
         this.path = path;
         this.parentVertexSchema = parentVertexSchema;
         this.parentDirection = parentDirection;
         this.childVertexSchema = createVertexSchema("vertex");
-        index.addValidation((indexName) -> client.validateNested(indexName, type, path));
-
     }
 
     protected VertexSchema createVertexSchema(String key) throws JSONException {
         JSONObject vertexConfiguration = this.json.optJSONObject(key);
         if (vertexConfiguration == null) return null;
         if (vertexConfiguration.optBoolean("ref", false)) return new NestedReferenceVertexSchema(vertexConfiguration, path, graph);
-        return new NestedVertexSchema(vertexConfiguration, path, index, type, client, graph);
+        return new NestedVertexSchema(vertexConfiguration, path, index, client, graph);
     }
 
     @Override
@@ -144,58 +138,67 @@ public class NestedEdgeSchema extends AbstractDocSchema<Edge> implements Documen
     }
 
     @Override
-    public QueryBuilder getSearch(SearchQuery<Edge> query) {
+    public Query getSearch(SearchQuery<Edge> query) {
         PredicatesHolder predicatesHolder = this.toPredicates(query.getPredicates());
-        QueryBuilder queryBuilder = createQueryBuilder(predicatesHolder);
-        if(queryBuilder == null)  return null;
-        return QueryBuilders.nestedQuery(this.path, queryBuilder, ScoreMode.None);
+        Query innerQuery = FilterHelper.createFilterBuilder(predicatesHolder);
+        if (innerQuery == null) return null;
+        return NestedQuery.of(n -> n.path(this.path).query(innerQuery).scoreMode(ChildScoreMode.None))._toQuery();
     }
 
     @Override
-    public QueryBuilder getSearch(SearchVertexQuery query) {
-        QueryBuilder queryBuilder = createQueryBuilder(query);
-
-        return queryBuilder;
+    public Query getSearch(SearchVertexQuery query) {
+        return createQueryBuilder(query);
     }
 
-    public QueryBuilder createQueryBuilder(SearchVertexQuery query) {
+    public Query createQueryBuilder(SearchVertexQuery query) {
         PredicatesHolder edgePredicates = this.toPredicates(query.getPredicates());
-        if(edgePredicates.isAborted()) return  null;
+        if (edgePredicates.isAborted()) return null;
 
         PredicatesHolder childPredicates = childVertexSchema.toPredicates(query.getVertices());
         childPredicates = PredicatesHolderFactory.and(edgePredicates, childPredicates);
-        QueryBuilder childQuery = createNestedQueryBuilder(childPredicates);
+        Query childQuery = createNestedQueryBuilder(childPredicates);
 
-        if(query.getDirection().equals(parentDirection.opposite())) {
+        if (query.getDirection().equals(parentDirection.opposite())) {
             if (childPredicates.isAborted()) return null;
             return childQuery;
         } else if (!query.getDirection().equals(Direction.BOTH)) childQuery = null;
 
         PredicatesHolder parentPredicates = parentVertexSchema.toPredicates(query.getVertices());
-        QueryBuilder parentQuery = createQueryBuilder(parentPredicates);
-        if(parentQuery != null) {
+        Query parentQuery = FilterHelper.createFilterBuilder(parentPredicates);
+        if (parentPredicates.isAborted()) parentQuery = null;
+        if (parentQuery != null) {
 //            if (parentPredicates.isAborted()) return null;
-            QueryBuilder edgeQuery = createNestedQueryBuilder(edgePredicates);
+            Query edgeQuery = createNestedQueryBuilder(edgePredicates);
             if (edgeQuery != null) {
-                parentQuery = QueryBuilders.boolQuery().must(parentQuery).must(edgeQuery);
+                final Query pq = parentQuery;
+                final Query eq = edgeQuery;
+                parentQuery = BoolQuery.of(b -> b.must(pq).must(eq))._toQuery();
             }
         }
-        if(query.getDirection().equals(parentDirection) && parentPredicates.notAborted()) return parentQuery;
-        else if(childQuery == null && parentPredicates.notAborted()) return parentQuery;
-        else if(parentQuery == null && childPredicates.notAborted()) return childQuery;
-        else if(parentPredicates.isAborted() && childPredicates.isAborted()) return null;
-        else return QueryBuilders.boolQuery().should(parentQuery).should(childQuery);
+        if (query.getDirection().equals(parentDirection) && parentPredicates.notAborted()) return parentQuery;
+        else if (childQuery == null && parentPredicates.notAborted()) return parentQuery;
+        else if (parentQuery == null && childPredicates.notAborted()) return childQuery;
+        else if (parentPredicates.isAborted() && childPredicates.isAborted()) return null;
+        else {
+            final Query pq = parentQuery;
+            final Query cq = childQuery;
+            return BoolQuery.of(b -> b.should(pq).should(cq))._toQuery();
+        }
     }
 
-    private QueryBuilder createNestedQueryBuilder(PredicatesHolder nestedPredicates) {
-        QueryBuilder nestedQuery = createQueryBuilder(nestedPredicates);
-        if(nestedQuery == null)  return null;
-        return QueryBuilders.nestedQuery(this.path, nestedQuery, ScoreMode.None);
+    private Query createNestedQueryBuilder(PredicatesHolder nestedPredicates) {
+        if (nestedPredicates.isAborted()) return null;
+        Query innerQuery = FilterHelper.createFilterBuilder(nestedPredicates);
+        if (innerQuery == null) return null;
+        return NestedQuery.of(n -> n.path(this.path).query(innerQuery).scoreMode(ChildScoreMode.None))._toQuery();
     }
 
     @Override
-    public BulkableAction<DocumentResult> addElement(Edge edge, boolean create) {
+    public BulkOperation addElement(Edge edge, boolean create) {
         //TODO: use the 'create' parameter to differentiate between add and update
+        // TODO(nested best-effort): Painless scripted upsert (Groovy removed in ES 8); currently falls back to a plain
+        // index operation for the parent document including the nested array. Nested-edge process tests are skipped
+        // in Phase 1, so this does not block the module compile. Implement a proper Painless scripted upsert in Phase 2.
         Vertex parentVertex = parentDirection.equals(Direction.OUT) ? edge.outVertex() : edge.inVertex();
         Document parentDoc = parentVertexSchema.toDocument(parentVertex);
         if (parentDoc == null) return null;
@@ -203,31 +206,14 @@ public class NestedEdgeSchema extends AbstractDocSchema<Edge> implements Documen
         Map<String, Object> childFields = getVertexFields(edge, parentDirection.opposite());
         Map<String, Object> nestedFields = ConversionUtils.merge(Lists.newArrayList(edgeFields, childFields), this::mergeFields, false);
         if (nestedFields == null) return null;
-        Set<String> idField = propertySchemas.stream()
-                .map(schema -> schema.toFields(Collections.singleton(T.id.getAccessor()))).findFirst().get();
-        try {
-            HashMap<String, Object> params = new HashMap<>();
-            params.put("nestedDoc", nestedFields);
-            params.put("path", path);
-            params.put("edgeId", edge.id());
-            params.put("idField", idField.iterator().next());
-            HashMap<String, Object> docMap = new HashMap<>();
-            HashMap<String, Object> script = new HashMap<>();
-            script.put("params", params);
-            script.put("inline", UPDATE_SCRIPT);
-            script.put("lang", "groovy");
-            docMap.put("scripted_upsert", true);
-            docMap.put("script", script);
-            String json = mapper.writeValueAsString(docMap);
-            return new Update.Builder(json).index(parentDoc.getIndex()).type(parentDoc.getType()).id(parentDoc.getId()).build();
-        } catch (JsonProcessingException e) {
-            e.printStackTrace();
-            return null;
-        }
+
+        // Build the full document with the nested array embedded (best-effort plain index, no script)
+        Map<String, Object> docFields = new HashMap<>(parentDoc.getFields());
+        docFields.put(this.path, new Object[]{nestedFields});
+
+        return BulkOperation.of(op -> op.index(idx -> idx
+                .index(parentDoc.getIndex())
+                .id(parentDoc.getId())
+                .document(docFields)));
     }
-
-    static String UPDATE_SCRIPT = "if (!ctx._source.containsKey(path)) {ctx._source[path] = [nestedDoc]}; " +
-            "else { items_to_remove = []; ctx._source[path].each { item -> if (item[idField] == edgeId) { items_to_remove.add(item); } };" +
-            "items_to_remove.each { item -> ctx._source[path].remove(item) }; ctx._source[path].add(nestedDoc);}";
-
 }

--- a/unipop-elastic/src/org/unipop/elastic/document/schema/nested/NestedVertexSchema.java
+++ b/unipop-elastic/src/org/unipop/elastic/document/schema/nested/NestedVertexSchema.java
@@ -1,15 +1,14 @@
 package org.unipop.elastic.document.schema.nested;
 
-import io.searchbox.action.BulkableAction;
-import io.searchbox.core.DocumentResult;
-import org.apache.lucene.search.join.ScoreMode;
+import co.elastic.clients.elasticsearch._types.query_dsl.ChildScoreMode;
+import co.elastic.clients.elasticsearch._types.query_dsl.NestedQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryBuilders;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.unipop.elastic.common.ElasticClient;
+import org.unipop.elastic.common.FilterHelper;
 import org.unipop.elastic.document.DocumentVertexSchema;
 import org.unipop.elastic.document.schema.AbstractDocSchema;
 import org.unipop.elastic.document.schema.property.IndexPropertySchema;
@@ -26,11 +25,10 @@ import java.util.stream.Collectors;
 public class NestedVertexSchema extends AbstractDocSchema<Vertex> implements DocumentVertexSchema {
     private String path;
 
-    public NestedVertexSchema(JSONObject configuration, String path, IndexPropertySchema index, String type, ElasticClient client, UniGraph graph) throws JSONException {
+    public NestedVertexSchema(JSONObject configuration, String path, IndexPropertySchema index, ElasticClient client, UniGraph graph) throws JSONException {
         super(configuration, client, graph);
         this.path = path;
         this.index = index;
-        this.type = type;
     }
 
     @Override
@@ -83,15 +81,15 @@ public class NestedVertexSchema extends AbstractDocSchema<Vertex> implements Doc
     }
 
     @Override
-    public BulkableAction<DocumentResult> addElement(Vertex element, boolean create) {
+    public co.elastic.clients.elasticsearch.core.bulk.BulkOperation addElement(Vertex element, boolean create) {
         return null;
     }
 
-    @Override
-    public QueryBuilder createQueryBuilder(PredicatesHolder predicatesHolder) {
-        QueryBuilder queryBuilder = super.createQueryBuilder(predicatesHolder);
-        if(queryBuilder == null) return null;
-        return QueryBuilders.nestedQuery(this.path, queryBuilder, ScoreMode.None);
+    /** Build a nested query wrapping an inner ES 8 Query for this path. */
+    protected Query createNestedQuery(PredicatesHolder predicatesHolder) {
+        Query innerQuery = FilterHelper.createFilterBuilder(predicatesHolder);
+        if (innerQuery == null) return null;
+        return NestedQuery.of(n -> n.path(this.path).query(innerQuery).scoreMode(ChildScoreMode.None))._toQuery();
     }
 
     @Override
@@ -100,9 +98,9 @@ public class NestedVertexSchema extends AbstractDocSchema<Vertex> implements Doc
     }
 
     @Override
-    public QueryBuilder getSearch(DeferredVertexQuery query) {
+    public Query getSearch(DeferredVertexQuery query) {
         PredicatesHolder predicatesHolder = this.toPredicates(query.getVertices());
-        QueryBuilder queryBuilder = createQueryBuilder(predicatesHolder);
-        return queryBuilder;
+        if (predicatesHolder.isAborted()) return null;
+        return createNestedQuery(predicatesHolder);
     }
 }


### PR DESCRIPTION
## Summary

**Phase 1 of #143** — port the `unipop-elastic` **production** code from Elasticsearch 5.3.1 (Jest `io.searchbox` HTTP client + `org.elasticsearch` transport-client query builders) to **Elasticsearch 8.15.3** using the official `co.elastic.clients:elasticsearch-java` client over the REST client, on **Java 17**. The module now compiles and packages green and re-enters the Maven reactor.

This is the first of four phases (see Scope below); it is intentionally **production-code-only** — the test harness migration (Testcontainers + Gherkin) and the `rest`/`test` modules are deferred to later phases.

## What changed

- **Deps/build** (`unipop-elastic/pom.xml`): drop `transport`, `transport-netty4-client`, `embedded-elasticsearch`, `io.searchbox:jest`, the ES-5 `elasticsearch` server jar; add `co.elastic.clients:elasticsearch-java` + `elasticsearch-rest-client` (`8.15.3`); compiler `release 17`.
- **`ElasticClient`**: wraps `ElasticsearchClient` over `RestClient` + `RestClientTransport(JacksonJsonpMapper)` — `validateIndex`, `bulk(BulkOperation)`, `search` (`SearchResponse<Map>`), `scroll` (`ScrollResponse<Map>`), `clearScroll`, `refresh`, `close`.
- **`FilterHelper`**: rewritten to build typed `co.elastic.clients` `Query` objects (`BoolQuery`/`TermQuery`/`RangeQuery`/`WildcardQuery`/… ~1:1 from the old `QueryBuilders`).
- **`Document` + `DocumentSchema` interfaces + `AbstractDocSchema`/doc schemas + `DocumentController`**: ES 8 `SearchRequest` execution + scroll, `BulkOperation` index/delete, parse `Hit<Map<String,Object>>`.
- **`_type` removed** (ES 8 has no mapping type). The Gremlin **label** moves from the `_type` meta-field to a **stored `_source` field**, and each label routes to its **own index** (`"index":"@label"`). Discrimination is now by index, not type.
- **Configs** (`resources/configuration/**`): `"@_type"`→`"@label"`, `{field:_type}`→`{field:label}`, static `index`→`"@label"`; `_type` purged.
- **Nested edges**: typed `NestedQuery`; the Groovy scripted upsert (Groovy is gone in ES 8) is a documented **best-effort** plain-index `BulkOperation` for now (nested-edge tests are skipped).
- **Reactor**: `unipop-elastic` re-enabled in the root `pom.xml` (`rest`/`test` remain commented for later phases).

## Scope (phased)

| Phase | Content | Status |
|-------|---------|--------|
| **1 (this PR)** | `unipop-elastic` production port; module compiles/packages on Java 17; reactor re-entry | ✅ |
| 2 | Testcontainers ES 8 + Gherkin/Cucumber harness (`ElasticWorld`/`ElasticFeatureTest`); migrate the `src/test` harness; remove the temporary `test/**` compile/javadoc exclude | ⏳ |
| 3 | `unipop-rest` (dep cleanup + harness) | ⏳ |
| 4 | `unipop-test` + restore all `<module>` entries + `MIGRATION_NOTES.md` | ⏳ |

## Verification

- `mvn -f unipop-elastic/pom.xml clean compile` → **BUILD SUCCESS** (Java 17).
- `mvn -pl unipop-elastic -am clean install -DskipTests -Dmaven.test.skip=true` → **BUILD SUCCESS** (root, core, elastic; clean, no Javadoc errors).
- **Tests deferred to Phase 2.** The elastic test tree (the `src/test` package-`test` harness `LocalNode`/`ElasticGraphProvider` and the `test/` JUnit suites) is not migrated; it's excluded from the Phase-1 main compile via a `maven-compiler-plugin` `<excludes>test/**` (and a matching javadoc `excludePackageNames`), reverted in Phase 2. Behavior is validated against a live ES 8 container in Phase 2.

## Notes / follow-ups (Phase 2)

- Verify on a live container: nested-vertex `getSearch` wrapping on all overloads (currently a child-only schema, so the inherited non-nesting path is unreachable); nested-edge upsert append semantics (best-effort plain-index for now); scroll pagination at/over `maxLimit`; and `IndexPropertySchema`'s `"*"` default fanning out across per-label indices.
- `FilterHelper`'s now-dead `_type` predicate branch is left in place pending a Phase-2 check of how structure-test `hasLabel` predicates map now that label is a stored field.

Built and reviewed task-by-task (per-task spec+quality reviews + a final whole-branch review: *Ready to merge*).

Refs #143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
