### PR TITLE
feat(core): env-var interpolation in provider config files

### DIFF
--- a/MIGRATION_NOTES.md
+++ b/MIGRATION_NOTES.md
@@ -339,3 +339,26 @@ vertex/edge's `properties`, contributed through `SourceProvider.providerBuilders
 A stale `"enums"` key is now silently ignored: the column falls back to a plain text column, so an
 enum comparison fails at **query time** with a `PSQLException` (enum vs varchar) rather than at config
 load — update configs when upgrading.
+
+## Environment variables in provider configs
+
+Any string value in a provider config JSON may reference an environment variable:
+
+- `${VAR}` — replaced with the value of environment variable `VAR`.
+- `${VAR:-default}` — uses `default` when `VAR` is unset or empty-absent.
+
+Resolution happens once when the config is loaded (`ConfigurationControllerManager`),
+before the provider connects. A `${VAR}` with no default that is not set fails startup
+with an `IllegalStateException` naming the variable and the config file. Text that is not
+a well-formed `${...}` placeholder is left as-is.
+
+Example (`unipop-jdbc` PostgreSQL provider):
+
+```json
+{
+  "class": "org.unipop.jdbc.JdbcSourceProvider",
+  "address": ["jdbc:postgresql://${DB_HOST:-localhost}:5432/graph"],
+  "user": "${DB_USER:-postgres}",
+  "password": "${DB_PASSWORD}"
+}
+```

--- a/MIGRATION_NOTES.md
+++ b/MIGRATION_NOTES.md
@@ -345,7 +345,7 @@ load — update configs when upgrading.
 Any string value in a provider config JSON may reference an environment variable:
 
 - `${VAR}` — replaced with the value of environment variable `VAR`.
-- `${VAR:-default}` — uses `default` when `VAR` is unset or empty-absent.
+- `${VAR:-default}` — uses `default` when `VAR` is not set (a var set to an empty string counts as set, yielding `""`).
 
 Resolution happens once when the config is loaded (`ConfigurationControllerManager`),
 before the provider connects. A `${VAR}` with no default that is not set fails startup

--- a/unipop-core/pom.xml
+++ b/unipop-core/pom.xml
@@ -66,6 +66,11 @@
             <artifactId>commons-lang</artifactId>
             <version>2.6</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.1</version>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/unipop-core/src/org/unipop/query/controller/ConfigurationControllerManager.java
+++ b/unipop-core/src/org/unipop/query/controller/ConfigurationControllerManager.java
@@ -5,6 +5,7 @@ import org.json.JSONObject;
 import org.unipop.schema.property.PropertySchema;
 import org.unipop.structure.traversalfilter.TraversalFilter;
 import org.unipop.structure.UniGraph;
+import org.unipop.util.ConfigInterpolator;
 import org.unipop.util.DirectoryWatcher;
 import org.unipop.util.PropertySchemaFactory;
 
@@ -47,6 +48,7 @@ public class ConfigurationControllerManager implements ControllerManager {
             if (Files.isRegularFile(filePath)){
                 String providerJson = readFile(filePath.toAbsolutePath().toString());
                 JSONObject providerConfig = new JSONObject(providerJson);
+                ConfigInterpolator.interpolate(providerConfig, filePath.toString());
                 String providerClass = providerConfig.getString("class");
                 SourceProvider sourceProvider = null;
                 try {

--- a/unipop-core/src/org/unipop/util/ConfigInterpolator.java
+++ b/unipop-core/src/org/unipop/util/ConfigInterpolator.java
@@ -1,0 +1,107 @@
+package org.unipop.util;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.util.function.Function;
+
+/**
+ * Interpolates {@code ${VAR}} / {@code ${VAR:-default}} placeholders in provider config JSON,
+ * resolving from environment variables. Applied once when a config is loaded, so every provider
+ * benefits. A config with no placeholders is returned unchanged.
+ */
+public final class ConfigInterpolator {
+
+    private ConfigInterpolator() {
+    }
+
+    /** Interpolate all string values in {@code config} (in place) using OS environment variables. */
+    public static void interpolate(JSONObject config, String sourceName) {
+        interpolate(config, System::getenv, sourceName);
+    }
+
+    static void interpolate(JSONObject config, Function<String, String> resolver, String sourceName) {
+        for (String key : config.keySet()) {
+            Object value = config.get(key);
+            if (value instanceof String) {
+                config.put(key, interpolateString((String) value, resolver, sourceName));
+            } else if (value instanceof JSONObject) {
+                interpolate((JSONObject) value, resolver, sourceName);
+            } else if (value instanceof JSONArray) {
+                interpolate((JSONArray) value, resolver, sourceName);
+            }
+        }
+    }
+
+    private static void interpolate(JSONArray array, Function<String, String> resolver, String sourceName) {
+        for (int i = 0; i < array.length(); i++) {
+            Object value = array.get(i);
+            if (value instanceof String) {
+                array.put(i, interpolateString((String) value, resolver, sourceName));
+            } else if (value instanceof JSONObject) {
+                interpolate((JSONObject) value, resolver, sourceName);
+            } else if (value instanceof JSONArray) {
+                interpolate((JSONArray) value, resolver, sourceName);
+            }
+        }
+    }
+
+    static String interpolateString(String value, Function<String, String> resolver, String sourceName) {
+        if (value.indexOf("${") < 0) {
+            return value;                                   // fast path: no placeholder
+        }
+        StringBuilder out = new StringBuilder();
+        int i = 0;
+        while (i < value.length()) {
+            int open = value.indexOf("${", i);
+            if (open < 0) {
+                out.append(value, i, value.length());
+                break;
+            }
+            int close = value.indexOf('}', open + 2);
+            if (close < 0) {
+                out.append(value, i, value.length());       // no closing brace -> rest is literal
+                break;
+            }
+            out.append(value, i, open);                     // literal text before "${"
+            String body = value.substring(open + 2, close);
+            String raw = value.substring(open, close + 1);  // "${...}" as written
+            out.append(resolve(body, resolver, sourceName, raw));
+            i = close + 1;
+        }
+        return out.toString();
+    }
+
+    private static String resolve(String body, Function<String, String> resolver, String sourceName, String raw) {
+        int sep = body.indexOf(":-");
+        String name = sep >= 0 ? body.substring(0, sep) : body;
+        String def = sep >= 0 ? body.substring(sep + 2) : null;
+        if (!isValidName(name)) {
+            return raw;                                     // not a well-formed placeholder -> literal
+        }
+        String resolved = resolver.apply(name);
+        if (resolved != null) {
+            return resolved;
+        }
+        if (def != null) {
+            return def;
+        }
+        throw new IllegalStateException("Unresolved environment variable ${" + name + "} in config "
+                + sourceName + " (set it, or provide a default via ${" + name + ":-...})");
+    }
+
+    private static boolean isValidName(String name) {
+        if (name.isEmpty()) {
+            return false;
+        }
+        for (int i = 0; i < name.length(); i++) {
+            char c = name.charAt(i);
+            boolean ok = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '_'
+                    || (i > 0 && c >= '0' && c <= '9');
+            if (!ok) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/unipop-core/test/org/unipop/util/ConfigInterpolatorTest.java
+++ b/unipop-core/test/org/unipop/util/ConfigInterpolatorTest.java
@@ -1,0 +1,86 @@
+package org.unipop.util;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.junit.Assert.*;
+
+public class ConfigInterpolatorTest {
+
+    /** Map-backed resolver (OS env vars can't be set inside a running JVM). */
+    private static Function<String, String> env(String... kv) {
+        Map<String, String> m = new HashMap<>();
+        for (int i = 0; i < kv.length; i += 2) m.put(kv[i], kv[i + 1]);
+        return m::get;
+    }
+
+    @Test public void substitutesSetVar() {
+        assertEquals("alice",
+                ConfigInterpolator.interpolateString("${DB_USER}", env("DB_USER", "alice"), "cfg"));
+    }
+
+    @Test public void usesDefaultWhenUnset() {
+        assertEquals("postgres",
+                ConfigInterpolator.interpolateString("${DB_USER:-postgres}", env(), "cfg"));
+    }
+
+    @Test public void setVarBeatsDefault() {
+        assertEquals("alice",
+                ConfigInterpolator.interpolateString("${DB_USER:-postgres}", env("DB_USER", "alice"), "cfg"));
+    }
+
+    @Test public void emptyDefaultAllowed() {
+        assertEquals("", ConfigInterpolator.interpolateString("${DB_USER:-}", env(), "cfg"));
+    }
+
+    @Test public void missingVarNoDefaultThrows() {
+        try {
+            ConfigInterpolator.interpolateString("${DB_PASSWORD}", env(), "myconfig.json");
+            fail("expected IllegalStateException");
+        } catch (IllegalStateException e) {
+            assertTrue(e.getMessage().contains("DB_PASSWORD"));
+            assertTrue(e.getMessage().contains("myconfig.json"));
+        }
+    }
+
+    @Test public void multiplePlaceholdersInOneString() {
+        String url = "jdbc:postgresql://${DB_HOST:-localhost}:${DB_PORT}/graph";
+        assertEquals("jdbc:postgresql://localhost:5432/graph",
+                ConfigInterpolator.interpolateString(url, env("DB_PORT", "5432"), "cfg"));
+    }
+
+    @Test public void malformedPlaceholderLeftLiteral() {
+        assertEquals("${}", ConfigInterpolator.interpolateString("${}", env(), "cfg"));
+        assertEquals("${1BAD}", ConfigInterpolator.interpolateString("${1BAD}", env(), "cfg"));
+        assertEquals("${UNCLOSED", ConfigInterpolator.interpolateString("${UNCLOSED", env(), "cfg"));
+    }
+
+    @Test public void noPlaceholderPassthrough() {
+        assertEquals("plain", ConfigInterpolator.interpolateString("plain", env(), "cfg"));
+    }
+
+    @Test public void walksNestedObjectsAndArrays() {
+        JSONObject cfg = new JSONObject()
+                .put("user", "${DB_USER:-postgres}")
+                .put("port", 5432)
+                .put("address", new JSONArray().put("jdbc://${DB_HOST:-localhost}:5432/g"))
+                .put("nested", new JSONObject().put("password", "${DB_PW:-secret}"));
+        ConfigInterpolator.interpolate(cfg, env(), "cfg");
+        assertEquals("postgres", cfg.getString("user"));
+        assertEquals(5432, cfg.getInt("port"));            // non-string untouched
+        assertEquals("jdbc://localhost:5432/g", cfg.getJSONArray("address").getString(0));
+        assertEquals("secret", cfg.getJSONObject("nested").getString("password"));
+    }
+
+    @Test public void publicOverloadUsesEnvWithDefault() {
+        // Exercises the System.getenv path via a default so it needs no real env var.
+        JSONObject cfg = new JSONObject().put("user", "${DEFINITELY_UNSET_VAR_XYZ:-fallback}");
+        ConfigInterpolator.interpolate(cfg, "cfg");
+        assertEquals("fallback", cfg.getString("user"));
+    }
+}


### PR DESCRIPTION
## Summary

Lets provider config JSON reference environment variables, so secrets (DB credentials, hosts) can be kept out of committed configs and loaded from the environment at startup. Opt-in and backward compatible — a config with no `${...}` behaves exactly as before.

```json
{
  "class": "org.unipop.jdbc.JdbcSourceProvider",
  "address": ["jdbc:postgresql://${DB_HOST:-localhost}:5432/graph"],
  "user": "${DB_USER:-postgres}",
  "password": "${DB_PASSWORD}"
}
```

## Behavior

- **Syntax:** `${VAR}` and `${VAR:-default}`. `VAR` = `[A-Za-z_][A-Za-z0-9_]*`; the default runs to the first `}` (no nesting).
- **Lookup:** `System.getenv` only.
- **Missing var, no default:** fail fast — `IllegalStateException` naming the variable and the config file (never silently substitutes empty).
- **Malformed / non-placeholder `${...}`:** left literal, never throws.
- Resolution happens once at config load, before any provider connects, so all providers (jdbc/elastic/rest) benefit.

## Design

Post-parse **recursive tree walk** (chosen over pre-parse raw-string regex so credential values containing JSON metacharacters like `"`/`\` can't corrupt parsing): a new stateless util `org.unipop.util.ConfigInterpolator` rewrites `${...}` in every String value of the parsed `JSONObject`, invoked at the single existing load point `ConfigurationControllerManager.loadControllers()`. An injectable `Function<String,String>` resolver makes the grammar unit-testable (OS env vars can't be set at test time); the public overload uses `System::getenv`.

## Tests

New `ConfigInterpolatorTest` — 10 cases: var set, default used, var-beats-default, empty default, missing→throws (message names var + source), multiple placeholders in one string, malformed→literal, no-placeholder passthrough, nested object/array walk (non-strings untouched), public `System.getenv` overload. Regression: `JdbcEnumTest` (a placeholder-free config) still loads unchanged.

## Review

Built via subagent-driven-development (implementer + task review per task, final whole-branch review on the most capable model): **READY TO MERGE**, 0 Critical / 0 Important. Three Minors: one doc/code wording mismatch fixed in this branch; two are pre-existing/out-of-scope.

**Follow-up for maintainers (pre-existing):** `unipop-core/src/org/unipop/test/UnipopStructureSuite.java` lives in *main* sources and imports JUnit, which forces the new junit dependency to compile scope (test scope would break `mvn compile`). Moving that suite into the test tree would let junit be `test`-scoped.

## Files
- Core: `ConfigInterpolator` (new) + `ConfigInterpolatorTest` (new, core's first unit test) + junit in `unipop-core/pom.xml`; one import + one call in `ConfigurationControllerManager`.
- Docs: usage section in `MIGRATION_NOTES.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)