### PR TITLE
perf(jdbc): bound deferred vertex fetch to produced ids

### DIFF
--- a/unipop-jdbc/src/org/unipop/jdbc/controller/simple/RowController.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/controller/simple/RowController.java
@@ -27,6 +27,8 @@ import org.unipop.query.mutation.AddVertexQuery;
 import org.unipop.query.mutation.PropertyQuery;
 import org.unipop.query.mutation.RemoveQuery;
 import org.unipop.query.predicates.PredicatesHolder;
+import org.unipop.query.predicates.PredicatesHolderFactory;
+import org.unipop.schema.element.VertexSchema;
 import org.unipop.query.search.DeferredVertexQuery;
 import org.unipop.query.search.SearchQuery;
 import org.unipop.query.search.SearchVertexQuery;
@@ -98,7 +100,9 @@ public class RowController implements SimpleController {
     public void fetchProperties(DeferredVertexQuery uniQuery) {
         SelectCollector<JdbcSchema<Vertex>, Select, Vertex> collector = new SelectCollector<>(
                 schema -> schema.getSearch(uniQuery,
-                        schema.toPredicates(uniQuery.getPredicates())),
+                        PredicatesHolderFactory.and(
+                                ((VertexSchema) schema).toPredicates(uniQuery.getVertices()),
+                                schema.toPredicates(uniQuery.getPredicates()))),
                 (schema, results) -> schema.parseResults(results, uniQuery)
         );
 

--- a/unipop-jdbc/test/org/unipop/jdbc/adjacency/JdbcAdjacencyFilterTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/adjacency/JdbcAdjacencyFilterTest.java
@@ -15,9 +15,12 @@ import java.io.File;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
+import java.util.List;
 import java.util.UUID;
+import org.unipop.jdbc.utils.TimingExecuterListener;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /** Vertex-property has() after out()/outV() must filter (push down), enabling PartitionStrategy. */
 public class JdbcAdjacencyFilterTest {
@@ -114,5 +117,49 @@ public class JdbcAdjacencyFilterTest {
         // g.V().bothE('E').otherV() also yields 6 traversers with each id twice (EdgeOtherVertexStep).
         assertEquals(6L, (long) g.V().bothE("E").otherV().has("org_id", U.toString()).count().next());
         assertEquals(0L, (long) g.V().bothE("E").otherV().has("org_id", OTHER.toString()).count().next());
+    }
+
+    /** Largest number of rows any executed query against the adjnodes table fetched. */
+    private static int maxAdjnodesFetch() {
+        return TimingExecuterListener.timing.entrySet().stream()
+                .filter(e -> e.getKey().toLowerCase().contains("adjnodes"))
+                .mapToInt(e -> e.getValue().getValue1())
+                .max().orElse(-1);
+    }
+
+    /**
+     * The deferred vertex fetch must be bounded to the produced neighbour ids, not scan the whole
+     * table (hydrate-only path) or the whole partition (pushed-predicate path). Proven by inserting
+     * same-partition non-neighbour "poison" rows and asserting the fetch reads only the neighbour.
+     * g.E("e1").inV() isolates adjnodes to a single query (the deferred fetch of b).
+     */
+    @Test
+    public void deferredFetchIsBoundedToProducedIds() throws Exception {
+        try (Connection c = DriverManager.getConnection(EmbeddedPostgresServer.URL, EmbeddedPostgresServer.USER, "");
+             Statement s = c.createStatement()) {
+            for (int i = 0; i < 30; i++) {
+                s.execute("INSERT INTO adjnodes VALUES ('p" + i + "','n','" + U + "')");
+            }
+        }
+        try {
+            // Hydrate-only path (no pushed predicate): before the fix this was WHERE true (full scan).
+            TimingExecuterListener.timing.clear();
+            List<Object> vals = g.E("e1").inV().values("org_id").toList();
+            assertEquals(1, vals.size());
+            assertEquals(U, vals.get(0));
+            assertTrue("hydrate-only deferred fetch scanned " + maxAdjnodesFetch()
+                    + " adjnodes rows; must be bounded to the produced id", maxAdjnodesFetch() <= 2);
+
+            // Pushed-predicate path: before the fix this was WHERE org_id = ? (partition scan).
+            TimingExecuterListener.timing.clear();
+            assertEquals(1L, (long) g.E("e1").inV().has("org_id", U.toString()).count().next());
+            assertTrue("pushed-predicate deferred fetch scanned " + maxAdjnodesFetch()
+                    + " adjnodes rows; must be bounded to the produced id", maxAdjnodesFetch() <= 2);
+        } finally {
+            try (Connection c = DriverManager.getConnection(EmbeddedPostgresServer.URL, EmbeddedPostgresServer.USER, "");
+                 Statement s = c.createStatement()) {
+                s.execute("DELETE FROM adjnodes WHERE id LIKE 'p%'");
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #163. jdbc's `RowController.fetchProperties(DeferredVertexQuery)` now bounds the deferred vertex fetch to the **produced neighbour ids** instead of scanning the whole predicate-matched set.

Before, the fetch built its `WHERE` from the pushed vertex-predicates only, with no `id IN (…)` restriction, and reconciled the produced ids in memory *after* the query returned:

- **Hydrate-only path** (`out().values('name')`, no pushed predicate): predicates empty → `WHERE true` → **full-table scan** of the target vertex table.
- **Pushed-predicate path** (PartitionStrategy-scoped `out().has(org_id, X)`): `WHERE org_id = X` → scans the **entire partition**, not just the neighbours.

## Change

One method. AND the existing `VertexSchema.toPredicates(getVertices())` id-restriction (the same builder the non-deferred `search` path already uses) into the fetch `WHERE`:

```java
schema -> schema.getSearch(uniQuery,
    PredicatesHolderFactory.and(
        ((VertexSchema) schema).toPredicates(uniQuery.getVertices()),  // T.id within [produced ids], per label
        schema.toPredicates(uniQuery.getPredicates())))                 // pushed has() predicates (may be empty)
```

| Path | Before | After |
|------|--------|-------|
| Hydrate-only | `WHERE true` (full-table scan) | `WHERE id IN (neighbours)` |
| Pushed-predicate | `WHERE org_id = X` (partition scan) | `WHERE id IN (neighbours) AND org_id = X` |

## Pure optimization — results identical

The post-fetch reconcile already kept only the produced ids, so restricting the query to those ids returns the same matched set; only the number of rows fetched shrinks (from O(table/partition) to O(neighbours)). No behaviour change.

## Tests

New `JdbcAdjacencyFilterTest#deferredFetchIsBoundedToProducedIds`: inserts same-partition non-neighbour "poison" rows, then uses `g.E("e1").inV()...` (which isolates the vertex table to the single deferred fetch) and asserts via `TimingExecuterListener` row counts that both the hydrate-only and pushed-predicate fetches read only the neighbour (≤2 rows), not the full table (~33). Results are also asserted correct. A behavioural test can't distinguish a pure optimization, so the proof is on rows fetched.

**Full-module regression unchanged:** `JdbcFeatureTest` 20 failures / 0 errors, `JdbcStructureSuite` 30 failures / 16 errors, all schema suites green, `JdbcAdjacencyFilterTest` 8/8.

## Scope

jdbc-only. elastic/rest vertex schemas already restrict by `getVertices()` in their deferred path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
