### PR TITLE
feat(jdbc): expose full JSONB object under bare column key on read

### DIFF
--- a/MIGRATION_NOTES.md
+++ b/MIGRATION_NOTES.md
@@ -331,7 +331,8 @@ vertex/edge's `properties`, contributed through `SourceProvider.providerBuilders
   metadata-only; optional `"field"` to alias the column). Backed by `EnumPropertySchema` (extends
   `FieldPropertySchema`); the query comparison renders `col::text = ?`.
 - **JSONB column** — `"<col>": {"type": "jsonb"}`. Schemaless catch-all addressed `<col>.<path>`
-  (any key, nested paths, text comparison). Backed by `JsonbPropertySchema`.
+  (any key, nested paths, text comparison); the bare `<col>` key is also readable as the full
+  JSON object (`Map`). Backed by `JsonbPropertySchema`.
 
 **Breaking change (enum):** the earlier element-level `"enums": {column: typeName}` object is
 **removed** and no longer parsed. Migrate each entry to a keyed declaration on that column, e.g.

--- a/unipop-jdbc/pom.xml
+++ b/unipop-jdbc/pom.xml
@@ -129,6 +129,7 @@
                         <include>**/JdbcEnumTest.java</include>
                         <include>**/JdbcJsonbTest.java</include>
                         <include>**/JdbcMultiJsonbTest.java</include>
+                        <include>**/JsonbPropertySchemaTest.java</include>
                         <include>**/EnumPropertySchemaTest.java</include>
                         <include>**/UuidPropertySchemaTest.java</include>
                         <include>**/JdbcUuidTest.java</include>

--- a/unipop-jdbc/src/org/unipop/jdbc/schemas/property/JsonbPropertySchema.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/schemas/property/JsonbPropertySchema.java
@@ -17,8 +17,9 @@ import java.util.stream.Collectors;
 /**
  * A keyed property schema backing one PostgreSQL JSONB column. The property key is the column name
  * and the schema owns the {@code <column>.<path>} namespace: writes route those properties into the
- * column's JSON at the dotted path, reads expand the column's top-level keys back prefixed, and
- * queries on {@code <column>.<path>} pass through to the jdbc translator (which renders col->>'k').
+ * column's JSON at the dotted path, reads expose the full parsed JSON object under the bare column
+ * key and expand top-level keys as {@code <column>.<path>}, and queries on {@code <column>.<path>}
+ * pass through to the jdbc translator (which renders col->>'k').
  * Declare one per column: {@code "data": {"type": "jsonb"}}.
  */
 public class JsonbPropertySchema implements PropertySchema, JsonbColumnSchema {

--- a/unipop-jdbc/src/org/unipop/jdbc/schemas/property/JsonbPropertySchema.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/schemas/property/JsonbPropertySchema.java
@@ -54,7 +54,9 @@ public class JsonbPropertySchema implements PropertySchema, JsonbColumnSchema {
             Object parsed = MAPPER.readValue(raw.toString(), Object.class);
             if (!(parsed instanceof Map)) return Collections.emptyMap();
             Map<String, Object> props = new HashMap<>();
-            ((Map<String, Object>) parsed).forEach((k, v) -> {
+            Map<String, Object> whole = (Map<String, Object>) parsed;
+            props.put(column, whole);
+            whole.forEach((k, v) -> {
                 if (v != null) props.put(column + "." + k, v);
             });
             return props;

--- a/unipop-jdbc/test/org/unipop/jdbc/jsonb/JdbcJsonbTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/jsonb/JdbcJsonbTest.java
@@ -62,6 +62,11 @@ public class JdbcJsonbTest {
         assertEquals(1L, (long) g.V().has("data.address.city", "NYC").count().next());
         // read-back
         assertEquals("active", g.V("1").values("data.status").next());
+        // whole JSONB object under bare column key
+        @SuppressWarnings("unchecked")
+        Map<String, Object> data = (Map<String, Object>) g.V("1").values("data").next();
+        assertEquals("active", data.get("status"));
+        assertEquals("NYC", ((Map<?, ?>) data.get("address")).get("city"));
         // negative
         assertEquals(0L, (long) g.V().has("data.status", "inactive").count().next());
     }

--- a/unipop-jdbc/test/org/unipop/jdbc/jsonb/JsonbPropertySchemaTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/jsonb/JsonbPropertySchemaTest.java
@@ -1,0 +1,43 @@
+package org.unipop.jdbc.jsonb;
+
+import org.junit.Test;
+import org.unipop.jdbc.schemas.property.JsonbPropertySchema;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class JsonbPropertySchemaTest {
+
+    @Test
+    public void toPropertiesExposesWholeDictAndDottedKeys() {
+        JsonbPropertySchema schema = new JsonbPropertySchema("data");
+        Map<String, Object> props = schema.toProperties(
+                Collections.singletonMap("data",
+                        "{\"status\":\"active\",\"address\":{\"city\":\"NYC\"}}"));
+
+        assertTrue(props.get("data") instanceof Map);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> whole = (Map<String, Object>) props.get("data");
+        assertEquals("active", whole.get("status"));
+        assertTrue(whole.get("address") instanceof Map);
+        assertEquals("active", props.get("data.status"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> address = (Map<String, Object>) props.get("data.address");
+        assertEquals("NYC", address.get("city"));
+    }
+
+    @Test
+    public void toPropertiesEmptyForNonObjectJson() {
+        JsonbPropertySchema schema = new JsonbPropertySchema("data");
+        assertTrue(schema.toProperties(Collections.singletonMap("data", "[1,2]")).isEmpty());
+        assertTrue(schema.toProperties(Collections.singletonMap("data", "\"x\"")).isEmpty());
+    }
+
+    @Test
+    public void toPropertiesEmptyWhenColumnAbsent() {
+        JsonbPropertySchema schema = new JsonbPropertySchema("data");
+        assertTrue(schema.toProperties(Collections.emptyMap()).isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- On read, JSONB columns declared as `"type": "jsonb"` now expose the full parsed object under the bare column key (e.g. `values("data")`) while keeping existing dotted `<col>.<path>` expansion, writes, and path queries unchanged.
- Adds unit + integration coverage and a migration-notes note for the bare-column read.

## Test plan
- [x] `JsonbPropertySchemaTest` (unit) — pass
- [x] `JdbcJsonbTest` / `JdbcMultiJsonbTest` — pass
- [x] Broader JDBC-focused suites (enum/uuid/timestamptz/adjacency) — pass
- [x] `JdbcFeatureTest` / `JdbcStructureSuite` — baseline unchanged (20F/0E and 30F/16E)


Made with [Cursor](https://cursor.com)