### PR TITLE
feat(jdbc): timestamptz property schema for native PostgreSQL timestamptz columns

### DIFF
--- a/unipop-jdbc/pom.xml
+++ b/unipop-jdbc/pom.xml
@@ -133,6 +133,7 @@
                         <include>**/UuidPropertySchemaTest.java</include>
                         <include>**/JdbcUuidTest.java</include>
                         <include>**/TimestamptzPropertySchemaTest.java</include>
+                        <include>**/JdbcTimestamptzTest.java</include>
                     </includes>
                     <environmentVariables>
                         <conf>basic</conf>

--- a/unipop-jdbc/pom.xml
+++ b/unipop-jdbc/pom.xml
@@ -132,6 +132,7 @@
                         <include>**/EnumPropertySchemaTest.java</include>
                         <include>**/UuidPropertySchemaTest.java</include>
                         <include>**/JdbcUuidTest.java</include>
+                        <include>**/TimestamptzPropertySchemaTest.java</include>
                     </includes>
                     <environmentVariables>
                         <conf>basic</conf>

--- a/unipop-jdbc/resources/configuration/timestamptz/tstz.json
+++ b/unipop-jdbc/resources/configuration/timestamptz/tstz.json
@@ -1,0 +1,20 @@
+{
+  "class": "org.unipop.jdbc.JdbcSourceProvider",
+  "driver": "org.postgresql.Driver",
+  "address": ["jdbc:postgresql://localhost:54329/postgres"],
+  "user": "postgres",
+  "sqlDialect": "POSTGRES",
+  "vertices": [
+    {
+      "table": "tstz",
+      "id": "@id",
+      "label": "@label",
+      "properties": {
+        "name": "@name",
+        "at": { "type": "timestamptz" }
+      },
+      "dynamicProperties": false
+    }
+  ],
+  "edges": []
+}

--- a/unipop-jdbc/src/org/unipop/jdbc/JdbcSourceProvider.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/JdbcSourceProvider.java
@@ -10,6 +10,7 @@ import org.unipop.jdbc.schemas.RowVertexSchema;
 import org.unipop.jdbc.schemas.jdbc.JdbcSchema;
 import org.unipop.jdbc.schemas.property.EnumPropertySchema;
 import org.unipop.jdbc.schemas.property.JsonbPropertySchema;
+import org.unipop.jdbc.schemas.property.TimestamptzPropertySchema;
 import org.unipop.jdbc.schemas.property.UuidPropertySchema;
 import org.unipop.jdbc.utils.ContextManager;
 import org.unipop.jdbc.utils.JdbcPredicatesTranslator;
@@ -60,7 +61,7 @@ public class JdbcSourceProvider implements SourceProvider {
     @Override
     public List<PropertySchema.PropertySchemaBuilder> providerBuilders() {
         return Arrays.asList(new JsonbPropertySchema.Builder(), new EnumPropertySchema.Builder(),
-                new UuidPropertySchema.Builder());
+                new UuidPropertySchema.Builder(), new TimestamptzPropertySchema.Builder());
     }
 
     @Override

--- a/unipop-jdbc/src/org/unipop/jdbc/schemas/AbstractRowSchema.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/schemas/AbstractRowSchema.java
@@ -12,6 +12,7 @@ import org.json.JSONObject;
 import org.unipop.jdbc.schemas.jdbc.JdbcSchema;
 import org.unipop.jdbc.schemas.property.EnumColumnSchema;
 import org.unipop.jdbc.schemas.property.JsonbColumnSchema;
+import org.unipop.jdbc.schemas.property.TimestamptzColumnSchema;
 import org.unipop.jdbc.schemas.property.UuidColumnSchema;
 import org.unipop.jdbc.utils.ContextManager;
 import org.unipop.jdbc.utils.JdbcPredicatesTranslator;
@@ -101,7 +102,11 @@ public abstract class AbstractRowSchema<E extends Element> extends AbstractEleme
                 .filter(s -> s instanceof UuidColumnSchema)
                 .map(s -> ((UuidColumnSchema) s).getUuidColumn())
                 .collect(Collectors.toSet());
-        Condition conditions = new JdbcPredicatesTranslator(idFields, enumColumns, jsonbColumns, uuidColumns).translate(predicatesHolder);
+        Set<String> timestamptzColumns = getPropertySchemas().stream()
+                .filter(s -> s instanceof TimestamptzColumnSchema)
+                .map(s -> ((TimestamptzColumnSchema) s).getTimestamptzColumn())
+                .collect(Collectors.toSet());
+        Condition conditions = new JdbcPredicatesTranslator(idFields, enumColumns, jsonbColumns, uuidColumns, timestamptzColumns).translate(predicatesHolder);
         int finalLimit = query.getLimit() < 0 ? Integer.MAX_VALUE : query.getLimit();
 
         SelectConditionStep<Record> where = createSqlQuery(query.getPropertyKeys())

--- a/unipop-jdbc/src/org/unipop/jdbc/schemas/property/TimestamptzColumnSchema.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/schemas/property/TimestamptzColumnSchema.java
@@ -1,0 +1,11 @@
+package org.unipop.jdbc.schemas.property;
+
+/**
+ * Implemented by property schemas backed by a PostgreSQL native timestamptz column, so the row
+ * schema can tell the predicates translator which columns take native-temporal predicate handling
+ * (values coerced to OffsetDateTime and compared as real timestamps, not text).
+ */
+public interface TimestamptzColumnSchema {
+    /** @return the timestamptz column name this schema is backed by. */
+    String getTimestamptzColumn();
+}

--- a/unipop-jdbc/src/org/unipop/jdbc/schemas/property/TimestamptzPropertySchema.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/schemas/property/TimestamptzPropertySchema.java
@@ -1,0 +1,91 @@
+package org.unipop.jdbc.schemas.property;
+
+import org.json.JSONObject;
+import org.unipop.schema.property.AbstractPropertyContainer;
+import org.unipop.schema.property.FieldPropertySchema;
+import org.unipop.schema.property.PropertySchema;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
+
+/**
+ * A keyed property schema backing a PostgreSQL native {@code timestamptz} column. Extends
+ * {@link FieldPropertySchema}; the column is reported via {@link TimestamptzColumnSchema} so the jdbc
+ * translator compares it as a native temporal (never text-cast, which would break ordering). Values
+ * are coerced to {@link OffsetDateTime} on write and read, so the column round-trips and
+ * {@code values(col)} is always an {@code OffsetDateTime}. Declare: {@code "at": {"type":"timestamptz"}}.
+ */
+public class TimestamptzPropertySchema extends FieldPropertySchema implements TimestamptzColumnSchema {
+
+    public TimestamptzPropertySchema(String key, String field, boolean nullable) {
+        super(key, field, nullable);
+    }
+
+    @Override
+    public String getTimestamptzColumn() {
+        return field;
+    }
+
+    /**
+     * Coerce a supported value to an {@link OffsetDateTime} (UTC for zone-less inputs).
+     * Accepts OffsetDateTime (passthrough), Instant, java.util.Date (incl. java.sql.Timestamp), and
+     * ISO-8601 String. Returns {@code null} for {@code null}. Throws {@link IllegalArgumentException}
+     * for any other type.
+     */
+    public static OffsetDateTime toOffsetDateTime(Object value) {
+        if (value == null) return null;
+        if (value instanceof OffsetDateTime) return (OffsetDateTime) value;
+        if (value instanceof Instant) return ((Instant) value).atOffset(ZoneOffset.UTC);
+        if (value instanceof Date) return ((Date) value).toInstant().atOffset(ZoneOffset.UTC);
+        if (value instanceof String) {
+            String s = (String) value;
+            try {
+                return OffsetDateTime.parse(s);
+            } catch (DateTimeParseException e) {
+                return LocalDateTime.parse(s).atOffset(ZoneOffset.UTC);
+            }
+        }
+        throw new IllegalArgumentException("Cannot coerce " + value.getClass().getName() + " to timestamptz: " + value);
+    }
+
+    @Override
+    public Map<String, Object> toFields(Map<String, Object> properties) {
+        Map<String, Object> fields = super.toFields(properties);
+        if (fields == null || fields.isEmpty()) return fields;
+        Object value = fields.get(field);
+        if (value != null) {
+            return Collections.singletonMap(field, toOffsetDateTime(value));
+        }
+        return fields;
+    }
+
+    @Override
+    public Map<String, Object> toProperties(Map<String, Object> source) {
+        Map<String, Object> props = super.toProperties(source);
+        if (props == null || props.isEmpty()) return props;
+        Object value = props.get(key);
+        if (value != null) {
+            return Collections.singletonMap(key, toOffsetDateTime(value));
+        }
+        return props;
+    }
+
+    public static class Builder implements PropertySchemaBuilder {
+        @Override
+        public PropertySchema build(String key, Object conf, AbstractPropertyContainer container) {
+            if (!(conf instanceof JSONObject)) return null;
+            JSONObject config = (JSONObject) conf;
+            if (!"timestamptz".equalsIgnoreCase(config.optString("type", ""))) return null;
+            String field = config.optString("field", key);
+            if (field.startsWith("@")) field = field.substring(1);
+            boolean nullable = config.optBoolean("nullable", true);
+            return new TimestamptzPropertySchema(key, field, nullable);
+        }
+    }
+}

--- a/unipop-jdbc/src/org/unipop/jdbc/schemas/property/TimestamptzPropertySchema.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/schemas/property/TimestamptzPropertySchema.java
@@ -48,7 +48,11 @@ public class TimestamptzPropertySchema extends FieldPropertySchema implements Ti
             try {
                 return OffsetDateTime.parse(s);
             } catch (DateTimeParseException e) {
-                return LocalDateTime.parse(s).atOffset(ZoneOffset.UTC);
+                try {
+                    return LocalDateTime.parse(s).atOffset(ZoneOffset.UTC);
+                } catch (DateTimeParseException e2) {
+                    throw new IllegalArgumentException("Cannot coerce String to timestamptz: " + s, e2);
+                }
             }
         }
         throw new IllegalArgumentException("Cannot coerce " + value.getClass().getName() + " to timestamptz: " + value);

--- a/unipop-jdbc/src/org/unipop/jdbc/utils/JdbcPredicatesTranslator.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/utils/JdbcPredicatesTranslator.java
@@ -12,6 +12,7 @@ import org.jooq.Field;
 import org.jooq.QueryPart;
 import org.jooq.impl.DSL;
 import org.unipop.common.util.PredicatesTranslator;
+import org.unipop.jdbc.schemas.property.TimestamptzPropertySchema;
 import org.unipop.process.predicate.Date;
 import org.unipop.process.predicate.ExistsP;
 import org.unipop.process.predicate.Text;
@@ -35,6 +36,7 @@ public class JdbcPredicatesTranslator implements PredicatesTranslator<Condition>
     private final Set<String> enumColumns;
     private final Set<String> jsonbColumns;
     private final Set<String> uuidColumns;
+    private final Set<String> timestamptzColumns;
 
     public JdbcPredicatesTranslator() {
         this(Collections.emptySet(), Collections.emptySet(), Collections.emptySet());
@@ -53,10 +55,15 @@ public class JdbcPredicatesTranslator implements PredicatesTranslator<Condition>
     }
 
     public JdbcPredicatesTranslator(Set<String> idFields, Set<String> enumColumns, Set<String> jsonbColumns, Set<String> uuidColumns) {
+        this(idFields, enumColumns, jsonbColumns, uuidColumns, Collections.emptySet());
+    }
+
+    public JdbcPredicatesTranslator(Set<String> idFields, Set<String> enumColumns, Set<String> jsonbColumns, Set<String> uuidColumns, Set<String> timestamptzColumns) {
         this.idFields = idFields == null ? Collections.emptySet() : idFields;
         this.enumColumns = enumColumns == null ? Collections.emptySet() : enumColumns;
         this.jsonbColumns = jsonbColumns == null ? Collections.emptySet() : jsonbColumns;
         this.uuidColumns = uuidColumns == null ? Collections.emptySet() : uuidColumns;
+        this.timestamptzColumns = timestamptzColumns == null ? Collections.emptySet() : timestamptzColumns;
     }
 
     /** A dotted key whose first segment is a JSONB column, e.g. {@code data.address.city}. */
@@ -102,6 +109,15 @@ public class JdbcPredicatesTranslator implements PredicatesTranslator<Condition>
         return value == null ? null : value.toString();
     }
 
+    private static Object coerceTemporal(Object value) {
+        if (value instanceof Collection) {
+            return ((Collection<?>) value).stream()
+                    .map(v -> v == null ? null : TimestamptzPropertySchema.toOffsetDateTime(v))
+                    .collect(Collectors.toList());
+        }
+        return value == null ? null : TimestamptzPropertySchema.toOffsetDateTime(value);
+    }
+
     @Override
     public Condition translate(PredicatesHolder predicatesHolder) {
         Set<Condition> predicateFilters = predicatesHolder.getPredicates().stream()
@@ -137,6 +153,7 @@ public class JdbcPredicatesTranslator implements PredicatesTranslator<Condition>
             return field.isNotNull();
         } else {
             if (idFields.contains(key) || isJsonbKey(key) || uuidColumns.contains(key)) value = stringifyValue(value);
+            else if (timestamptzColumns.contains(key)) value = coerceTemporal(value);
             return predicateToQuery(field, value, biPredicate);
         }
     }

--- a/unipop-jdbc/test/org/unipop/jdbc/timestamptz/JdbcTimestamptzTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/timestamptz/JdbcTimestamptzTest.java
@@ -1,0 +1,107 @@
+package org.unipop.jdbc.timestamptz;
+
+import org.apache.commons.configuration2.BaseConfiguration;
+import org.apache.commons.configuration2.Configuration;
+import org.apache.tinkerpop.gremlin.process.traversal.P;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.unipop.jdbc.suite.EmbeddedPostgresServer;
+import org.unipop.structure.UniGraph;
+
+import java.io.File;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Exercises a property backed by a PostgreSQL native timestamptz column (write + read + range
+ * query + update), with OffsetDateTime and ISO-string values, against embedded PostgreSQL.
+ */
+public class JdbcTimestamptzTest {
+
+    private static GraphTraversalSource g;
+    private static final OffsetDateTime T1 = OffsetDateTime.parse("2020-01-01T00:00:00Z");
+    private static final OffsetDateTime T2 = OffsetDateTime.parse("2021-06-15T12:00:00Z");
+    private static final OffsetDateTime T3 = OffsetDateTime.parse("2022-12-31T23:59:59Z");
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        EmbeddedPostgresServer.ensureStarted();
+        Class.forName("org.postgresql.Driver");
+        try (Connection c = DriverManager.getConnection(EmbeddedPostgresServer.URL, EmbeddedPostgresServer.USER, "");
+             Statement s = c.createStatement()) {
+            s.execute("DROP TABLE IF EXISTS tstz");
+            s.execute("CREATE TABLE tstz (id varchar(100) primary key, label varchar(100), name varchar(100), at timestamptz)");
+        }
+        String dir = new File(JdbcTimestamptzTest.class.getResource("/configuration/timestamptz/tstz.json").toURI()).getParent();
+        Configuration conf = new BaseConfiguration();
+        conf.setProperty(Graph.GRAPH, UniGraph.class.getName());
+        conf.setProperty("graphName", "tstztest");
+        conf.setProperty("providers", dir);
+        g = UniGraph.open(conf).traversal();
+    }
+
+    @Before
+    public void clean() throws Exception {
+        try (Connection c = DriverManager.getConnection(EmbeddedPostgresServer.URL, EmbeddedPostgresServer.USER, "");
+             Statement s = c.createStatement()) {
+            s.execute("TRUNCATE TABLE tstz");
+        }
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        if (g != null) g.close();
+    }
+
+    @Test
+    public void writeOffsetDateTimeReadBackAndRangeQuery() {
+        g.addV("thing").property(T.id, "1").property("name", "a").property("at", T1).next();
+        g.addV("thing").property(T.id, "2").property("name", "b").property("at", T2).next();
+        g.addV("thing").property(T.id, "3").property("name", "c").property("at", T3).next();
+
+        Object read = g.V("2").values("at").next();
+        assertTrue("values(at) must be a java.time.OffsetDateTime", read instanceof OffsetDateTime);
+        // Normalize both to UTC for comparison (JDBC driver may return with session timezone)
+        OffsetDateTime readUTC = ((OffsetDateTime) read).withOffsetSameInstant(ZoneOffset.UTC);
+        assertEquals(T2, readUTC);
+
+        assertEquals(1L, (long) g.V().has("at", T2).count().next());          // eq
+        assertEquals(1L, (long) g.V().has("at", P.gt(T2)).count().next());     // T3
+        assertEquals(1L, (long) g.V().has("at", P.lt(T2)).count().next());     // T1
+        assertEquals(2L, (long) g.V().has("at", P.between(T1, T3)).count().next()); // T1, T2 (half-open)
+    }
+
+    @Test
+    public void writeIsoStringReadBackAsOffsetDateTimeAndQueryByString() {
+        g.addV("thing").property(T.id, "4").property("name", "d").property("at", "2019-03-03T08:30:00Z").next();
+        Object read = g.V("4").values("at").next();
+        assertTrue(read instanceof OffsetDateTime);
+        // Normalize to UTC for comparison (JDBC driver may return with session timezone)
+        OffsetDateTime readUTC = ((OffsetDateTime) read).withOffsetSameInstant(ZoneOffset.UTC);
+        assertEquals(OffsetDateTime.parse("2019-03-03T08:30:00Z"), readUTC);
+        assertEquals(1L, (long) g.V().has("at", "2019-03-03T08:30:00Z").count().next()); // string predicate coerced
+    }
+
+    @Test
+    public void updateTimestamptz() {
+        g.addV("thing").property(T.id, "5").property("name", "e").property("at", T1).next();
+        g.V("5").property("at", T3).next();
+        Object read = g.V("5").values("at").next();
+        // Normalize to UTC for comparison (JDBC driver may return with session timezone)
+        OffsetDateTime readUTC = ((OffsetDateTime) read).withOffsetSameInstant(ZoneOffset.UTC);
+        assertEquals(T3, readUTC);
+        assertEquals(1L, (long) g.V().has("at", P.gt(T2)).count().next()); // now T3
+        assertEquals(0L, (long) g.V().has("at", P.lt(T2)).count().next());
+    }
+}

--- a/unipop-jdbc/test/org/unipop/jdbc/timestamptz/JdbcTimestamptzTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/timestamptz/JdbcTimestamptzTest.java
@@ -98,6 +98,7 @@ public class JdbcTimestamptzTest {
         g.addV("thing").property(T.id, "5").property("name", "e").property("at", T1).next();
         g.V("5").property("at", T3).next();
         Object read = g.V("5").values("at").next();
+        assertTrue(read instanceof OffsetDateTime);
         // Normalize to UTC for comparison (JDBC driver may return with session timezone)
         OffsetDateTime readUTC = ((OffsetDateTime) read).withOffsetSameInstant(ZoneOffset.UTC);
         assertEquals(T3, readUTC);

--- a/unipop-jdbc/test/org/unipop/jdbc/timestamptz/TimestamptzPropertySchemaTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/timestamptz/TimestamptzPropertySchemaTest.java
@@ -1,0 +1,112 @@
+package org.unipop.jdbc.timestamptz;
+
+import org.json.JSONObject;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.unipop.jdbc.schemas.property.TimestamptzPropertySchema;
+import org.unipop.schema.property.PropertySchema;
+import org.unipop.schema.property.type.DateType;
+import org.unipop.schema.property.type.DoubleType;
+import org.unipop.schema.property.type.FloatType;
+import org.unipop.schema.property.type.IntType;
+import org.unipop.schema.property.type.LongType;
+import org.unipop.schema.property.type.NumberType;
+import org.unipop.schema.property.type.TextType;
+import org.unipop.util.PropertyTypeFactory;
+
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class TimestamptzPropertySchemaTest {
+
+    private static final OffsetDateTime ODT = OffsetDateTime.parse("2020-08-02T00:00:00Z");
+
+    @BeforeClass
+    public static void initPropertyTypes() {
+        // FieldPropertySchema's constructor resolves its PropertyType from PropertyTypeFactory, which
+        // UniGraph populates at graph bootstrap. Replicate that init so the builder works standalone.
+        PropertyTypeFactory.init(Arrays.asList(
+                TextType.class.getCanonicalName(),
+                DateType.class.getCanonicalName(),
+                NumberType.class.getCanonicalName(),
+                DoubleType.class.getCanonicalName(),
+                FloatType.class.getCanonicalName(),
+                IntType.class.getCanonicalName(),
+                LongType.class.getCanonicalName()));
+    }
+
+    @Test public void coerceOffsetDateTimePassthrough() {
+        assertSame(ODT, TimestamptzPropertySchema.toOffsetDateTime(ODT));
+    }
+
+    @Test public void coerceInstant() {
+        assertEquals(ODT, TimestamptzPropertySchema.toOffsetDateTime(ODT.toInstant()));
+    }
+
+    @Test public void coerceUtilDate() {
+        assertEquals(ODT, TimestamptzPropertySchema.toOffsetDateTime(Date.from(ODT.toInstant())));
+    }
+
+    @Test public void coerceSqlTimestamp() {
+        assertEquals(ODT, TimestamptzPropertySchema.toOffsetDateTime(java.sql.Timestamp.from(ODT.toInstant())));
+    }
+
+    @Test public void coerceIsoStringWithOffset() {
+        assertEquals(ODT, TimestamptzPropertySchema.toOffsetDateTime("2020-08-02T00:00:00Z"));
+    }
+
+    @Test public void coerceIsoStringWithoutOffsetAssumedUtc() {
+        assertEquals(ODT, TimestamptzPropertySchema.toOffsetDateTime("2020-08-02T00:00:00"));
+    }
+
+    @Test(expected = IllegalArgumentException.class) public void coerceBareLongRejected() {
+        TimestamptzPropertySchema.toOffsetDateTime(1596326400000L);
+    }
+
+    @Test(expected = RuntimeException.class) public void coerceNonParseableStringThrows() {
+        TimestamptzPropertySchema.toOffsetDateTime("not-a-date");
+    }
+
+    @Test public void toFieldsCoercesStringToOffsetDateTime() {
+        TimestamptzPropertySchema s = new TimestamptzPropertySchema("at", "at", true);
+        Map<String, Object> f = s.toFields(Collections.singletonMap("at", "2020-08-02T00:00:00Z"));
+        assertEquals(ODT, f.get("at"));
+        assertTrue(f.get("at") instanceof OffsetDateTime);
+    }
+
+    @Test public void toPropertiesCoercesTimestampToOffsetDateTime() {
+        TimestamptzPropertySchema s = new TimestamptzPropertySchema("at", "at", true);
+        Map<String, Object> p = s.toProperties(Collections.singletonMap("at", java.sql.Timestamp.from(ODT.toInstant())));
+        assertEquals(ODT, p.get("at"));
+        assertTrue(p.get("at") instanceof OffsetDateTime);
+    }
+
+    @Test public void toFieldsEmptyWhenAbsentAndNullable() {
+        TimestamptzPropertySchema s = new TimestamptzPropertySchema("at", "at", true);
+        assertTrue(s.toFields(Collections.emptyMap()).isEmpty());
+    }
+
+    @Test public void builderMatches() {
+        PropertySchema s = new TimestamptzPropertySchema.Builder()
+                .build("at", new JSONObject().put("type", "timestamptz"), null);
+        assertNotNull(s);
+        assertTrue(s instanceof TimestamptzPropertySchema);
+        assertEquals("at", ((TimestamptzPropertySchema) s).getTimestamptzColumn());
+    }
+
+    @Test public void builderHonorsFieldAlias() {
+        PropertySchema s = new TimestamptzPropertySchema.Builder()
+                .build("at", new JSONObject().put("type", "timestamptz").put("field", "@at_col"), null);
+        assertEquals("at_col", ((TimestamptzPropertySchema) s).getTimestamptzColumn());
+    }
+
+    @Test public void builderIgnoresOtherTypesAndNonObjects() {
+        assertNull(new TimestamptzPropertySchema.Builder().build("x", new JSONObject().put("type", "uuid"), null));
+        assertNull(new TimestamptzPropertySchema.Builder().build("x", "plainstring", null));
+    }
+}

--- a/unipop-jdbc/test/org/unipop/jdbc/timestamptz/TimestamptzPropertySchemaTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/timestamptz/TimestamptzPropertySchemaTest.java
@@ -68,7 +68,7 @@ public class TimestamptzPropertySchemaTest {
         TimestamptzPropertySchema.toOffsetDateTime(1596326400000L);
     }
 
-    @Test(expected = RuntimeException.class) public void coerceNonParseableStringThrows() {
+    @Test(expected = IllegalArgumentException.class) public void coerceNonParseableStringThrows() {
         TimestamptzPropertySchema.toOffsetDateTime("not-a-date");
     }
 


### PR DESCRIPTION
## Summary

Adds a keyed `{"type":"timestamptz"}` property schema to the JDBC provider — full CRUD **and range queries** against native PostgreSQL `timestamptz` columns.

```json
"properties": {
  "at": { "type": "timestamptz" }
}
```

- **Write:** `property(k, datetime)` binds a native `timestamptz` (values coerced to `java.time.OffsetDateTime`).
- **Read:** `values(k)` returns an `OffsetDateTime`.
- **Query:** `has(k, eq/gt/gte/lt/lte/between/within …)` — compared **natively** so ordering is correct as real timestamps.
- **Accepted value forms** (write + predicate), coerced to `OffsetDateTime`: `OffsetDateTime`, `Instant`, `java.util.Date`/`java.sql.Timestamp`, and ISO-8601 `String` (zone-less → UTC). A bare epoch `Long` is rejected.

## Design (native temporal binding)

Unlike the enum/uuid schemas (which text-cast, `col::text = ?`), a `timestamptz` column is **not** text-cast — that would render in the session zone and break `gt`/`lt`/`between` ordering. Instead:

- New `TimestamptzColumnSchema` marker + `TimestamptzPropertySchema extends FieldPropertySchema`, registered via `providerBuilders()`. A shared `static OffsetDateTime toOffsetDateTime(Object)` does the coercion; `toFields`/`toProperties` coerce write/read.
- `JdbcPredicatesTranslator` gains a `timestamptzColumns` set + a **backward-compatible 5-arg constructor** (the 4-arg delegates with an empty set). `columnField` leaves these columns a plain field (native comparison); `extractCondition` **coerces** the predicate value to `OffsetDateTime` (scalar or collection) rather than stringifying.
- `AbstractRowSchema.getSearch` collects them via the marker.
- Independent of the legacy `Date`/`DateType` (`convertToSqlDate`, date-only) path.

**Read offset:** pgjdbc returns a `timestamptz` as an `OffsetDateTime` in the JVM's local offset (same instant). Per decision, the schema keeps that passthrough (values are the same instant); the integration test compares by instant via `withOffsetSameInstant(UTC)`.

## Tests

- `TimestamptzPropertySchemaTest` — 14 unit tests (each coercion form incl. offset-less-string→UTC, bare-Long/unparseable rejected, Builder matching).
- `JdbcTimestamptzTest` — 3 integration tests on a native `timestamptz` column (embedded PostgreSQL): write `OffsetDateTime` → read back → `eq`/`gt`/`lt`/`between` order correctly; write ISO string → read back; update.
- Both added to the surefire `<includes>`.

## Full-module regression (no regressions)

| Suite | Result |
|---|---|
| `JdbcFeatureTest` | 1884, **20 fail, 0 err** (unchanged baseline) |
| `JdbcStructureSuite` | 935, 30 fail, **16 err** (unchanged baseline) |
| `JdbcTimestamptzTest` / `TimestamptzPropertySchemaTest` | 3/0/0, 14/0/0 |
| uuid / enum / jsonb schema tests | all green |

## Review

Built via brainstorming → writing-plans → subagent-driven-development (implementer + task review per task, final opus whole-branch review): **READY TO MERGE**, 0 Critical / 0 Important. Final-review minors fixed in this branch (unparseable string now throws `IllegalArgumentException` per spec; added an `instanceof` guard in one test).

**Follow-up (pre-existing, not introduced here):** `handleConnectiveP` (`P.and`/`P.or`, and `P.between` which is an `AndP`) doesn't run the value coercion, so a **String** bound inside a connective predicate on a typed column (timestamptz/uuid/id/jsonb) isn't coerced — `OffsetDateTime` bounds work. Optionally, un-exclude TinkerPop's `@AllowDateTimePropertyValues` scenarios now that native timestamptz is supported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)