### PR TITLE
fix(core): push adjacency vertex-property has() into SQL fetch (enables PartitionStrategy scoping)

### DIFF
--- a/unipop-core/src/org/unipop/process/edge/EdgeStepsStrategy.java
+++ b/unipop-core/src/org/unipop/process/edge/EdgeStepsStrategy.java
@@ -7,6 +7,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.EdgeVertexStep;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.unipop.process.predicate.PredicatesUtil;
 import org.unipop.structure.UniGraph;
 
 /**
@@ -26,12 +27,14 @@ public class EdgeStepsStrategy extends AbstractTraversalStrategy<TraversalStrate
             UniGraphEdgeOtherVertexStep uniGraphEdgeOtherVertexStep = new UniGraphEdgeOtherVertexStep(traversal, uniGraph, uniGraph.getControllerManager());
             edgeOtherVertexStep.getLabels().forEach(uniGraphEdgeOtherVertexStep::addLabel);
             TraversalHelper.replaceStep(edgeOtherVertexStep, uniGraphEdgeOtherVertexStep, traversal);
+            uniGraphEdgeOtherVertexStep.setVertexPredicates(PredicatesUtil.collectVertexPredicates(uniGraphEdgeOtherVertexStep, traversal));
         });
 
         TraversalHelper.getStepsOfClass(EdgeVertexStep.class, traversal).forEach(edgeVertexStep -> {
             UniGraphEdgeVertexStep uniGraphEdgeVertexStep = new UniGraphEdgeVertexStep(traversal, edgeVertexStep.getDirection(), uniGraph, uniGraph.getControllerManager());
             edgeVertexStep.getLabels().forEach(uniGraphEdgeVertexStep::addLabel);
             TraversalHelper.replaceStep(edgeVertexStep, uniGraphEdgeVertexStep, traversal);
+            uniGraphEdgeVertexStep.setVertexPredicates(PredicatesUtil.collectVertexPredicates(uniGraphEdgeVertexStep, traversal));
         });
     }
 }

--- a/unipop-core/src/org/unipop/process/edge/UniGraphEdgeOtherVertexStep.java
+++ b/unipop-core/src/org/unipop/process/edge/UniGraphEdgeOtherVertexStep.java
@@ -15,6 +15,8 @@ import org.unipop.process.UniPredicatesStep;
 import org.unipop.process.order.Orderable;
 import org.unipop.query.StepDescriptor;
 import org.unipop.query.controller.ControllerManager;
+import org.unipop.query.predicates.PredicatesHolder;
+import org.unipop.query.predicates.PredicatesHolderFactory;
 import org.unipop.query.search.DeferredVertexQuery;
 import org.unipop.schema.reference.DeferredVertex;
 import org.unipop.structure.UniGraph;
@@ -26,6 +28,11 @@ public class UniGraphEdgeOtherVertexStep extends UniPredicatesStep<Edge, Vertex>
     private List<DeferredVertexQuery.DeferredVertexController> deferredVertexControllers;
     private StepDescriptor stepDescriptor;
     private List<Pair<String, Order>> orders;
+    private PredicatesHolder vertexPredicates = PredicatesHolderFactory.empty();
+
+    public void setVertexPredicates(PredicatesHolder vertexPredicates) {
+        this.vertexPredicates = vertexPredicates == null ? PredicatesHolderFactory.empty() : vertexPredicates;
+    }
 
     public UniGraphEdgeOtherVertexStep(Traversal.Admin traversal, UniGraph graph, ControllerManager controllerManager) {
         super(traversal, graph);
@@ -46,19 +53,24 @@ public class UniGraphEdgeOtherVertexStep extends UniPredicatesStep<Edge, Vertex>
             }
         });
 
-        if (propertyKeys == null || propertyKeys.size() > 0){
+        boolean fetch = this.vertexPredicates.notEmpty() || propertyKeys == null || propertyKeys.size() > 1;
+        if (fetch) {
             List<DeferredVertex> v = vertices.stream().map(Attachable::get)
                     .filter(vertex -> vertex instanceof DeferredVertex)
                     .map(vertex -> ((DeferredVertex) vertex))
                     .filter(DeferredVertex::isDeferred)
                     .collect(Collectors.toList());
             if (v.size() > 0) {
-                DeferredVertexQuery query = new DeferredVertexQuery(v, propertyKeys, orders, stepDescriptor, traversal);
+                Set<String> fetchKeys = (this.vertexPredicates.notEmpty() && propertyKeys != null && propertyKeys.isEmpty())
+                        ? null : propertyKeys;
+                DeferredVertexQuery query = new DeferredVertexQuery(v, this.vertexPredicates, fetchKeys, orders, this.stepDescriptor, traversal);
                 deferredVertexControllers.forEach(deferredVertexController -> deferredVertexController.fetchProperties(query));
             }
         }
-
-        return vertices.iterator();
+        if (!this.vertexPredicates.notEmpty()) return vertices.iterator();
+        return vertices.stream()
+                .filter(t -> { Vertex x = t.get(); return !(x instanceof DeferredVertex) || !((DeferredVertex) x).isDeferred(); })
+                .iterator();
     }
 
     @Override

--- a/unipop-core/src/org/unipop/process/edge/UniGraphEdgeOtherVertexStep.java
+++ b/unipop-core/src/org/unipop/process/edge/UniGraphEdgeOtherVertexStep.java
@@ -68,8 +68,15 @@ public class UniGraphEdgeOtherVertexStep extends UniPredicatesStep<Edge, Vertex>
             }
         }
         if (!this.vertexPredicates.notEmpty()) return vertices.iterator();
+        // See UniGraphVertexStep: one DeferredVertex per incident edge means a matched id may have
+        // several instances but the fetch un-defers only one. Keep every traverser whose vertex id
+        // matched, dropping only unmatched ids.
+        Set<Object> matchedIds = vertices.stream().map(Attachable::get)
+                .filter(x -> x instanceof DeferredVertex && !((DeferredVertex) x).isDeferred())
+                .map(x -> ((DeferredVertex) x).id())
+                .collect(Collectors.toSet());
         return vertices.stream()
-                .filter(t -> { Vertex x = t.get(); return !(x instanceof DeferredVertex) || !((DeferredVertex) x).isDeferred(); })
+                .filter(t -> { Vertex x = t.get(); return !(x instanceof DeferredVertex) || matchedIds.contains(((DeferredVertex) x).id()); })
                 .iterator();
     }
 

--- a/unipop-core/src/org/unipop/process/edge/UniGraphEdgeVertexStep.java
+++ b/unipop-core/src/org/unipop/process/edge/UniGraphEdgeVertexStep.java
@@ -65,8 +65,15 @@ public class UniGraphEdgeVertexStep extends UniPredicatesStep<Edge, Vertex> impl
             }
         }
         if (!this.vertexPredicates.notEmpty()) return vertices.iterator();
+        // See UniGraphVertexStep: one DeferredVertex per incident edge means a matched id may have
+        // several instances but the fetch un-defers only one. Keep every traverser whose vertex id
+        // matched, dropping only unmatched ids.
+        Set<Object> matchedIds = vertices.stream().map(Attachable::get)
+                .filter(x -> x instanceof DeferredVertex && !((DeferredVertex) x).isDeferred())
+                .map(x -> ((DeferredVertex) x).id())
+                .collect(Collectors.toSet());
         return vertices.stream()
-                .filter(t -> { Vertex x = t.get(); return !(x instanceof DeferredVertex) || !((DeferredVertex) x).isDeferred(); })
+                .filter(t -> { Vertex x = t.get(); return !(x instanceof DeferredVertex) || matchedIds.contains(((DeferredVertex) x).id()); })
                 .iterator();
     }
 

--- a/unipop-core/src/org/unipop/process/edge/UniGraphEdgeVertexStep.java
+++ b/unipop-core/src/org/unipop/process/edge/UniGraphEdgeVertexStep.java
@@ -16,6 +16,8 @@ import org.unipop.process.UniPredicatesStep;
 import org.unipop.process.order.Orderable;
 import org.unipop.query.StepDescriptor;
 import org.unipop.query.controller.ControllerManager;
+import org.unipop.query.predicates.PredicatesHolder;
+import org.unipop.query.predicates.PredicatesHolderFactory;
 import org.unipop.query.search.DeferredVertexQuery;
 import org.unipop.schema.reference.DeferredVertex;
 import org.unipop.structure.UniGraph;
@@ -29,6 +31,11 @@ public class UniGraphEdgeVertexStep extends UniPredicatesStep<Edge, Vertex> impl
     private List<DeferredVertexQuery.DeferredVertexController> deferredVertexControllers;
     private StepDescriptor stepDescriptor;
     private List<Pair<String, Order>> orders;
+    private PredicatesHolder vertexPredicates = PredicatesHolderFactory.empty();
+
+    public void setVertexPredicates(PredicatesHolder vertexPredicates) {
+        this.vertexPredicates = vertexPredicates == null ? PredicatesHolderFactory.empty() : vertexPredicates;
+    }
 
     public UniGraphEdgeVertexStep(Traversal.Admin traversal, Direction direction, UniGraph graph, ControllerManager controllerManager) {
         super(traversal, graph);
@@ -40,23 +47,27 @@ public class UniGraphEdgeVertexStep extends UniPredicatesStep<Edge, Vertex> impl
     @Override
     protected Iterator<Traverser.Admin<Vertex>> process(List<Traverser.Admin<Edge>> traversers) {
         List<Traverser.Admin<Vertex>> vertices = new ArrayList<>();
-        traversers.forEach(travrser -> {
-            travrser.get().vertices(direction).forEachRemaining(vertex -> vertices.add(travrser.split(vertex, this)));
-        });
+        traversers.forEach(travrser ->
+                travrser.get().vertices(direction).forEachRemaining(vertex -> vertices.add(travrser.split(vertex, this))));
 
-        if (propertyKeys == null || propertyKeys.size() > 1){
+        boolean fetch = this.vertexPredicates.notEmpty() || propertyKeys == null || propertyKeys.size() > 1;
+        if (fetch) {
             List<DeferredVertex> v = vertices.stream().map(Attachable::get)
                     .filter(vertex -> vertex instanceof DeferredVertex)
                     .map(vertex -> ((DeferredVertex) vertex))
                     .filter(DeferredVertex::isDeferred)
                     .collect(Collectors.toList());
-            if(v.size() > 0) {
-                DeferredVertexQuery query = new DeferredVertexQuery(v, propertyKeys, orders, this.stepDescriptor, traversal);
+            if (v.size() > 0) {
+                Set<String> fetchKeys = (this.vertexPredicates.notEmpty() && propertyKeys != null && propertyKeys.isEmpty())
+                        ? null : propertyKeys;
+                DeferredVertexQuery query = new DeferredVertexQuery(v, this.vertexPredicates, fetchKeys, orders, this.stepDescriptor, traversal);
                 deferredVertexControllers.forEach(deferredVertexController -> deferredVertexController.fetchProperties(query));
             }
         }
-
-        return vertices.iterator();
+        if (!this.vertexPredicates.notEmpty()) return vertices.iterator();
+        return vertices.stream()
+                .filter(t -> { Vertex x = t.get(); return !(x instanceof DeferredVertex) || !((DeferredVertex) x).isDeferred(); })
+                .iterator();
     }
 
     @Override

--- a/unipop-core/src/org/unipop/process/predicate/PredicatesUtil.java
+++ b/unipop-core/src/org/unipop/process/predicate/PredicatesUtil.java
@@ -4,10 +4,13 @@ import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.step.HasContainerHolder;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeGlobalStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.NoOpBarrierStep;
 import org.unipop.query.predicates.PredicatesHolder;
 import org.unipop.query.predicates.PredicatesHolderFactory;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 public class PredicatesUtil {
@@ -83,11 +86,18 @@ public class PredicatesUtil {
      * removing them from the traversal, so they can be pushed into the produced-vertex fetch. Unlike
      * {@link #collectPredicates}, the result is returned (not added to the step as edge predicates),
      * because these filter the produced VERTEX, not the adjacency edge query. Stops at the first
-     * non-HasContainerHolder step.
+     * non-HasContainerHolder step (transparently skipping NoOpBarrierStep inserted by LazyBarrierStrategy).
      */
     public static PredicatesHolder collectVertexPredicates(Step<?, ?> step, Traversal.Admin traversal) {
         Set<PredicatesHolder> predicates = new HashSet<>();
+        // Collect any NoOpBarrierStep instances to remove once we know there are has() steps to fold.
+        List<Step<?, ?>> barrierStepsToRemove = new ArrayList<>();
         Step<?, ?> nextStep = step.getNextStep();
+        // Skip transparent NoOpBarrierStep(s) inserted by LazyBarrierStrategy before looking for has() steps.
+        while (nextStep instanceof NoOpBarrierStep) {
+            barrierStepsToRemove.add(nextStep);
+            nextStep = nextStep.getNextStep();
+        }
         while (nextStep instanceof HasContainerHolder) {
             HasContainerHolder<?, ?> hasContainerHolder = (HasContainerHolder<?, ?>) nextStep;
             hasContainerHolder.getHasContainers().stream().map(PredicatesHolderFactory::predicate).forEach(predicates::add);
@@ -97,6 +107,12 @@ public class PredicatesUtil {
             nextStep = nextStep.getNextStep();
             traversal.removeStep(toRemove);
             if (hasLabels) break;
+        }
+        // If we found and consumed has() steps, remove any barrier steps we skipped over — they are
+        // now either between the vertex step and non-has steps (identity passthrough, not needed) or
+        // are skipped over correctly. Removing them avoids double-buffering.
+        if (!predicates.isEmpty()) {
+            barrierStepsToRemove.forEach(traversal::removeStep);
         }
         return PredicatesHolderFactory.and(predicates);
     }

--- a/unipop-core/src/org/unipop/process/predicate/PredicatesUtil.java
+++ b/unipop-core/src/org/unipop/process/predicate/PredicatesUtil.java
@@ -77,4 +77,27 @@ public class PredicatesUtil {
         step.getLabels().forEach(originalStep::addLabel);
         return step.getLabels().size() > 0;
     }
+
+    /**
+     * Fold the has()-steps that immediately follow a vertex-producing step into a predicates holder,
+     * removing them from the traversal, so they can be pushed into the produced-vertex fetch. Unlike
+     * {@link #collectPredicates}, the result is returned (not added to the step as edge predicates),
+     * because these filter the produced VERTEX, not the adjacency edge query. Stops at the first
+     * non-HasContainerHolder step.
+     */
+    public static PredicatesHolder collectVertexPredicates(Step<?, ?> step, Traversal.Admin traversal) {
+        Set<PredicatesHolder> predicates = new HashSet<>();
+        Step<?, ?> nextStep = step.getNextStep();
+        while (nextStep instanceof HasContainerHolder) {
+            HasContainerHolder<?, ?> hasContainerHolder = (HasContainerHolder<?, ?>) nextStep;
+            hasContainerHolder.getHasContainers().stream().map(PredicatesHolderFactory::predicate).forEach(predicates::add);
+            Step<?, ?> toRemove = nextStep;
+            boolean hasLabels = !nextStep.getLabels().isEmpty();
+            nextStep.getLabels().forEach(step::addLabel);
+            nextStep = nextStep.getNextStep();
+            traversal.removeStep(toRemove);
+            if (hasLabels) break;
+        }
+        return PredicatesHolderFactory.and(predicates);
+    }
 }

--- a/unipop-core/src/org/unipop/process/vertex/UniGraphVertexStep.java
+++ b/unipop-core/src/org/unipop/process/vertex/UniGraphVertexStep.java
@@ -40,6 +40,7 @@ public class UniGraphVertexStep<E extends Element> extends UniPredicatesStep<Ver
     private String[] edgeLabels = new String[0];
     private int limit;
     private PredicatesHolder predicates = PredicatesHolderFactory.empty();
+    private PredicatesHolder vertexPredicates = PredicatesHolderFactory.empty();
     private StepDescriptor stepDescriptor;
     private List<SearchVertexQuery.SearchVertexController> controllers;
     private List<DeferredVertexQuery.DeferredVertexController> deferredVertexControllers;
@@ -85,9 +86,10 @@ public class UniGraphVertexStep<E extends Element> extends UniPredicatesStep<Ver
         Iterator<Traverser.Admin<E>> traversersIterator = controllers.stream().<Iterator<Edge>>map(controller -> controller.search(vertexQuery))
                 .<Edge>flatMap(ConversionUtils::asStream)
                 .<Traverser.Admin<E>>flatMap(edge -> toTraversers(edge, idToTraverser)).iterator();
-        if (!this.returnsVertex || (propertyKeys != null && propertyKeys.size() == 0))
-            return traversersIterator;
-        return getTraversersWithProperties(traversersIterator);
+        boolean noProps = propertyKeys != null && propertyKeys.size() == 0;
+        if (this.returnsVertex && (this.vertexPredicates.notEmpty() || !noProps))
+            return getTraversersWithProperties(traversersIterator);
+        return traversersIterator;
     }
 
     private Iterator<Traverser.Admin<E>> getTraversersWithProperties(Iterator<Traverser.Admin<E>> traversers) {
@@ -98,10 +100,20 @@ public class UniGraphVertexStep<E extends Element> extends UniPredicatesStep<Ver
                 .filter(DeferredVertex::isDeferred)
                 .collect(Collectors.toList());
         if (deferredVertices.size() > 0) {
-            DeferredVertexQuery query = new DeferredVertexQuery(deferredVertices, propertyKeys, orders, this.stepDescriptor, traversal);
+            // When filtering with no requested properties (e.g. out().has(k,v).count()), pass null
+            // propertyKeys so the fetch still SELECTs the row (and applies the WHERE) rather than an
+            // empty projection.
+            Set<String> fetchKeys = (this.vertexPredicates.notEmpty() && propertyKeys != null && propertyKeys.isEmpty())
+                    ? null : propertyKeys;
+            DeferredVertexQuery query = new DeferredVertexQuery(deferredVertices, this.vertexPredicates, fetchKeys, orders, this.stepDescriptor, traversal);
             deferredVertexControllers.stream().forEach(controller -> controller.fetchProperties(query));
         }
-        return copyTraversers.iterator();
+        if (!this.vertexPredicates.notEmpty()) return copyTraversers.iterator();
+        // Vertex predicates were pushed: a produced vertex that did not match was not returned by the
+        // fetch, so it is still deferred -> drop those traversers.
+        return copyTraversers.stream()
+                .filter(t -> { E e = t.get(); return !(e instanceof DeferredVertex) || !((DeferredVertex) e).isDeferred(); })
+                .iterator();
     }
 
     private Stream<Traverser.Admin<E>> toTraversers(Edge edge, Map<Object, List<Traverser<Vertex>>> traversers) {
@@ -145,6 +157,10 @@ public class UniGraphVertexStep<E extends Element> extends UniPredicatesStep<Ver
     @Override
     public PredicatesHolder getPredicates() {
         return predicates;
+    }
+
+    public void setVertexPredicates(PredicatesHolder vertexPredicates) {
+        this.vertexPredicates = vertexPredicates == null ? PredicatesHolderFactory.empty() : vertexPredicates;
     }
 
     @Override

--- a/unipop-core/src/org/unipop/process/vertex/UniGraphVertexStep.java
+++ b/unipop-core/src/org/unipop/process/vertex/UniGraphVertexStep.java
@@ -109,10 +109,17 @@ public class UniGraphVertexStep<E extends Element> extends UniPredicatesStep<Ver
             deferredVertexControllers.stream().forEach(controller -> controller.fetchProperties(query));
         }
         if (!this.vertexPredicates.notEmpty()) return copyTraversers.iterator();
-        // Vertex predicates were pushed: a produced vertex that did not match was not returned by the
-        // fetch, so it is still deferred -> drop those traversers.
+        // A vertex step emits one DeferredVertex object per incident edge, so a single id can appear as
+        // several instances; the filtered fetch dedups by id and un-defers only one instance per matched
+        // id. Keep every traverser whose vertex id matched (any produced instance now non-deferred), so
+        // duplicate-id traversers survive -- matching the un-filtered hydrate path -- dropping only
+        // unmatched ids.
+        Set<Object> matchedIds = copyTraversers.stream().map(Attachable::get)
+                .filter(e -> e instanceof DeferredVertex && !((DeferredVertex) e).isDeferred())
+                .map(e -> ((DeferredVertex) e).id())
+                .collect(Collectors.toSet());
         return copyTraversers.stream()
-                .filter(t -> { E e = t.get(); return !(e instanceof DeferredVertex) || !((DeferredVertex) e).isDeferred(); })
+                .filter(t -> { E e = t.get(); return !(e instanceof DeferredVertex) || matchedIds.contains(((DeferredVertex) e).id()); })
                 .iterator();
     }
 

--- a/unipop-core/src/org/unipop/process/vertex/UniGraphVertexStepStrategy.java
+++ b/unipop-core/src/org/unipop/process/vertex/UniGraphVertexStepStrategy.java
@@ -31,6 +31,7 @@ public class UniGraphVertexStepStrategy extends AbstractTraversalStrategy<Traver
                 UniGraphVertexStep uniGraphVertexStep = new UniGraphVertexStep<>(vertexStep, uniGraph, uniGraph.getControllerManager());
                 TraversalHelper.replaceStep(vertexStep, uniGraphVertexStep, traversal);
                 if (vertexStep.returnsEdge()) PredicatesUtil.collectPredicates(uniGraphVertexStep, traversal);
+                else uniGraphVertexStep.setVertexPredicates(PredicatesUtil.collectVertexPredicates(uniGraphVertexStep, traversal));
             }
             else{
                 TraversalHelper.getStepsOfAssignableClass(TraversalParent.class, traversal).forEach(traversalParent -> {
@@ -39,6 +40,7 @@ public class UniGraphVertexStepStrategy extends AbstractTraversalStrategy<Traver
                             UniGraphVertexStep uniGraphVertexStep = new UniGraphVertexStep<>(vertexStep, uniGraph, uniGraph.getControllerManager());
                             TraversalHelper.replaceStep(vertexStep, uniGraphVertexStep, child);
                             if (vertexStep.returnsEdge()) PredicatesUtil.collectPredicates(uniGraphVertexStep, child);
+                            else uniGraphVertexStep.setVertexPredicates(PredicatesUtil.collectVertexPredicates(uniGraphVertexStep, child));
                         }
                     });
                     traversalParent.getGlobalChildren().forEach(child -> {
@@ -46,6 +48,7 @@ public class UniGraphVertexStepStrategy extends AbstractTraversalStrategy<Traver
                             UniGraphVertexStep uniGraphVertexStep = new UniGraphVertexStep<>(vertexStep, uniGraph, uniGraph.getControllerManager());
                             TraversalHelper.replaceStep(vertexStep, uniGraphVertexStep, child);
                             if (vertexStep.returnsEdge()) PredicatesUtil.collectPredicates(uniGraphVertexStep, child);
+                            else uniGraphVertexStep.setVertexPredicates(PredicatesUtil.collectVertexPredicates(uniGraphVertexStep, child));
                         }
                         else if (TraversalHelper.hasStepOfAssignableClass(TraversalParent.class, child)){
                             TraversalHelper.getStepsOfAssignableClass(TraversalParent.class, child).forEach(traversalParent1 -> {
@@ -54,6 +57,7 @@ public class UniGraphVertexStepStrategy extends AbstractTraversalStrategy<Traver
                                         UniGraphVertexStep uniGraphVertexStep = new UniGraphVertexStep<>(vertexStep, uniGraph, uniGraph.getControllerManager());
                                         TraversalHelper.replaceStep(vertexStep, uniGraphVertexStep, child1);
                                         if (vertexStep.returnsEdge()) PredicatesUtil.collectPredicates(uniGraphVertexStep, child1);
+                                        else uniGraphVertexStep.setVertexPredicates(PredicatesUtil.collectVertexPredicates(uniGraphVertexStep, child1));
                                     }
                                 });
                                 traversalParent.getGlobalChildren().forEach(child1 -> {
@@ -61,6 +65,7 @@ public class UniGraphVertexStepStrategy extends AbstractTraversalStrategy<Traver
                                         UniGraphVertexStep uniGraphVertexStep = new UniGraphVertexStep<>(vertexStep, uniGraph, uniGraph.getControllerManager());
                                         TraversalHelper.replaceStep(vertexStep, uniGraphVertexStep, child1);
                                         if (vertexStep.returnsEdge()) PredicatesUtil.collectPredicates(uniGraphVertexStep, child1);
+                                        else uniGraphVertexStep.setVertexPredicates(PredicatesUtil.collectVertexPredicates(uniGraphVertexStep, child1));
                                     }
                                 });
                             });

--- a/unipop-core/src/org/unipop/query/search/DeferredVertexQuery.java
+++ b/unipop-core/src/org/unipop/query/search/DeferredVertexQuery.java
@@ -6,6 +6,7 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.javatuples.Pair;
 import org.unipop.query.StepDescriptor;
 import org.unipop.query.controller.UniQueryController;
+import org.unipop.query.predicates.PredicatesHolder;
 import org.unipop.query.predicates.PredicatesHolderFactory;
 import org.unipop.schema.reference.DeferredVertex;
 
@@ -16,7 +17,11 @@ public class DeferredVertexQuery extends SearchQuery<Vertex> {
     private List<DeferredVertex> vertices;
 
     public DeferredVertexQuery(List<DeferredVertex> vertices, Set<String> propertyKeys, List<Pair<String, Order>> orders, StepDescriptor stepDescriptor, Traversal traversal) {
-        super(Vertex.class, PredicatesHolderFactory.empty(), -1, propertyKeys, orders, stepDescriptor, traversal);
+        this(vertices, PredicatesHolderFactory.empty(), propertyKeys, orders, stepDescriptor, traversal);
+    }
+
+    public DeferredVertexQuery(List<DeferredVertex> vertices, PredicatesHolder predicates, Set<String> propertyKeys, List<Pair<String, Order>> orders, StepDescriptor stepDescriptor, Traversal traversal) {
+        super(Vertex.class, predicates, -1, propertyKeys, orders, stepDescriptor, traversal);
         this.vertices = vertices;
     }
 

--- a/unipop-jdbc/pom.xml
+++ b/unipop-jdbc/pom.xml
@@ -134,6 +134,7 @@
                         <include>**/JdbcUuidTest.java</include>
                         <include>**/TimestamptzPropertySchemaTest.java</include>
                         <include>**/JdbcTimestamptzTest.java</include>
+                        <include>**/JdbcAdjacencyFilterTest.java</include>
                     </includes>
                     <environmentVariables>
                         <conf>basic</conf>

--- a/unipop-jdbc/test-resources/configuration/adjfilter/graph.json
+++ b/unipop-jdbc/test-resources/configuration/adjfilter/graph.json
@@ -1,0 +1,27 @@
+{
+  "class": "org.unipop.jdbc.JdbcSourceProvider",
+  "driver": "org.postgresql.Driver",
+  "address": ["jdbc:postgresql://localhost:54329/postgres"],
+  "user": "postgres",
+  "sqlDialect": "POSTGRES",
+  "vertices": [
+    {
+      "table": "adjnodes",
+      "id": "@id",
+      "label": "@label",
+      "properties": { "org_id": { "type": "uuid" } },
+      "dynamicProperties": false
+    }
+  ],
+  "edges": [
+    {
+      "table": "adjedges",
+      "id": "@id",
+      "label": "@label",
+      "properties": { "org_id": { "type": "uuid" } },
+      "dynamicProperties": false,
+      "outVertex": { "ref": "true", "id": "@src_id", "label": "@src_label", "properties": {} },
+      "inVertex":  { "ref": "true", "id": "@dst_id", "label": "@dst_label", "properties": {} }
+    }
+  ]
+}

--- a/unipop-jdbc/test/org/unipop/jdbc/adjacency/JdbcAdjacencyFilterTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/adjacency/JdbcAdjacencyFilterTest.java
@@ -39,6 +39,8 @@ public class JdbcAdjacencyFilterTest {
                     "src_id varchar(100), src_label varchar(100), dst_id varchar(100), dst_label varchar(100), org_id uuid)");
             s.execute("INSERT INTO adjnodes VALUES ('a','n','" + U + "'), ('b','n','" + U + "')");
             s.execute("INSERT INTO adjedges VALUES ('e1','E','a','n','b','n','" + U + "')");
+            s.execute("INSERT INTO adjnodes VALUES ('c','n','" + U + "')");
+            s.execute("INSERT INTO adjedges VALUES ('e2','E','b','n','c','n','" + U + "')");
         }
         String dir = new File(JdbcAdjacencyFilterTest.class.getResource("/configuration/adjfilter/graph.json").toURI()).getParent();
         Configuration conf = new BaseConfiguration();
@@ -72,7 +74,7 @@ public class JdbcAdjacencyFilterTest {
 
     @Test
     public void hasAfterOutVFiltersByString() {
-        assertEquals(1L, (long) g.E().outV().has("org_id", U.toString()).count().next());
+        assertEquals(2L, (long) g.E().outV().has("org_id", U.toString()).count().next());
         assertEquals(0L, (long) g.E().outV().has("org_id", OTHER.toString()).count().next());
     }
 
@@ -80,9 +82,19 @@ public class JdbcAdjacencyFilterTest {
     public void partitionStrategyScopesOutV() {
         GraphTraversalSource in = g.withStrategies(
                 PartitionStrategy.build().partitionKey("org_id").readPartitions(U.toString()).create());
-        assertEquals(1L, (long) in.E().outV().count().next());
+        assertEquals(2L, (long) in.E().outV().count().next());
         GraphTraversalSource out = g.withStrategies(
                 PartitionStrategy.build().partitionKey("org_id").readPartitions(OTHER.toString()).create());
         assertEquals(0L, (long) out.E().outV().count().next());
+    }
+
+    @Test
+    public void partitionStrategyScopesMultiHop() {
+        GraphTraversalSource in = g.withStrategies(
+                PartitionStrategy.build().partitionKey("org_id").readPartitions(U.toString()).create());
+        assertEquals(1L, (long) in.V("a").out("E").out("E").count().next());   // a->b->c
+        GraphTraversalSource out = g.withStrategies(
+                PartitionStrategy.build().partitionKey("org_id").readPartitions(OTHER.toString()).create());
+        assertEquals(0L, (long) out.V("a").out("E").out("E").count().next());
     }
 }

--- a/unipop-jdbc/test/org/unipop/jdbc/adjacency/JdbcAdjacencyFilterTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/adjacency/JdbcAdjacencyFilterTest.java
@@ -1,0 +1,72 @@
+package org.unipop.jdbc.adjacency;
+
+import org.apache.commons.configuration2.BaseConfiguration;
+import org.apache.commons.configuration2.Configuration;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.PartitionStrategy;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.unipop.jdbc.suite.EmbeddedPostgresServer;
+import org.unipop.structure.UniGraph;
+
+import java.io.File;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+
+/** Vertex-property has() after out()/outV() must filter (push down), enabling PartitionStrategy. */
+public class JdbcAdjacencyFilterTest {
+
+    private static GraphTraversalSource g;
+    private static final UUID U = UUID.fromString("019ef96c-f001-7c4f-82cc-b2413065f8c1");
+    private static final UUID OTHER = UUID.fromString("11111111-1111-4111-8111-111111111111");
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        EmbeddedPostgresServer.ensureStarted();
+        Class.forName("org.postgresql.Driver");
+        try (Connection c = DriverManager.getConnection(EmbeddedPostgresServer.URL, EmbeddedPostgresServer.USER, "");
+             Statement s = c.createStatement()) {
+            s.execute("DROP TABLE IF EXISTS adjnodes");
+            s.execute("DROP TABLE IF EXISTS adjedges");
+            s.execute("CREATE TABLE adjnodes (id varchar(100) primary key, label varchar(100), org_id uuid)");
+            s.execute("CREATE TABLE adjedges (id varchar(100) primary key, label varchar(100), " +
+                    "src_id varchar(100), src_label varchar(100), dst_id varchar(100), dst_label varchar(100), org_id uuid)");
+            s.execute("INSERT INTO adjnodes VALUES ('a','n','" + U + "'), ('b','n','" + U + "')");
+            s.execute("INSERT INTO adjedges VALUES ('e1','E','a','n','b','n','" + U + "')");
+        }
+        String dir = new File(JdbcAdjacencyFilterTest.class.getResource("/configuration/adjfilter/graph.json").toURI()).getParent();
+        Configuration conf = new BaseConfiguration();
+        conf.setProperty(Graph.GRAPH, UniGraph.class.getName());
+        conf.setProperty("graphName", "adjfilter");
+        conf.setProperty("providers", dir);
+        g = UniGraph.open(conf).traversal();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        if (g != null) g.close();
+    }
+
+    @Test
+    public void hasAfterOutFiltersByString() {
+        assertEquals(1L, (long) g.V("a").out("E").has("org_id", U.toString()).count().next());
+        assertEquals(1L, (long) g.V("a").out("E").has("org_id", U).count().next());
+        assertEquals(0L, (long) g.V("a").out("E").has("org_id", OTHER.toString()).count().next());
+    }
+
+    @Test
+    public void partitionStrategyScopesOutHop() {
+        GraphTraversalSource in = g.withStrategies(
+                PartitionStrategy.build().partitionKey("org_id").readPartitions(U.toString()).create());
+        assertEquals(1L, (long) in.V("a").out("E").count().next());
+        GraphTraversalSource out = g.withStrategies(
+                PartitionStrategy.build().partitionKey("org_id").readPartitions(OTHER.toString()).create());
+        assertEquals(0L, (long) out.V("a").out("E").count().next());
+    }
+}

--- a/unipop-jdbc/test/org/unipop/jdbc/adjacency/JdbcAdjacencyFilterTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/adjacency/JdbcAdjacencyFilterTest.java
@@ -69,4 +69,20 @@ public class JdbcAdjacencyFilterTest {
                 PartitionStrategy.build().partitionKey("org_id").readPartitions(OTHER.toString()).create());
         assertEquals(0L, (long) out.V("a").out("E").count().next());
     }
+
+    @Test
+    public void hasAfterOutVFiltersByString() {
+        assertEquals(1L, (long) g.E().outV().has("org_id", U.toString()).count().next());
+        assertEquals(0L, (long) g.E().outV().has("org_id", OTHER.toString()).count().next());
+    }
+
+    @Test
+    public void partitionStrategyScopesOutV() {
+        GraphTraversalSource in = g.withStrategies(
+                PartitionStrategy.build().partitionKey("org_id").readPartitions(U.toString()).create());
+        assertEquals(1L, (long) in.E().outV().count().next());
+        GraphTraversalSource out = g.withStrategies(
+                PartitionStrategy.build().partitionKey("org_id").readPartitions(OTHER.toString()).create());
+        assertEquals(0L, (long) out.E().outV().count().next());
+    }
 }

--- a/unipop-jdbc/test/org/unipop/jdbc/adjacency/JdbcAdjacencyFilterTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/adjacency/JdbcAdjacencyFilterTest.java
@@ -41,6 +41,7 @@ public class JdbcAdjacencyFilterTest {
             s.execute("INSERT INTO adjedges VALUES ('e1','E','a','n','b','n','" + U + "')");
             s.execute("INSERT INTO adjnodes VALUES ('c','n','" + U + "')");
             s.execute("INSERT INTO adjedges VALUES ('e2','E','b','n','c','n','" + U + "')");
+            s.execute("INSERT INTO adjedges VALUES ('e3','E','a','n','c','n','" + U + "')");
         }
         String dir = new File(JdbcAdjacencyFilterTest.class.getResource("/configuration/adjfilter/graph.json").toURI()).getParent();
         Configuration conf = new BaseConfiguration();
@@ -57,8 +58,8 @@ public class JdbcAdjacencyFilterTest {
 
     @Test
     public void hasAfterOutFiltersByString() {
-        assertEquals(1L, (long) g.V("a").out("E").has("org_id", U.toString()).count().next());
-        assertEquals(1L, (long) g.V("a").out("E").has("org_id", U).count().next());
+        assertEquals(2L, (long) g.V("a").out("E").has("org_id", U.toString()).count().next());
+        assertEquals(2L, (long) g.V("a").out("E").has("org_id", U).count().next());
         assertEquals(0L, (long) g.V("a").out("E").has("org_id", OTHER.toString()).count().next());
     }
 
@@ -66,7 +67,7 @@ public class JdbcAdjacencyFilterTest {
     public void partitionStrategyScopesOutHop() {
         GraphTraversalSource in = g.withStrategies(
                 PartitionStrategy.build().partitionKey("org_id").readPartitions(U.toString()).create());
-        assertEquals(1L, (long) in.V("a").out("E").count().next());
+        assertEquals(2L, (long) in.V("a").out("E").count().next());
         GraphTraversalSource out = g.withStrategies(
                 PartitionStrategy.build().partitionKey("org_id").readPartitions(OTHER.toString()).create());
         assertEquals(0L, (long) out.V("a").out("E").count().next());
@@ -74,7 +75,7 @@ public class JdbcAdjacencyFilterTest {
 
     @Test
     public void hasAfterOutVFiltersByString() {
-        assertEquals(2L, (long) g.E().outV().has("org_id", U.toString()).count().next());
+        assertEquals(3L, (long) g.E().outV().has("org_id", U.toString()).count().next());
         assertEquals(0L, (long) g.E().outV().has("org_id", OTHER.toString()).count().next());
     }
 
@@ -82,7 +83,7 @@ public class JdbcAdjacencyFilterTest {
     public void partitionStrategyScopesOutV() {
         GraphTraversalSource in = g.withStrategies(
                 PartitionStrategy.build().partitionKey("org_id").readPartitions(U.toString()).create());
-        assertEquals(2L, (long) in.E().outV().count().next());
+        assertEquals(3L, (long) in.E().outV().count().next());
         GraphTraversalSource out = g.withStrategies(
                 PartitionStrategy.build().partitionKey("org_id").readPartitions(OTHER.toString()).create());
         assertEquals(0L, (long) out.E().outV().count().next());
@@ -96,5 +97,22 @@ public class JdbcAdjacencyFilterTest {
         GraphTraversalSource out = g.withStrategies(
                 PartitionStrategy.build().partitionKey("org_id").readPartitions(OTHER.toString()).create());
         assertEquals(0L, (long) out.V("a").out("E").out("E").count().next());
+    }
+
+    @Test
+    public void hasAfterBothPreservesDuplicateIds() {
+        // both() reaches every vertex from multiple incident edges: with e1(a-b),e2(b-c),e3(a-c),
+        // g.V().both('E') yields [b,c, a,c, b,a] = 6 traversers (each id appears twice). The filtered
+        // fetch dedups by id and un-defers one instance per id; the drop must keep BOTH instances of
+        // each matching id, not collapse to the distinct-id count (3).
+        assertEquals(6L, (long) g.V().both("E").has("org_id", U.toString()).count().next());
+        assertEquals(0L, (long) g.V().both("E").has("org_id", OTHER.toString()).count().next());
+    }
+
+    @Test
+    public void hasAfterOtherVPreservesDuplicateIds() {
+        // g.V().bothE('E').otherV() also yields 6 traversers with each id twice (EdgeOtherVertexStep).
+        assertEquals(6L, (long) g.V().bothE("E").otherV().has("org_id", U.toString()).count().next());
+        assertEquals(0L, (long) g.V().bothE("E").otherV().has("org_id", OTHER.toString()).count().next());
     }
 }


### PR DESCRIPTION
## Problem

A property `has()` applied to a vertex produced by a traversal step matched nothing on the JDBC provider, even though the vertex carried the property:

```
g.V('a').out('E').values('org_id')            => [U]   (vertex has it)
g.V('a').out('E').has('org_id', U.toString()) => 0     (EXPECTED 1)
```

Because TinkerPop's `PartitionStrategy` injects `has(partitionKey, within([…]))` after **every** graph step, this silently zeroed every multi-hop traversal under partition scoping — only the root `g.V()`/`g.E()` survived. PartitionStrategy (the standard multi-tenant / row-level-scoping mechanism) was therefore unusable.

**Root cause:** for vertex-producing steps the following `has()` was left as an in-memory `HasStep`, and the produced vertex's keyed value (e.g. `java.util.UUID`) never `.equals()` the injected **String** predicate.

## Fix

Fold the following `has()` into predicates carried by the produced-vertex fetch (`DeferredVertexQuery`), so the filter renders as SQL `WHERE` — reusing the existing keyed-schema translation (uuid `col::text = ?`, timestamptz native, enum) — and drop produced vertices that did not match. Affected steps: `out()/in()/both()` and `outV()/inV()/otherV()`. **Core-only** change.

- `DeferredVertexQuery` gains a predicate-carrying constructor (the old one delegates with empty predicates).
- `PredicatesUtil.collectVertexPredicates(...)` folds the immediately-following `has()` steps into a `PredicatesHolder`, removes them from the traversal, transfers labels, and skips/removes the `NoOpBarrierStep` that `LazyBarrierStrategy` inserts between an edge-vertex step and its `has()`.
- `UniGraphVertexStep`, `UniGraphEdgeVertexStep`, `UniGraphEdgeOtherVertexStep` thread the collected predicates into the fetch (forcing the fetch even for `count()` / no-property traversals) and drop non-matching produced vertices.

## Duplicate-id correctness

A vertex step emits one `DeferredVertex` **per incident edge**, so one id can appear as several instances; the fetch dedups by id and un-defers only one. The drop therefore keys off the **matched-id set** (any produced instance non-deferred after the fetch), keeping every traverser whose id matched — not a per-object `isDeferred()` test, which would drop legitimately-matching duplicates. Kept duplicate instances stay deferred and lazily self-hydrate on property access, exactly as the un-filtered hydrate path does. This is provider-agnostic (correct whether a controller un-defers one, all, or at-least-one instance per matched id).

## Tests

New `JdbcAdjacencyFilterTest` (embedded PostgreSQL, ref-endpoint edges, `uuid org_id` keyed column), 7/7:

- `has()` after `out()`/`outV()` by String and by UUID; non-matching → 0.
- PartitionStrategy-scoped single-hop and multi-hop: in-partition matches, cross-partition → 0.
- Duplicate-id multiplicity: `both()` and `bothE().otherV()` with `has(org_id)` return the full count (6), not the distinct-id count (3).

**Full-module regression:** `JdbcFeatureTest` 20 failures / 0 errors and `JdbcStructureSuite` 30 failures / 16 errors — both identical to the `master` baseline (an interim `isDeferred()`-based drop had regressed the feature suite to 31; the matched-id drop fully restores it). All schema suites (enum / jsonb / uuid / timestamptz) green.

## Scope / notes

- **jdbc is the verified target.** elastic/rest keep correct behavior for plain (String) properties via their in-memory predicate backstop with no source changes; keyed-schema (uuid/timestamptz/enum) push-down is jdbc-only. Enabling keyed push-down on elastic/rest later would require routing `query.getPredicates()` into their `getSearch(DeferredVertexQuery)` (out of scope here).
- **Fetch breadth:** the deferred fetch is `WHERE <predicates> LIMIT MAX_VALUE` with no `id IN (producedIds)` restriction (ids reconciled post-fetch). This is a pre-existing DeferredVertexQuery characteristic — the hydrate path already scanned `WHERE true`; this change *narrows* it to a partition scan. Bounding the scan with `id IN (…)` is a possible future optimization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
