### PR TITLE
fix(core): register UniGraph strategies in GlobalCache (restore has() push-down under gremlin-server)

### DIFF
--- a/unipop-core/src/org/unipop/structure/UniGraph.java
+++ b/unipop-core/src/org/unipop/structure/UniGraph.java
@@ -143,7 +143,17 @@ public class UniGraph implements Graph {
 
     private void init(ControllerManager controllerManager, StrategyProvider strategyProvider) {
         this.strategies = strategyProvider.get();
-        //TraversalStrategies.GlobalCache.registerStrategies(UniGraph.class, strategies);
+        // Register the provider strategies under UniGraph in TinkerPop's GlobalCache so that a
+        // traversal source built the standard way — traversal().withEmbedded(graph) /
+        // new GraphTraversalSource(graph), which is how gremlin-server binds `g` — also gets them.
+        // Without this, only our traversal() override (below) carried the strategies, so a
+        // withEmbedded source ran with the default strategy set: has() predicates were never pushed
+        // to the source query (SELECT ... WHERE true) and were filtered in memory, where a typed
+        // value (uuid/timestamptz coerced to java.util.UUID/OffsetDateTime) never matches a String
+        // predicate. The provider strategies are stateless (they read the graph from the traversal
+        // at apply time), so a class-level registration is safe; traversal() still applies the
+        // per-instance/config strategies explicitly.
+        TraversalStrategies.GlobalCache.registerStrategies(UniGraph.class, strategies);
 
         this.controllerManager = controllerManager;
         this.queryControllers = controllerManager.getControllers(SearchQuery.SearchController.class);

--- a/unipop-jdbc/test/org/unipop/jdbc/uuid/JdbcUuidTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/uuid/JdbcUuidTest.java
@@ -2,6 +2,7 @@ package org.unipop.jdbc.uuid;
 
 import org.apache.commons.configuration2.BaseConfiguration;
 import org.apache.commons.configuration2.Configuration;
+import org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.structure.Graph;
@@ -88,5 +89,22 @@ public class JdbcUuidTest {
         assertEquals(U2, g.V("3").values("ref").next());
         assertEquals(0L, (long) g.V().has("ref", U1).count().next());
         assertEquals(1L, (long) g.V().has("ref", U2).count().next());
+    }
+
+    /**
+     * Regression for the reported deployment bug: a traversal source built the standard TinkerPop
+     * way ({@code traversal().withEmbedded(graph)}, as gremlin-server does) must also push the uuid
+     * predicate down to SQL. Before the fix, UniGraph did not register its provider strategies in
+     * {@code TraversalStrategies.GlobalCache}, so a withEmbedded source lacked them, evaluated
+     * has() in memory, and compared the coerced java.util.UUID value against the String predicate
+     * (never matching) -> 0.
+     */
+    @Test
+    public void withEmbeddedTraversalSourcePushesDownUuidStringFilter() {
+        g.addV("thing").property(T.id, "4").property("name", "d").property("ref", U2).next();
+        Graph graph = g.getGraph();
+        GraphTraversalSource gStd = AnonymousTraversalSource.traversal().withEmbedded(graph);
+        assertEquals(1L, (long) gStd.V().has("ref", U2.toString()).count().next());
+        assertEquals(1L, (long) gStd.V().has("ref", U2).count().next());
     }
 }


### PR DESCRIPTION
## Summary

Fixes a deployment bug where `g.V().has('<uuidCol>', '<uuid-string>').count()` returns **0** despite matching rows (reported on master `878d9af2`, gremlin-server + real PostgreSQL). Root-caused to strategy registration, not the uuid schema itself.

## Root cause

`UniGraph` attaches its provider optimization strategies (`UniGraphStepStrategy`, `UniGraphPredicatesStrategy`, …) **only** in its own `traversal()` override (`new GraphTraversalSource(this, strategies)`). The `TraversalStrategies.GlobalCache.registerStrategies(UniGraph.class, …)` call in `init()` was commented out (deliberately, in `3a4ad894`).

**gremlin-server does not call `uniGraph.traversal()`** — it binds `g` the standard way, `traversal().withEmbedded(graph)` / `new GraphTraversalSource(graph)`, which looks up strategies from the `GlobalCache` by graph class. For `UniGraph.class` that returns only the **default** set (no UniGraph strategies). With no `UniGraphPredicatesStrategy`, `has()` predicates are never folded into the source query → `SELECT … WHERE true` → everything is filtered **in memory**. String-valued props (enum) match by luck; `uuid`/`timestamptz` values (coerced to `java.util.UUID`/`OffsetDateTime`) never `.equals()` a `String` predicate → **0**.

Reproduced in `unipop-jdbc` (embedded PG), which is why the minimal unit tests passed — they use `UniGraph.open().traversal()` (24 strategies, push-down works), whereas `traversal().withEmbedded(graph)` has 16 (default only) and returns 0. Registering the strategies in the GlobalCache brings `withEmbedded` back to 24 and the filter to 1.

## Fix

Register the provider strategies in `TraversalStrategies.GlobalCache` for `UniGraph.class` (re-enable `UniGraph.java:146`), so **any** traversal source — including gremlin-server's — gets push-down. The strategies are stateless (they read the graph from the traversal at apply time), so a class-level registration is safe; `traversal()` still applies per-instance/config strategies explicitly.

This restores index-friendly SQL push-down for **all** backends (jdbc/elastic/rest) under gremlin-server, and makes uuid/timestamptz filtering work (emits `col::text = ?` / native temporal comparison).

## Tests

- New regression `JdbcUuidTest.withEmbeddedTraversalSourcePushesDownUuidStringFilter`: builds a `withEmbedded` source and asserts `has("ref", uuid.toString()).count() == 1` (and by `UUID`). Fails without the fix (0), passes with it.
- Full jdbc module unchanged: `JdbcFeatureTest` **20 fail / 0 err**, `JdbcStructureSuite` **30 fail / 16 err** (both baselines), all schema tests green (`JdbcUuidTest` 4/4).

## Notes
- The GlobalCache registration was originally removed to allow per-configuration strategy providers without a global. That still works: a custom `strategyProvider` applies via `uniGraph.traversal()`; the GlobalCache entry is the standard set used by `withEmbedded` sources.
- Deployment consumers: after merge, bump the `UNIPOP_SHA` pin and rebuild. A residual in-memory type-mismatch remains only for genuinely non-foldable traversals (e.g. lambda-`filter()` before `has()`), which is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)