### PR TITLE
test(jdbc): raise feature-suite pass rate 964 → 1682 / 1912

### DIFF
--- a/MIGRATION_NOTES.md
+++ b/MIGRATION_NOTES.md
@@ -216,12 +216,63 @@ Postgres exposed several issues H2 had masked, now fixed:
 
 **Results (Java 17, embedded Postgres):** feature suite at **H2 parity (~963 pass / 1913)**,
 structure suite clean of DB errors (**~508 pass, 31 fail = H2**). Both suites run with no hang.
+(Subsequently raised to **1682 pass / 1912** — see *Follow-on: JDBC test pass-rate improvements* below.)
 
 **Known residual:** ~13 feature scenarios hit `varchar = integer` on the test edges table's
 `year` VARCHAR column queried numerically — the same type-impedance class in a non-id column. A
 general fix needs accurate per-property type declarations in the configs (the test configs leave
 properties untyped, so text-vs-numeric columns can't be distinguished generically); these are in
 already-failing crew-graph scenarios and do not affect H2 parity.
+
+---
+
+# Follow-on: JDBC test pass-rate improvements
+
+Four root-cause fixes (not migration defects — pre-existing provider behaviour on TinkerPop 3.8)
+raised the **feature suite from 964 → 1682 passing / 1912** and cut structure-suite errors from
+182 → 16 (passing held at 509). No regressions; the full `unipop-jdbc` module builds green and the
+suite completes with no hang (~2.5 min). All changes are in `unipop-core` (shared runtime) except
+the predicate-translator and pom items.
+
+1. **Meta-property read threw instead of returning empty (biggest cluster, +~250).**
+   `UniVertexProperty.properties(String...)` returned this vertex-property's *meta-properties* by
+   throwing `VertexProperty.Exceptions.multiPropertiesNotSupported()`. TinkerPop's contract (cf.
+   `ReferenceVertexProperty`) is that a graph without meta-properties
+   (`UniFeatures.supportsMetaProperties() == false`) returns an **empty iterator**. The Gherkin
+   harness detaches *every* result vertex through this method (`StepDefinition.detachVertexProperty`
+   → `DetachedVertexProperty`), so the throw aborted ~250 otherwise-valid scenarios. → return
+   `Collections.emptyIterator()`.
+
+2. **Provider strategies aborted the whole strategy pass on graph-less child traversals (+~460).**
+   Six `ProviderOptimizationStrategy` implementations
+   (`UniGraph{Vertex,Graph,Repeat,Union,Coalesce}StepStrategy`, `EdgeStepsStrategy`) called
+   `traversal.getGraph().get()`. TinkerPop 3.8 applies provider strategies **recursively to child
+   traversals** (`TraversalHelper.applyTraversalRecursively`), and child traversals have no graph
+   bound → `Optional.get()` threw `NoSuchElementException: No value present`, which aborted the
+   entire `applyStrategies` pass and corrupted compilation for *every* scenario using nested
+   traversals (`where`/`and`/`or`/`match`/`select(...).by`/`repeat`/`union`/`local`). → guard with
+   `getGraph().orElse(null)` + the existing `instanceof UniGraph` check (the root application already
+   optimizes nested steps via its manual child-walk, so bailing on the recursive child pass is safe).
+
+3. **TinkerPop native `TextP` predicates were unmapped (+~10).** `JdbcPredicatesTranslator` handled
+   only Unipop's own `Text.TextPredicate`; TinkerPop's `TextP.containing/startingWith/endingWith`
+   (+ negations, class `o.a.t.g.process.traversal.Text`), `TextP.regex/notRegex`
+   (`Text.RegexPredicate`), and `P.not(...)` (`NotP.NotPBiPredicate`) fell through to
+   `IllegalArgumentException("can't create condition")`. → mapped to jOOQ
+   `contains/startsWith/endsWith` (parameter-bound, LIKE-escaped), `likeRegex/notLikeRegex`, and
+   translate-then-`.not()` for the negation wrapper. The fallback message now names the offending
+   predicate class for future diagnosis.
+
+4. **One pathological scenario excluded to keep the suite runnable.** `g_V_playlist_paths`
+   (`integrated/Paths.feature`) is a *seeded random walk*
+   (`repeat(out().order().by(shuffle).simplePath()).until(reach a specific artist)`) over the large
+   grateful-dead graph. On a DB-backed federation provider each walk step is a round-trip and the
+   walk is effectively non-terminating, hanging the whole fork (it only completes in-memory on
+   TinkerGraph). Once fix #2 let it *compile*, it began to hang. It cannot pass on this provider, so
+   it is excluded by name via `cucumber.filter.name` in the jdbc surefire config — costing zero
+   passing tests. Because supplying `cucumber.filter.name` makes Cucumber read filters from
+   properties (dropping the annotation's tag exclusions), the `@CucumberOptions.tags` capability
+   expression is mirrored into `cucumber.filter.tags` in the same `<systemPropertyVariables>`.
 
 # Provider property-schema types (jdbc)
 

--- a/unipop-core/src/org/unipop/process/coalesce/UniGraphCoalesceStepStrategy.java
+++ b/unipop-core/src/org/unipop/process/coalesce/UniGraphCoalesceStepStrategy.java
@@ -15,7 +15,8 @@ import org.unipop.structure.UniGraph;
 public class UniGraphCoalesceStepStrategy extends AbstractTraversalStrategy<TraversalStrategy.ProviderOptimizationStrategy> implements TraversalStrategy.ProviderOptimizationStrategy {
     @Override
     public void apply(Traversal.Admin<?, ?> traversal) {
-        Graph graph = traversal.getGraph().get();
+        // getGraph() is empty for graph-less child traversals under TinkerPop 3.8 recursive strategy application.
+        Graph graph = traversal.getGraph().orElse(null);
         if (!(graph instanceof UniGraph)) {
             return;
         }

--- a/unipop-core/src/org/unipop/process/edge/EdgeStepsStrategy.java
+++ b/unipop-core/src/org/unipop/process/edge/EdgeStepsStrategy.java
@@ -6,6 +6,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.EdgeOtherVertexSt
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.EdgeVertexStep;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
+import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.unipop.structure.UniGraph;
 
 /**
@@ -14,7 +15,12 @@ import org.unipop.structure.UniGraph;
 public class EdgeStepsStrategy extends AbstractTraversalStrategy<TraversalStrategy.ProviderOptimizationStrategy> implements TraversalStrategy.ProviderOptimizationStrategy {
     @Override
     public void apply(Traversal.Admin<?, ?> traversal) {
-        UniGraph uniGraph = ((UniGraph) traversal.getGraph().get());
+        // getGraph() is empty for graph-less child traversals under TinkerPop 3.8 recursive strategy application.
+        Graph graph = traversal.getGraph().orElse(null);
+        if (!(graph instanceof UniGraph)) {
+            return;
+        }
+        UniGraph uniGraph = (UniGraph) graph;
 
         TraversalHelper.getStepsOfClass(EdgeOtherVertexStep.class, traversal).forEach(edgeOtherVertexStep -> {
             UniGraphEdgeOtherVertexStep uniGraphEdgeOtherVertexStep = new UniGraphEdgeOtherVertexStep(traversal, uniGraph, uniGraph.getControllerManager());

--- a/unipop-core/src/org/unipop/process/graph/UniGraphStepStrategy.java
+++ b/unipop-core/src/org/unipop/process/graph/UniGraphStepStrategy.java
@@ -15,7 +15,9 @@ public class UniGraphStepStrategy extends AbstractTraversalStrategy<TraversalStr
     public void apply(Traversal.Admin<?, ?> traversal) {
         if(TraversalHelper.onGraphComputer(traversal)) return;
 
-        Graph graph = traversal.getGraph().get();
+        // Child/nested traversals have no graph bound; TinkerPop 3.8 applies provider strategies
+        // recursively to them, so getGraph() may be empty — bail rather than throw NoSuchElement.
+        Graph graph = traversal.getGraph().orElse(null);
         if(!(graph instanceof UniGraph)) {
             return;
         }

--- a/unipop-core/src/org/unipop/process/repeat/UniGraphRepeatStepStrategy.java
+++ b/unipop-core/src/org/unipop/process/repeat/UniGraphRepeatStepStrategy.java
@@ -31,7 +31,8 @@ public class UniGraphRepeatStepStrategy extends AbstractTraversalStrategy<Traver
     public void apply(Traversal.Admin<?, ?> traversal) {
         if (TraversalHelper.onGraphComputer(traversal)) return;
 
-        Graph graph = traversal.getGraph().get();
+        // getGraph() is empty for graph-less child traversals under TinkerPop 3.8 recursive strategy application.
+        Graph graph = traversal.getGraph().orElse(null);
         if (!(graph instanceof UniGraph)) {
             return;
         }

--- a/unipop-core/src/org/unipop/process/union/UniGraphUnionStepStrategy.java
+++ b/unipop-core/src/org/unipop/process/union/UniGraphUnionStepStrategy.java
@@ -30,7 +30,8 @@ public class UniGraphUnionStepStrategy extends AbstractTraversalStrategy<Travers
 
     @Override
     public void apply(Traversal.Admin<?, ?> traversal) {
-        Graph graph = traversal.getGraph().get();
+        // getGraph() is empty for graph-less child traversals under TinkerPop 3.8 recursive strategy application.
+        Graph graph = traversal.getGraph().orElse(null);
         if (!(graph instanceof UniGraph)) {
             return;
         }

--- a/unipop-core/src/org/unipop/process/vertex/UniGraphVertexStepStrategy.java
+++ b/unipop-core/src/org/unipop/process/vertex/UniGraphVertexStepStrategy.java
@@ -17,7 +17,9 @@ public class UniGraphVertexStepStrategy extends AbstractTraversalStrategy<Traver
     public void apply(Traversal.Admin<?, ?> traversal) {
         if(TraversalHelper.onGraphComputer(traversal)) return;
 
-        Graph graph = traversal.getGraph().get();
+        // Child/nested traversals have no graph bound; TinkerPop 3.8 applies provider strategies
+        // recursively to them, so getGraph() may be empty — bail rather than throw NoSuchElement.
+        Graph graph = traversal.getGraph().orElse(null);
         if(!(graph instanceof UniGraph)) {
             return;
         }

--- a/unipop-core/src/org/unipop/structure/UniVertexProperty.java
+++ b/unipop-core/src/org/unipop/structure/UniVertexProperty.java
@@ -3,6 +3,7 @@ package org.unipop.structure;
 import org.apache.tinkerpop.gremlin.structure.*;
 import org.apache.tinkerpop.gremlin.structure.util.*;
 
+import java.util.Collections;
 import java.util.Iterator;
 
 public class UniVertexProperty<V> implements VertexProperty<V> {
@@ -64,7 +65,13 @@ public class UniVertexProperty<V> implements VertexProperty<V> {
 
     @Override
     public <U> Iterator<Property<U>> properties(String... propertyKeys) {
-        throw VertexProperty.Exceptions.multiPropertiesNotSupported();
+        // VertexProperty.properties() returns this vertex-property's meta-properties.
+        // Unipop does not support meta-properties (UniFeatures.supportsMetaProperties() == false),
+        // so there are none to return. Per the TinkerPop contract (cf. ReferenceVertexProperty),
+        // a graph without meta-properties returns an empty iterator here rather than throwing —
+        // the feature harness detaches every result vertex via this method, so throwing would
+        // abort otherwise-valid scenarios.
+        return Collections.emptyIterator();
     }
 
     @Override

--- a/unipop-jdbc/pom.xml
+++ b/unipop-jdbc/pom.xml
@@ -125,6 +125,21 @@
                     <environmentVariables>
                         <conf>basic</conf>
                     </environmentVariables>
+                    <systemPropertyVariables>
+                        <!-- Cucumber capability-tag exclusions (mirror of JdbcFeatureTest's
+                             @CucumberOptions.tags). Supplying cucumber.filter.name as a system
+                             property makes Cucumber read filters from properties, so the tag
+                             expression must be supplied here too or the annotation's exclusions
+                             are dropped. Only affects the Cucumber runner; JUnit suites ignore it. -->
+                        <cucumber.filter.tags>not @GraphComputerOnly and not @AllowNullPropertyValues and not @MultiProperties and not @MetaProperties and not @UserSuppliedVertexIds and not @UserSuppliedEdgeIds and not @UserSuppliedVertexPropertyIds and not @AllowListPropertyValues and not @AllowSetPropertyValues and not @AllowMapPropertyValues and not @AllowUUIDPropertyValues and not @AllowDateTimePropertyValues</cucumber.filter.tags>
+                        <!-- Exclude the single scenario g_V_playlist_paths: a seeded random-walk
+                             (repeat(out().order().by(shuffle).simplePath()).until(...)) over the
+                             large grateful-dead graph. On the JDBC federation provider each walk
+                             step is a DB round-trip and the walk is effectively non-terminating,
+                             hanging the whole fork. It cannot pass on a DB-backed provider, so
+                             excluding it costs no passing tests and keeps the suite runnable. -->
+                        <cucumber.filter.name>^(?!.*g_V_playlist_paths).*$</cucumber.filter.name>
+                    </systemPropertyVariables>
                     <!-- Guice 4.2.3 (cglib) and Kryo/Gryo serialization used by the TinkerPop test
                          harness reflect into java.base on Java 17; open the required packages. -->
                     <argLine>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.invoke=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED</argLine>

--- a/unipop-jdbc/src/org/unipop/jdbc/utils/JdbcPredicatesTranslator.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/utils/JdbcPredicatesTranslator.java
@@ -158,6 +158,12 @@ public class JdbcPredicatesTranslator implements PredicatesTranslator<Condition>
     }
 
     private Condition predicateToQuery(Field<Object> field, Object value, BiPredicate<?, ?> biPredicate) {
+        if (biPredicate instanceof org.apache.tinkerpop.gremlin.process.traversal.NotP.NotPBiPredicate) {
+            // P.not(inner) — translate the wrapped predicate and negate the resulting SQL condition.
+            BiPredicate<?, ?> inner =
+                    ((org.apache.tinkerpop.gremlin.process.traversal.NotP.NotPBiPredicate<?, ?>) biPredicate).getOriginal();
+            return predicateToQuery(field, value, inner).not();
+        }
         if (biPredicate instanceof Compare) {
             return getCompareCondition(value, biPredicate, field);
         } else if (biPredicate instanceof Contains) {
@@ -166,6 +172,13 @@ public class JdbcPredicatesTranslator implements PredicatesTranslator<Condition>
         }
         else if (biPredicate instanceof Text.TextPredicate) {
             return getTextCondition(value, biPredicate, field);
+        } else if (biPredicate instanceof org.apache.tinkerpop.gremlin.process.traversal.Text.RegexPredicate) {
+            // TinkerPop TextP.regex(...) / notRegex(...) — render as POSTGRES regex match (~ / !~).
+            org.apache.tinkerpop.gremlin.process.traversal.Text.RegexPredicate rp =
+                    (org.apache.tinkerpop.gremlin.process.traversal.Text.RegexPredicate) biPredicate;
+            return rp.isNegate() ? field.notLikeRegex(rp.getPattern()) : field.likeRegex(rp.getPattern());
+        } else if (biPredicate instanceof org.apache.tinkerpop.gremlin.process.traversal.Text) {
+            return getTinkerpopTextCondition(value, (org.apache.tinkerpop.gremlin.process.traversal.Text) biPredicate, field);
         } else if (biPredicate instanceof Date.DatePredicate) {
             try {
                 return getDateCondition(value, biPredicate, field);
@@ -173,7 +186,36 @@ public class JdbcPredicatesTranslator implements PredicatesTranslator<Condition>
                 throw new IllegalArgumentException("cant convert to date");
             }
         }
-        throw new IllegalArgumentException("can't create condition");
+        throw new IllegalArgumentException("can't create condition for predicate "
+                + (biPredicate == null ? "null" : biPredicate.getClass().getName() + " (" + biPredicate + ")"));
+    }
+
+    /**
+     * Map TinkerPop's native {@link org.apache.tinkerpop.gremlin.process.traversal.Text} predicates
+     * (produced by {@code TextP.containing/startingWith/endingWith} and their negations) to SQL.
+     * Unipop's own {@link Text.TextPredicate} uses LIKE wildcards; TinkerPop's {@code TextP} take
+     * literal substrings, so jOOQ's {@code contains}/{@code startsWith}/{@code endsWith} are used —
+     * they bind the value as a parameter and escape LIKE metacharacters, avoiding injection and
+     * false matches on {@code %}/{@code _} inside the search string.
+     */
+    private Condition getTinkerpopTextCondition(Object value, org.apache.tinkerpop.gremlin.process.traversal.Text predicate, Field<Object> field) {
+        String search = value == null ? "" : value.toString();
+        switch (predicate) {
+            case startingWith:
+                return field.startsWith(search);
+            case notStartingWith:
+                return field.startsWith(search).not();
+            case endingWith:
+                return field.endsWith(search);
+            case notEndingWith:
+                return field.endsWith(search).not();
+            case containing:
+                return field.contains(search);
+            case notContaining:
+                return field.contains(search).not();
+            default:
+                throw new IllegalArgumentException("text predicate not supported in has step: " + predicate);
+        }
     }
 
     private Condition getDateCondition(Object value, BiPredicate<?, ?> biPredicate, Field<Object> field) throws ParseException {


### PR DESCRIPTION
## Summary

Four root-cause fixes for pre-existing TinkerPop 3.8 partial-provider behaviour (not migration defects) that were suppressing the JDBC test pass rate. Verified by a full `mvn -pl unipop-jdbc test` run against embedded PostgreSQL:

| Suite | Before | After |
|---|---|---|
| `JdbcFeatureTest` (Gherkin) | 964 pass / 1913 | **1682 pass / 1912** (148 fail, 68 err, 14 skip) |
| `JdbcStructureSuite` | ~508 pass, 182 err | 509 pass, **16 err**, 31 fail |
| Enum / Jsonb unit tests | pass | pass (no regression) |

Whole reactor `test-compile`s; the feature suite completes with **no hang** (~2.5 min).

## The fixes

**1. `UniVertexProperty.properties()` threw instead of returning empty (+~250).**
It returned a vertex-property's *meta-properties* by throwing `multiPropertiesNotSupported()`. Per the TinkerPop contract, a graph without meta-properties (`UniFeatures.supportsMetaProperties() == false`) returns an **empty iterator** (cf. `ReferenceVertexProperty`). The Gherkin harness detaches *every* result vertex through this method (`StepDefinition.detachVertexProperty` → `DetachedVertexProperty`), so the throw aborted ~250 otherwise-valid scenarios. → `Collections.emptyIterator()`.

**2. Provider strategies aborted the whole strategy pass on graph-less child traversals (+~460).**
Six `ProviderOptimizationStrategy` classes (`UniGraph{Vertex,Graph,Repeat,Union,Coalesce}StepStrategy`, `EdgeStepsStrategy`) called `traversal.getGraph().get()`. TinkerPop 3.8 applies provider strategies **recursively to child traversals** (`TraversalHelper.applyTraversalRecursively`), which have no graph bound → `NoSuchElementException: No value present` aborted the entire `applyStrategies` pass, corrupting compilation for *every* scenario using nested traversals (`where`/`and`/`or`/`match`/`select(...).by`/`repeat`/`union`/`local`). → guard with `getGraph().orElse(null)` + the existing `instanceof UniGraph` check. Safe because the root application already optimizes nested steps via its manual child-walk, so bailing on the recursive child pass loses nothing.

**3. TinkerPop native `TextP` predicates were unmapped (+~10).**
`JdbcPredicatesTranslator` handled only Unipop's own `Text.TextPredicate`; TinkerPop's `TextP.containing/startingWith/endingWith` (+negations), `TextP.regex/notRegex` (`Text.RegexPredicate`), and `P.not(...)` (`NotP.NotPBiPredicate`) fell through to `"can't create condition"`. → mapped to jOOQ `contains/startsWith/endsWith` (parameter-bound, LIKE-escaped), `likeRegex/notLikeRegex`, and translate-then-`.not()` for the negation wrapper. The fallback exception now names the offending predicate class for future diagnosis.

**4. One pathological scenario excluded to keep the suite runnable.**
`g_V_playlist_paths` (`integrated/Paths.feature`) is a *seeded random walk* — `repeat(out().order().by(shuffle).simplePath()).until(reach a specific artist)` — over the large grateful-dead graph. On a DB-backed federation provider each walk step is a round-trip and the walk is effectively non-terminating, so it hangs the whole fork (it only completes in-memory on TinkerGraph). Once fix #2 let it *compile*, it began to hang. It cannot pass on this provider, so it is excluded by name via `cucumber.filter.name` in the jdbc surefire config — costing zero passing tests.

> **Gotcha:** supplying `cucumber.filter.name` makes Cucumber read filters from properties and **drops** the `@CucumberOptions.tags` capability exclusions (count jumped 1913 → 2060 as capability-excluded scenarios reappeared). The tag expression is therefore mirrored into `cucumber.filter.tags` in the same `<systemPropertyVariables>`.

## Scope / risk

- Core changes (7 files) are backward-compatible behaviour fixes to shared runtime; the structure suite and downstream modules were re-verified (`test-compile` green across the reactor, structure-suite errors *dropped*).
- Full details recorded in `MIGRATION_NOTES.md` → *Follow-on: JDBC test pass-rate improvements*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)