### PR TITLE
feat(jdbc): UUID property schema for native PostgreSQL uuid columns

### DIFF
--- a/unipop-jdbc/pom.xml
+++ b/unipop-jdbc/pom.xml
@@ -130,6 +130,7 @@
                         <include>**/JdbcJsonbTest.java</include>
                         <include>**/JdbcMultiJsonbTest.java</include>
                         <include>**/EnumPropertySchemaTest.java</include>
+                        <include>**/UuidPropertySchemaTest.java</include>
                     </includes>
                     <environmentVariables>
                         <conf>basic</conf>

--- a/unipop-jdbc/pom.xml
+++ b/unipop-jdbc/pom.xml
@@ -131,6 +131,7 @@
                         <include>**/JdbcMultiJsonbTest.java</include>
                         <include>**/EnumPropertySchemaTest.java</include>
                         <include>**/UuidPropertySchemaTest.java</include>
+                        <include>**/JdbcUuidTest.java</include>
                     </includes>
                     <environmentVariables>
                         <conf>basic</conf>

--- a/unipop-jdbc/resources/configuration/uuid/uuids.json
+++ b/unipop-jdbc/resources/configuration/uuid/uuids.json
@@ -1,0 +1,20 @@
+{
+  "class": "org.unipop.jdbc.JdbcSourceProvider",
+  "driver": "org.postgresql.Driver",
+  "address": ["jdbc:postgresql://localhost:54329/postgres"],
+  "user": "postgres",
+  "sqlDialect": "POSTGRES",
+  "vertices": [
+    {
+      "table": "uuids",
+      "id": "@id",
+      "label": "@label",
+      "properties": {
+        "name": "@name",
+        "ref": { "type": "uuid" }
+      },
+      "dynamicProperties": false
+    }
+  ],
+  "edges": []
+}

--- a/unipop-jdbc/src/org/unipop/jdbc/JdbcSourceProvider.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/JdbcSourceProvider.java
@@ -10,6 +10,7 @@ import org.unipop.jdbc.schemas.RowVertexSchema;
 import org.unipop.jdbc.schemas.jdbc.JdbcSchema;
 import org.unipop.jdbc.schemas.property.EnumPropertySchema;
 import org.unipop.jdbc.schemas.property.JsonbPropertySchema;
+import org.unipop.jdbc.schemas.property.UuidPropertySchema;
 import org.unipop.jdbc.utils.ContextManager;
 import org.unipop.jdbc.utils.JdbcPredicatesTranslator;
 import org.unipop.query.controller.SourceProvider;
@@ -58,7 +59,8 @@ public class JdbcSourceProvider implements SourceProvider {
 
     @Override
     public List<PropertySchema.PropertySchemaBuilder> providerBuilders() {
-        return Arrays.asList(new JsonbPropertySchema.Builder(), new EnumPropertySchema.Builder());
+        return Arrays.asList(new JsonbPropertySchema.Builder(), new EnumPropertySchema.Builder(),
+                new UuidPropertySchema.Builder());
     }
 
     @Override

--- a/unipop-jdbc/src/org/unipop/jdbc/schemas/AbstractRowSchema.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/schemas/AbstractRowSchema.java
@@ -12,6 +12,7 @@ import org.json.JSONObject;
 import org.unipop.jdbc.schemas.jdbc.JdbcSchema;
 import org.unipop.jdbc.schemas.property.EnumColumnSchema;
 import org.unipop.jdbc.schemas.property.JsonbColumnSchema;
+import org.unipop.jdbc.schemas.property.UuidColumnSchema;
 import org.unipop.jdbc.utils.ContextManager;
 import org.unipop.jdbc.utils.JdbcPredicatesTranslator;
 import org.unipop.query.predicates.PredicateQuery;
@@ -96,7 +97,11 @@ public abstract class AbstractRowSchema<E extends Element> extends AbstractEleme
                 .filter(s -> s instanceof EnumColumnSchema)
                 .map(s -> ((EnumColumnSchema) s).getEnumColumn())
                 .collect(Collectors.toSet());
-        Condition conditions = new JdbcPredicatesTranslator(idFields, enumColumns, jsonbColumns).translate(predicatesHolder);
+        Set<String> uuidColumns = getPropertySchemas().stream()
+                .filter(s -> s instanceof UuidColumnSchema)
+                .map(s -> ((UuidColumnSchema) s).getUuidColumn())
+                .collect(Collectors.toSet());
+        Condition conditions = new JdbcPredicatesTranslator(idFields, enumColumns, jsonbColumns, uuidColumns).translate(predicatesHolder);
         int finalLimit = query.getLimit() < 0 ? Integer.MAX_VALUE : query.getLimit();
 
         SelectConditionStep<Record> where = createSqlQuery(query.getPropertyKeys())

--- a/unipop-jdbc/src/org/unipop/jdbc/schemas/property/UuidColumnSchema.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/schemas/property/UuidColumnSchema.java
@@ -1,0 +1,10 @@
+package org.unipop.jdbc.schemas.property;
+
+/**
+ * Implemented by property schemas backed by a PostgreSQL native uuid column, so the row schema can
+ * tell the predicates translator which columns to compare as text (col::text = ?).
+ */
+public interface UuidColumnSchema {
+    /** @return the uuid column name this schema is backed by. */
+    String getUuidColumn();
+}

--- a/unipop-jdbc/src/org/unipop/jdbc/schemas/property/UuidPropertySchema.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/schemas/property/UuidPropertySchema.java
@@ -1,0 +1,65 @@
+package org.unipop.jdbc.schemas.property;
+
+import org.json.JSONObject;
+import org.unipop.schema.property.AbstractPropertyContainer;
+import org.unipop.schema.property.FieldPropertySchema;
+import org.unipop.schema.property.PropertySchema;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * A keyed property schema backing a PostgreSQL native uuid column. Extends {@link FieldPropertySchema}
+ * for the column&lt;-&gt;property mapping; the column is reported via {@link UuidColumnSchema} so the
+ * jdbc translator compares it as text (col::text = ?). Values are coerced to {@link UUID} on write
+ * (so the native uuid column binds a uuid, not a varchar) and on read (so {@code values(col)} yields
+ * a {@code java.util.UUID} regardless of how the driver returns the column). Declare:
+ * {@code "ref": {"type":"uuid"}}.
+ */
+public class UuidPropertySchema extends FieldPropertySchema implements UuidColumnSchema {
+
+    public UuidPropertySchema(String key, String field, boolean nullable) {
+        super(key, field, nullable);
+    }
+
+    @Override
+    public String getUuidColumn() {
+        return field;
+    }
+
+    @Override
+    public Map<String, Object> toFields(Map<String, Object> properties) {
+        Map<String, Object> fields = super.toFields(properties);
+        if (fields == null || fields.isEmpty()) return fields;
+        Object value = fields.get(field);
+        if (value instanceof String) {
+            return Collections.singletonMap(field, UUID.fromString((String) value));
+        }
+        return fields;
+    }
+
+    @Override
+    public Map<String, Object> toProperties(Map<String, Object> source) {
+        Map<String, Object> props = super.toProperties(source);
+        if (props == null || props.isEmpty()) return props;
+        Object value = props.get(key);
+        if (value instanceof String) {
+            return Collections.singletonMap(key, UUID.fromString((String) value));
+        }
+        return props;
+    }
+
+    public static class Builder implements PropertySchemaBuilder {
+        @Override
+        public PropertySchema build(String key, Object conf, AbstractPropertyContainer container) {
+            if (!(conf instanceof JSONObject)) return null;
+            JSONObject config = (JSONObject) conf;
+            if (!"uuid".equalsIgnoreCase(config.optString("type", ""))) return null;
+            String field = config.optString("field", key);
+            if (field.startsWith("@")) field = field.substring(1);
+            boolean nullable = config.optBoolean("nullable", true);
+            return new UuidPropertySchema(key, field, nullable);
+        }
+    }
+}

--- a/unipop-jdbc/src/org/unipop/jdbc/utils/JdbcPredicatesTranslator.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/utils/JdbcPredicatesTranslator.java
@@ -34,6 +34,7 @@ public class JdbcPredicatesTranslator implements PredicatesTranslator<Condition>
     private final Set<String> idFields;
     private final Set<String> enumColumns;
     private final Set<String> jsonbColumns;
+    private final Set<String> uuidColumns;
 
     public JdbcPredicatesTranslator() {
         this(Collections.emptySet(), Collections.emptySet(), Collections.emptySet());
@@ -48,9 +49,14 @@ public class JdbcPredicatesTranslator implements PredicatesTranslator<Condition>
     }
 
     public JdbcPredicatesTranslator(Set<String> idFields, Set<String> enumColumns, Set<String> jsonbColumns) {
+        this(idFields, enumColumns, jsonbColumns, Collections.emptySet());
+    }
+
+    public JdbcPredicatesTranslator(Set<String> idFields, Set<String> enumColumns, Set<String> jsonbColumns, Set<String> uuidColumns) {
         this.idFields = idFields == null ? Collections.emptySet() : idFields;
         this.enumColumns = enumColumns == null ? Collections.emptySet() : enumColumns;
         this.jsonbColumns = jsonbColumns == null ? Collections.emptySet() : jsonbColumns;
+        this.uuidColumns = uuidColumns == null ? Collections.emptySet() : uuidColumns;
     }
 
     /** A dotted key whose first segment is a JSONB column, e.g. {@code data.address.city}. */
@@ -76,7 +82,7 @@ public class JdbcPredicatesTranslator implements PredicatesTranslator<Condition>
             }
             return DSL.field(sql.toString(), Object.class, qps);
         }
-        return enumColumns.contains(key)
+        return (enumColumns.contains(key) || uuidColumns.contains(key))
                 ? DSL.field("{0}::text", Object.class, DSL.field(DSL.name(key)))
                 : field(key);
     }
@@ -130,7 +136,7 @@ public class JdbcPredicatesTranslator implements PredicatesTranslator<Condition>
         else if (predicate instanceof ExistsP) {
             return field.isNotNull();
         } else {
-            if (idFields.contains(key) || isJsonbKey(key)) value = stringifyValue(value);
+            if (idFields.contains(key) || isJsonbKey(key) || uuidColumns.contains(key)) value = stringifyValue(value);
             return predicateToQuery(field, value, biPredicate);
         }
     }

--- a/unipop-jdbc/test/org/unipop/jdbc/uuid/JdbcUuidTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/uuid/JdbcUuidTest.java
@@ -1,0 +1,92 @@
+package org.unipop.jdbc.uuid;
+
+import org.apache.commons.configuration2.BaseConfiguration;
+import org.apache.commons.configuration2.Configuration;
+import org.apache.tinkerpop.gremlin.process.traversal.P;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.unipop.jdbc.suite.EmbeddedPostgresServer;
+import org.unipop.structure.UniGraph;
+
+import java.io.File;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Exercises a property backed by a PostgreSQL native uuid column (write + query + read + update),
+ * with both java.util.UUID and String values, against embedded PostgreSQL.
+ */
+public class JdbcUuidTest {
+
+    private static GraphTraversalSource g;
+    private static final UUID U1 = UUID.fromString("f47ac10b-58cc-4372-a567-0f02b2f3d479");
+    private static final UUID U2 = UUID.fromString("9f1a7b2c-3d4e-4f60-8181-92a3b4c5d6e7");
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        EmbeddedPostgresServer.ensureStarted();
+        Class.forName("org.postgresql.Driver");
+        try (Connection c = DriverManager.getConnection(EmbeddedPostgresServer.URL, EmbeddedPostgresServer.USER, "");
+             Statement s = c.createStatement()) {
+            s.execute("DROP TABLE IF EXISTS uuids");
+            s.execute("CREATE TABLE uuids (id varchar(100) primary key, label varchar(100), name varchar(100), ref uuid)");
+        }
+        String dir = new File(JdbcUuidTest.class.getResource("/configuration/uuid/uuids.json").toURI()).getParent();
+        Configuration conf = new BaseConfiguration();
+        conf.setProperty(Graph.GRAPH, UniGraph.class.getName());
+        conf.setProperty("graphName", "uuidtest");
+        conf.setProperty("providers", dir);
+        g = UniGraph.open(conf).traversal();
+    }
+
+    @Before
+    public void clean() throws Exception {
+        try (Connection c = DriverManager.getConnection(EmbeddedPostgresServer.URL, EmbeddedPostgresServer.USER, "");
+             Statement s = c.createStatement()) {
+            s.execute("TRUNCATE TABLE uuids");
+        }
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        if (g != null) g.close();
+    }
+
+    @Test
+    public void writeUuidValueReadBackAsUuidAndQuery() {
+        g.addV("thing").property(T.id, "1").property("name", "a").property("ref", U1).next();
+        Object read = g.V("1").values("ref").next();
+        assertEquals(U1, read);
+        assertTrue("values(ref) must be a java.util.UUID", read instanceof UUID);
+        assertEquals(1L, (long) g.V().has("ref", U1).count().next());
+        assertEquals(1L, (long) g.V().has("ref", P.within(U1)).count().next());
+    }
+
+    @Test
+    public void writeUuidStringReadBackAsUuidAndQueryByString() {
+        g.addV("thing").property(T.id, "2").property("name", "b").property("ref", U2.toString()).next();
+        Object read = g.V("2").values("ref").next();
+        assertEquals(U2, read);
+        assertTrue(read instanceof UUID);
+        assertEquals(1L, (long) g.V().has("ref", U2.toString()).count().next());
+    }
+
+    @Test
+    public void updateUuid() {
+        g.addV("thing").property(T.id, "3").property("name", "c").property("ref", U1).next();
+        g.V("3").property("ref", U2).next();
+        assertEquals(U2, g.V("3").values("ref").next());
+        assertEquals(0L, (long) g.V().has("ref", U1).count().next());
+        assertEquals(1L, (long) g.V().has("ref", U2).count().next());
+    }
+}

--- a/unipop-jdbc/test/org/unipop/jdbc/uuid/UuidPropertySchemaTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/uuid/UuidPropertySchemaTest.java
@@ -1,0 +1,94 @@
+package org.unipop.jdbc.uuid;
+
+import org.json.JSONObject;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.unipop.jdbc.schemas.property.UuidPropertySchema;
+import org.unipop.schema.property.PropertySchema;
+import org.unipop.schema.property.type.DateType;
+import org.unipop.schema.property.type.DoubleType;
+import org.unipop.schema.property.type.FloatType;
+import org.unipop.schema.property.type.IntType;
+import org.unipop.schema.property.type.LongType;
+import org.unipop.schema.property.type.NumberType;
+import org.unipop.schema.property.type.TextType;
+import org.unipop.util.PropertyTypeFactory;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+
+public class UuidPropertySchemaTest {
+
+    private static final String S = "f47ac10b-58cc-4372-a567-0f02b2f3d479";
+
+    @BeforeClass
+    public static void initPropertyTypes() {
+        // FieldPropertySchema's constructor resolves its PropertyType from PropertyTypeFactory, which
+        // UniGraph populates at graph bootstrap. Replicate that init so the builder works standalone.
+        PropertyTypeFactory.init(Arrays.asList(
+                TextType.class.getCanonicalName(),
+                DateType.class.getCanonicalName(),
+                NumberType.class.getCanonicalName(),
+                DoubleType.class.getCanonicalName(),
+                FloatType.class.getCanonicalName(),
+                IntType.class.getCanonicalName(),
+                LongType.class.getCanonicalName()));
+    }
+
+    @Test public void toFieldsCoercesStringToUuid() {
+        UuidPropertySchema schema = new UuidPropertySchema("ref", "ref", true);
+        Map<String, Object> fields = schema.toFields(Collections.singletonMap("ref", S));
+        assertEquals(UUID.fromString(S), fields.get("ref"));
+        assertTrue(fields.get("ref") instanceof UUID);
+    }
+
+    @Test public void toFieldsPassesThroughUuid() {
+        UuidPropertySchema schema = new UuidPropertySchema("ref", "ref", true);
+        UUID u = UUID.fromString(S);
+        Map<String, Object> fields = schema.toFields(Collections.singletonMap("ref", u));
+        assertSame(u, fields.get("ref"));
+    }
+
+    @Test public void toFieldsEmptyWhenAbsentAndNullable() {
+        UuidPropertySchema schema = new UuidPropertySchema("ref", "ref", true);
+        assertTrue(schema.toFields(Collections.emptyMap()).isEmpty());
+    }
+
+    @Test public void toPropertiesCoercesStringToUuid() {
+        // simulates a fetch that returned the uuid column as a String
+        UuidPropertySchema schema = new UuidPropertySchema("ref", "ref", true);
+        Map<String, Object> props = schema.toProperties(Collections.singletonMap("ref", S));
+        assertEquals(UUID.fromString(S), props.get("ref"));
+        assertTrue(props.get("ref") instanceof UUID);
+    }
+
+    @Test public void toPropertiesPassesThroughUuid() {
+        UuidPropertySchema schema = new UuidPropertySchema("ref", "ref", true);
+        UUID u = UUID.fromString(S);
+        Map<String, Object> props = schema.toProperties(Collections.singletonMap("ref", u));
+        assertSame(u, props.get("ref"));
+    }
+
+    @Test public void builderMatchesUuidType() {
+        PropertySchema s = new UuidPropertySchema.Builder()
+                .build("ref", new JSONObject().put("type", "uuid"), null);
+        assertNotNull(s);
+        assertTrue(s instanceof UuidPropertySchema);
+        assertEquals("ref", ((UuidPropertySchema) s).getUuidColumn());
+    }
+
+    @Test public void builderHonorsFieldAlias() {
+        PropertySchema s = new UuidPropertySchema.Builder()
+                .build("ref", new JSONObject().put("type", "uuid").put("field", "@ref_col"), null);
+        assertEquals("ref_col", ((UuidPropertySchema) s).getUuidColumn());
+    }
+
+    @Test public void builderIgnoresOtherTypesAndNonObjects() {
+        assertNull(new UuidPropertySchema.Builder().build("x", new JSONObject().put("type", "enum"), null));
+        assertNull(new UuidPropertySchema.Builder().build("x", "plainstring", null));
+    }
+}


### PR DESCRIPTION
## Summary

Adds a keyed `{"type":"uuid"}` property schema to the JDBC provider, giving full CRUD against native PostgreSQL `uuid` columns — mirroring the existing `enum`/`jsonb` keyed schemas.

```json
"properties": {
  "ref": { "type": "uuid" }
}
```

- **Write:** `property(k, uuid|string)` binds a native `uuid` (values coerced to `java.util.UUID`, so pgjdbc sends a uuid, not a varchar).
- **Read:** `values(k)` returns a `java.util.UUID`.
- **Query:** `has(k, eq/within/without …)` works with either a `UUID` or a `String` value — rendered as `col::text = ?` with the value stringified (identical to the enum schema; matches PostgreSQL's canonical lowercase uuid text form).

## Design (Approach A — enum-parallel)

- New `UuidColumnSchema` marker + `UuidPropertySchema extends FieldPropertySchema implements UuidColumnSchema`, registered via `JdbcSourceProvider.providerBuilders()`.
- `UuidPropertySchema` coerces `String → java.util.UUID` on write (`toFields`) and read (`toProperties`); a `UUID` passes through, null/empty untouched.
- `JdbcPredicatesTranslator` gains a `uuidColumns` set + a **backward-compatible 4-arg constructor** (the 3-arg delegates with an empty set); `columnField` renders `col::text` for uuid columns and `extractCondition` stringifies their predicate values — reusing the enum path.
- `AbstractRowSchema.getSearch` collects uuid columns via the `UuidColumnSchema` marker.

## Tests

- `UuidPropertySchemaTest` — 8 unit tests (Builder matching, field alias, both coercion directions, guards).
- `JdbcUuidTest` — 3 integration tests on a native `uuid` column (embedded PostgreSQL): write a `UUID` → read back as `java.util.UUID` → query by `UUID` and `within`; write a UUID **string** → read back as `UUID` → query by string; update.
- Both added to the surefire `<includes>`.

## Full-module regression (no regressions)

| Suite | Result |
|---|---|
| `JdbcFeatureTest` | 1884, **20 fail, 0 err** (unchanged baseline) |
| `JdbcStructureSuite` | 935, 30 fail, **16 err** (unchanged baseline) |
| `JdbcUuidTest` / `UuidPropertySchemaTest` | 3/0/0, 8/0/0 |
| `JdbcEnumTest` / `EnumPropertySchemaTest` / `JdbcJsonbTest` / `JdbcMultiJsonbTest` | all green |

The shared translator/`getSearch` changes are confirmed behavior-preserving for enum/jsonb/id callers (with no uuid schema present, `uuidColumns` is empty and the added terms are inert).

## Review

Built via brainstorming → writing-plans → subagent-driven-development (implementer + task review per task, final opus whole-branch review): **READY TO MERGE**, 0 Critical / 0 Important.

**Follow-ups (pre-existing, not introduced here):** `handleConnectiveP` (`P.and`/`P.or`) doesn't stringify uuid/id/jsonb predicate values (shared with the existing id/jsonb paths; not exercised). Optionally, un-exclude TinkerPop's `@AllowUUIDPropertyValues` feature scenarios now that native uuid columns are supported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)