### PR TITLE
fix(core): defer child/modulator coalesce() to native CoalesceStep (fixes ClassCastException)

### DIFF
--- a/unipop-core/src/org/unipop/process/coalesce/UniGraphCoalesceStepStrategy.java
+++ b/unipop-core/src/org/unipop/process/coalesce/UniGraphCoalesceStepStrategy.java
@@ -34,6 +34,15 @@ public class UniGraphCoalesceStepStrategy extends AbstractTraversalStrategy<Trav
             boolean hasLambdaBranch = coalesceStep.getLocalChildren().stream()
                     .anyMatch(child -> child instanceof AbstractLambdaTraversal);
             if (hasLambdaBranch) return;
+            // The side-effect-smuggling origin-removal in UniGraphCoalesceStep only works when the
+            // step is a root step (its SIDE_EFFECTS requirement then forces a B_O_S_SE_SL_Traverser).
+            // In a child/modulator traversal (project/order/local/union .by/child) the parent supplies
+            // a bare B_O_Traverser whose getSideEffects() is the empty singleton, so the
+            // (B_O_S_SE_SL_Traverser) cast throws (CCE) and an interface-based read would silently
+            // break first-branch-wins. Native CoalesceStep is per-start and needs no side-effects, and
+            // branch push-down is preserved (branches remain local children optimized by the other
+            // provider strategies). Defer to it for non-root coalesce.
+            if (!traversal.isRoot()) return;
             UniGraphCoalesceStep uniGraphCoalesceStep = new UniGraphCoalesceStep(coalesceStep.getTraversal(), uniGraph, coalesceStep.getLocalChildren());
             TraversalHelper.replaceStep(coalesceStep, uniGraphCoalesceStep, traversal);
         });

--- a/unipop-jdbc/test/org/unipop/jdbc/adjacency/JdbcAdjacencyFilterTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/adjacency/JdbcAdjacencyFilterTest.java
@@ -16,8 +16,11 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.unipop.jdbc.utils.TimingExecuterListener;
+
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.*;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -117,6 +120,38 @@ public class JdbcAdjacencyFilterTest {
         // g.V().bothE('E').otherV() also yields 6 traversers with each id twice (EdgeOtherVertexStep).
         assertEquals(6L, (long) g.V().bothE("E").otherV().has("org_id", U.toString()).count().next());
         assertEquals(0L, (long) g.V().bothE("E").otherV().has("org_id", OTHER.toString()).count().next());
+    }
+
+    @Test
+    public void coalesceWorksAsByModulator() {
+        // 1. project().by(coalesce(...)) — was ClassCastException; now first-branch-wins => 1
+        List<Map<String, Object>> proj = g.V().project("w")
+                .by(coalesce(constant(1), constant(2))).toList();
+        assertEquals(3, proj.size());
+        proj.forEach(m -> assertEquals(1, m.get("w")));
+
+        // 2. order().by(coalesce(...)) — was CCE; now no throw, all 3 vertices returned
+        assertEquals(3L, (long) g.V().order().by(coalesce(constant(1), constant(2))).count().next());
+
+        // 3+4. local()/union() KEEP ALL branch outputs — proves correct first-branch-wins
+        //      (the rejected interface-swap returned [1,2,1,2,1,2] here).
+        assertEquals(List.of(1, 1, 1), g.V().local(coalesce(constant(1), constant(2))).toList());
+        assertEquals(List.of(1, 1, 1), g.V().union(coalesce(constant(1), constant(2))).toList());
+
+        // 5. main-step coalesce (root) — unchanged, still handled by UniGraphCoalesceStep
+        assertEquals(List.of(1, 1, 1), g.V().coalesce(constant(1), constant(2)).toList());
+
+        // 6. child-branch push-down + fallback preserved through native coalesce:
+        //    b has an out edge (e2 b->c) -> out('E').id() wins => "c";
+        //    c has no out edge -> coalesce falls through to the constant => "noedge".
+        assertEquals("c", g.V("b").project("n")
+                .by(coalesce(out("E").id(), constant("noedge"))).next().get("n"));
+        assertEquals("noedge", g.V("c").project("n")
+                .by(coalesce(out("E").id(), constant("noedge"))).next().get("n"));
+
+        // 7. values()+constant modulator (the reported failing shape) — org_id present => value wins
+        assertEquals(U, g.V("a").project("w")
+                .by(coalesce(values("org_id"), constant(false))).next().get("w"));
     }
 
     /** Largest number of rows any executed query against the adjnodes table fetched. */


### PR DESCRIPTION
## Problem

`coalesce(...)` used as a `by()`-modulator / child traversal — `project().by(coalesce(...))`, `order().by(...)`, `local(...)`, `union(...)` — threw:

```
java.lang.ClassCastException: B_O_Traverser cannot be cast to B_O_S_SE_SL_Traverser
    at org.unipop.process.coalesce.UniGraphCoalesceStep.lambda$process$3(UniGraphCoalesceStep.java:58)
```

`UniGraphCoalesceStep` implements coalesce's "first-branch-wins" by stashing each incoming start into the traverser's **side-effects** and reading it back from the branch output (casting to the concrete `B_O_S_SE_SL_Traverser`). That side-effect-bearing traverser is only allocated when `coalesce` is a **root** step (its `SIDE_EFFECTS` requirement forces it). In a child/modulator traversal the parent (`ProjectStep`/`OrderGlobalStep`/`LocalStep`/`UnionStep`) supplies a bare `B_O_Traverser`, so the cast throws. Net effect: `coalesce` (the natural "value or default" idiom) was unusable inside any `by()`-modulator.

## Root cause & why not the "obvious" fix

Confirmed with live traverser-class evidence (main step → `B_O_S_SE_SL_Traverser`; `project().by(...)` → `B_O_Traverser`, empty side-effects). The tempting fix — swap the cast for the `Traverser.Admin` interface (`item.asAdmin().getSideEffects()`) — is a **silent-correctness bug**: `B_O_Traverser.getSideEffects()` returns the empty singleton and `setSideEffects()` is a no-op, so origin-removal removes nothing and every branch emits for every start (`local(coalesce(constant(1),constant(2)))` → `[1,2,1,2,1,2]` instead of `[1,1,1]`). Rejected.

## Fix

Defer non-root `coalesce` to TinkerPop's native `CoalesceStep`, which is per-start and needs no side-effects. One guard in `UniGraphCoalesceStepStrategy.apply`, after the existing `hasLambdaBranch` guard:

```java
if (!traversal.isRoot()) return;
```

`UniGraphCoalesceStep` is left untouched and still handles root `coalesce` (keeping its bulk-batching). Branch push-down is preserved — branches remain local children optimized by the other provider strategies (verified: `V('b').project('n').by(coalesce(out('E').id(), constant('noedge')))` ⇒ `{n=c}`; a vertex with no out-edge falls through to the constant).

## Tests

New `JdbcAdjacencyFilterTest#coalesceWorksAsByModulator` (embedded PostgreSQL): the previously-crashing `project/order/local/union .by(coalesce(...))` cases now return correct results; `local`/`union` assert the full `[1,1,1]` (guarding against the rejected interface-swap's size-6 break); the graph-branch push-down + constant fallback both work through native coalesce; main-step `coalesce` unchanged.

**Full-module regression unchanged:** `JdbcFeatureTest` 20 failures / 0 errors, `JdbcStructureSuite` 30 failures / 16 errors, all schema suites green. The `hasLambdaBranch` guard (PR #155) runs first, so its coalesce fixes are untouched — the new guard only *adds* deferral for non-root coalesce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
