### PR TITLE
perf(jdbc): adjacency join push-down for vertex-return hops (out/in/both + filter/order/limit)

### DIFF
--- a/unipop-core/src/org/unipop/process/vertex/UniGraphVertexStep.java
+++ b/unipop-core/src/org/unipop/process/vertex/UniGraphVertexStep.java
@@ -81,7 +81,13 @@ public class UniGraphVertexStep<E extends Element> extends UniPredicatesStep<Ver
         if (!returnsVertex)
             vertexQuery = new SearchVertexQuery(Edge.class, vertices, direction, predicates, limit, propertyKeys, orders, stepDescriptor, traversal);
         else
-            vertexQuery = new SearchVertexQuery(Edge.class, vertices, direction, predicates, -1, propertyKeys, null, stepDescriptor, traversal);
+            vertexQuery = new SearchVertexQuery(Edge.class, vertices, direction, predicates,
+                    /*edgeLimit*/ -1, propertyKeys, /*edgeOrders*/ null,
+                    /*targetPredicates*/ vertexPredicates,
+                    /*targetOrders*/ orders,
+                    /*targetLimit*/ limit,
+                    /*hydrateTarget*/ true,
+                    stepDescriptor, traversal);
         logger.debug("Executing query: ", vertexQuery);
         Iterator<Traverser.Admin<E>> traversersIterator = controllers.stream().<Iterator<Edge>>map(controller -> controller.search(vertexQuery))
                 .<Edge>flatMap(ConversionUtils::asStream)

--- a/unipop-core/src/org/unipop/process/vertex/UniGraphVertexStep.java
+++ b/unipop-core/src/org/unipop/process/vertex/UniGraphVertexStep.java
@@ -24,6 +24,7 @@ import org.unipop.query.predicates.PredicatesHolderFactory;
 import org.unipop.query.search.DeferredVertexQuery;
 import org.unipop.query.search.SearchVertexQuery;
 import org.unipop.schema.reference.DeferredVertex;
+import org.unipop.structure.UniEdge;
 import org.unipop.structure.UniGraph;
 import org.unipop.structure.UniVertex;
 
@@ -130,7 +131,9 @@ public class UniGraphVertexStep<E extends Element> extends UniPredicatesStep<Ver
     }
 
     private Stream<Traverser.Admin<E>> toTraversers(Edge edge, Map<Object, List<Traverser<Vertex>>> traversers) {
-        return ConversionUtils.asStream(edge.vertices(direction))
+        Direction mapDir = (edge instanceof UniEdge && ((UniEdge) edge).isAdjacencyJoinDirected())
+                ? Direction.OUT : direction;
+        return ConversionUtils.asStream(edge.vertices(mapDir))
                 .<Traverser.Admin<E>>flatMap(originalVertex -> {
                     List<Traverser<Vertex>> vertexTraversers = traversers.get(originalVertex.id());
                     if (vertexTraversers == null) return null;
@@ -143,6 +146,8 @@ public class UniGraphVertexStep<E extends Element> extends UniPredicatesStep<Ver
 
     private E getReturnElement(Edge edge, Vertex originalVertex) {
         if (!this.returnsVertex) return (E) edge;
+        if (edge instanceof UniEdge && ((UniEdge) edge).isAdjacencyJoinDirected())
+            return (E) edge.inVertex(); // convention: in = hydrated target neighbour
         return (E) UniVertex.vertexToVertex(originalVertex, edge, this.direction);
     }
 

--- a/unipop-core/src/org/unipop/query/search/SearchVertexQuery.java
+++ b/unipop-core/src/org/unipop/query/search/SearchVertexQuery.java
@@ -10,6 +10,7 @@ import org.unipop.query.StepDescriptor;
 import org.unipop.query.VertexQuery;
 import org.unipop.query.controller.UniQueryController;
 import org.unipop.query.predicates.PredicatesHolder;
+import org.unipop.query.predicates.PredicatesHolderFactory;
 
 import java.util.Iterator;
 import java.util.List;
@@ -19,11 +20,46 @@ public class SearchVertexQuery extends SearchQuery<Edge> implements VertexQuery 
 
     private final List<Vertex> vertices;
     private final Direction direction;
+    private final PredicatesHolder targetPredicates;
+    private final List<Pair<String, Order>> targetOrders;
+    private final int targetLimit;
+    private final boolean hydrateTarget;
 
+    // Backward-compatible: edge-return / callers with no target intent.
     public SearchVertexQuery(Class<Edge> returnType, List<Vertex> vertices, Direction direction, PredicatesHolder predicates, int limit, Set<String> propertyKeys, List<Pair<String, Order>> orders, StepDescriptor stepDescriptor, Traversal traversal) {
+        this(returnType, vertices, direction, predicates, limit, propertyKeys, orders,
+                PredicatesHolderFactory.empty(), null, -1, false, stepDescriptor, traversal);
+    }
+
+    // Target-aware constructor with default stepDescriptor/traversal (for test compatibility)
+    public SearchVertexQuery(Class<Edge> returnType, List<Vertex> vertices, Direction direction, PredicatesHolder predicates, int limit, Set<String> propertyKeys, List<Pair<String, Order>> orders, PredicatesHolder targetPredicates, List<Pair<String, Order>> targetOrders, int targetLimit, boolean hydrateTarget) {
+        this(returnType, vertices, direction, predicates, limit, propertyKeys, orders, targetPredicates, targetOrders, targetLimit, hydrateTarget, null, null);
+    }
+
+    public SearchVertexQuery(Class<Edge> returnType, List<Vertex> vertices, Direction direction, PredicatesHolder predicates, int limit, Set<String> propertyKeys, List<Pair<String, Order>> orders, PredicatesHolder targetPredicates, List<Pair<String, Order>> targetOrders, int targetLimit, boolean hydrateTarget, StepDescriptor stepDescriptor, Traversal traversal) {
         super(returnType, predicates, limit, propertyKeys, orders, stepDescriptor, traversal);
         this.vertices = vertices;
         this.direction = direction;
+        this.targetPredicates = targetPredicates == null ? PredicatesHolderFactory.empty() : targetPredicates;
+        this.targetOrders = targetOrders;
+        this.targetLimit = targetLimit;
+        this.hydrateTarget = hydrateTarget;
+    }
+
+    public PredicatesHolder getTargetPredicates() {
+        return targetPredicates;
+    }
+
+    public List<Pair<String, Order>> getTargetOrders() {
+        return targetOrders;
+    }
+
+    public int getTargetLimit() {
+        return targetLimit;
+    }
+
+    public boolean isHydrateTarget() {
+        return hydrateTarget;
     }
 
     @Override

--- a/unipop-core/src/org/unipop/structure/UniEdge.java
+++ b/unipop-core/src/org/unipop/structure/UniEdge.java
@@ -17,6 +17,7 @@ public class UniEdge extends UniElement implements Edge {
     protected Map<String, Property> properties;
     protected Vertex inVertex;
     protected Vertex outVertex;
+    private boolean adjacencyJoinDirected = false;
 
     public UniEdge(Map<String, Object> keyValues, Vertex outV, Vertex inV, ElementSchema schema, final UniGraph graph) {
         super(keyValues, schema, graph);
@@ -57,6 +58,12 @@ public class UniEdge extends UniElement implements Edge {
                 controller.property(propertyQuery));
         return vertexProperty;
     }
+
+    /** Marks an edge produced by the JDBC adjacency-join path: out = source (query) vertex,
+     *  in = hydrated target neighbour. The vertex step maps these by the source (out) only. */
+    public boolean isAdjacencyJoinDirected() { return adjacencyJoinDirected; }
+
+    public UniEdge asAdjacencyJoinDirected() { this.adjacencyJoinDirected = true; return this; }
 
     @Override
     public Iterator<Vertex> vertices(Direction direction) {

--- a/unipop-core/test/org/unipop/query/search/SearchVertexQueryTest.java
+++ b/unipop-core/test/org/unipop/query/search/SearchVertexQueryTest.java
@@ -1,0 +1,41 @@
+package org.unipop.query.search;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Order;
+import org.apache.tinkerpop.gremlin.structure.Direction;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.javatuples.Pair;
+import org.junit.Test;
+import org.unipop.query.predicates.PredicatesHolderFactory;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SearchVertexQueryTest {
+
+    @Test
+    public void oldConstructorHasNoTargetIntent() {
+        SearchVertexQuery q = new SearchVertexQuery(Edge.class, Collections.emptyList(), Direction.OUT,
+                PredicatesHolderFactory.empty(), 5, Collections.emptySet(), null, null, null);
+        assertFalse(q.isHydrateTarget());
+        assertEquals(-1, q.getTargetLimit());
+        assertTrue(q.getTargetPredicates().isEmpty());
+    }
+
+    @Test
+    public void newConstructorCarriesTargetIntent() {
+        List<Pair<String, Order>> orders = Collections.singletonList(Pair.with("name", Order.asc));
+        SearchVertexQuery q = new SearchVertexQuery(Edge.class, Collections.emptyList(), Direction.OUT,
+                PredicatesHolderFactory.empty(), -1, null, null,
+                PredicatesHolderFactory.predicate(new org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer(
+                        "status", org.apache.tinkerpop.gremlin.process.traversal.P.eq("open"))),
+                orders, 50, true);
+        assertTrue(q.isHydrateTarget());
+        assertEquals(50, q.getTargetLimit());
+        assertEquals(orders, q.getTargetOrders());
+        assertTrue(q.getTargetPredicates().notEmpty());
+    }
+}

--- a/unipop-jdbc/src/org/unipop/jdbc/controller/simple/RowController.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/controller/simple/RowController.java
@@ -144,38 +144,47 @@ public class RowController implements SimpleController {
     private boolean joinApplicable(SearchVertexQuery q) {
         if (!graph.configuration().getBoolean("jdbc.joinPushdown", true)) return false;
         if (!q.isHydrateTarget()) return false;
-        // BOTH is out of scope here (single-direction join, see getJoinSearch's contract): a joined
-        // row already carries a complete edge (source-shell endpoint + hydrated target endpoint), so
-        // edge.vertices(BOTH) fans out over both ends on its own. Running this once per direction for
-        // BOTH would double-fetch every edge, and since the join doesn't project the real edge id
-        // (fromJoinRow has no id column to key off), the duplicates can't be deduped by id either.
-        // BOTH keeps the existing OR-combined fallback query, which already handles this correctly.
-        if (q.getDirection().equals(Direction.BOTH)) return false;
         boolean propertiesRequested = q.getPropertyKeys() == null || !q.getPropertyKeys().isEmpty();
         boolean hasOrder = q.getTargetOrders() != null && !q.getTargetOrders().isEmpty();
         return q.getTargetPredicates().notEmpty() || hasOrder || propertiesRequested;
     }
 
-    /** Join fan-out over (edge schema x surviving vertex schema), single-direction only (see joinApplicable). Returns null to fall back. */
+    /**
+     * Join fan-out over (edge schema x surviving vertex schema x direction). BOTH runs as two
+     * directed joins (OUT and IN); each produced edge is flagged adjacencyJoinDirected so the vertex
+     * step maps it by its own source only (see UniGraphVertexStep), avoiding the double-count that
+     * would otherwise come from edge.vertices(BOTH) fanning into both endpoints. Returns null to fall back.
+     */
     private Iterator<Edge> searchJoin(SearchVertexQuery uniQuery) {
-        Direction dir = uniQuery.getDirection();
+        List<Direction> dirs = uniQuery.getDirection().equals(Direction.BOTH)
+                ? Arrays.asList(Direction.OUT, Direction.IN)
+                : Collections.singletonList(uniQuery.getDirection());
 
-        Map<Pair<RowEdgeSchema, JdbcSchema<Vertex>>, Select> selects = new HashMap<>();
+        // Keyed by (edgeSchema, vertexSchema, direction) -- BOTH runs the same (edgeSchema, vs) pair
+        // once per direction, so direction must be part of the key or one direction's select clobbers
+        // the other's map entry.
+        Map<Pair<Pair<RowEdgeSchema, JdbcSchema<Vertex>>, Direction>, Select> selects = new HashMap<>();
         for (JdbcSchema<Edge> es : edgeSchemas) {
-            if (!(es instanceof RowEdgeSchema)) return null; // InnerRowEdgeSchema etc. -> fall back
+            // Exact-class check: InnerRowEdgeSchema (and any other RowEdgeSchema subclass) extends
+            // RowEdgeSchema but represents adjacency embedded in the vertex row, not a real joinable
+            // edge table -- an `instanceof` check here would wrongly let it through this join path.
+            if (es.getClass() != org.unipop.jdbc.schemas.RowEdgeSchema.class) return null; // inner/other edge schemas -> fall back
             if (!this.traversalFilter.filter(es, uniQuery.getTraversal())) continue;
             RowEdgeSchema edgeSchema = (RowEdgeSchema) es;
             for (JdbcSchema<Vertex> vs : vertexSchemas) {
-                Select sel = edgeSchema.getJoinSearch(uniQuery, (JdbcVertexSchema) vs, dir);
-                if (sel != null) selects.put(new Pair<>(edgeSchema, vs), sel);
+                for (Direction dir : dirs) {
+                    Select sel = edgeSchema.getJoinSearch(uniQuery, (JdbcVertexSchema) vs, dir);
+                    if (sel != null) selects.put(new Pair<>(new Pair<>(edgeSchema, vs), dir), sel);
+                }
             }
         }
         if (selects.isEmpty()) return Collections.emptyIterator();
 
         Set<Edge> out = new HashSet<>();
-        for (Map.Entry<Pair<RowEdgeSchema, JdbcSchema<Vertex>>, Select> entry : selects.entrySet()) {
-            RowEdgeSchema edgeSchema = entry.getKey().getValue0();
-            JdbcVertexSchema vs = (JdbcVertexSchema) entry.getKey().getValue1();
+        for (Map.Entry<Pair<Pair<RowEdgeSchema, JdbcSchema<Vertex>>, Direction>, Select> entry : selects.entrySet()) {
+            RowEdgeSchema edgeSchema = entry.getKey().getValue0().getValue0();
+            JdbcVertexSchema vs = (JdbcVertexSchema) entry.getKey().getValue0().getValue1();
+            Direction dir = entry.getKey().getValue1();
             for (Map<String, Object> row : this.getContextManager().fetch(entry.getValue())) {
                 Edge edge = edgeSchema.fromJoinRow(row, vs, dir);
                 if (edge != null) out.add(edge);

--- a/unipop-jdbc/src/org/unipop/jdbc/controller/simple/RowController.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/controller/simple/RowController.java
@@ -142,6 +142,7 @@ public class RowController implements SimpleController {
     }
 
     private boolean joinApplicable(SearchVertexQuery q) {
+        // ponytail: kill-switch for rollout, remove after bake-in
         if (!graph.configuration().getBoolean("jdbc.joinPushdown", true)) return false;
         if (!q.isHydrateTarget()) return false;
         boolean propertiesRequested = q.getPropertyKeys() == null || !q.getPropertyKeys().isEmpty();
@@ -164,19 +165,23 @@ public class RowController implements SimpleController {
         // once per direction, so direction must be part of the key or one direction's select clobbers
         // the other's map entry.
         Map<Pair<Pair<RowEdgeSchema, JdbcSchema<Vertex>>, Direction>, Select> selects = new HashMap<>();
-        for (JdbcSchema<Edge> es : edgeSchemas) {
-            // Exact-class check: InnerRowEdgeSchema (and any other RowEdgeSchema subclass) extends
-            // RowEdgeSchema but represents adjacency embedded in the vertex row, not a real joinable
-            // edge table -- an `instanceof` check here would wrongly let it through this join path.
-            if (es.getClass() != org.unipop.jdbc.schemas.RowEdgeSchema.class) return null; // inner/other edge schemas -> fall back
-            if (!this.traversalFilter.filter(es, uniQuery.getTraversal())) continue;
-            RowEdgeSchema edgeSchema = (RowEdgeSchema) es;
-            for (JdbcSchema<Vertex> vs : vertexSchemas) {
-                for (Direction dir : dirs) {
-                    Select sel = edgeSchema.getJoinSearch(uniQuery, (JdbcVertexSchema) vs, dir);
-                    if (sel != null) selects.put(new Pair<>(new Pair<>(edgeSchema, vs), dir), sel);
+        try {
+            for (JdbcSchema<Edge> es : edgeSchemas) {
+                // Exact-class check: InnerRowEdgeSchema (and any other RowEdgeSchema subclass) extends
+                // RowEdgeSchema but represents adjacency embedded in the vertex row, not a real joinable
+                // edge table -- an `instanceof` check here would wrongly let it through this join path.
+                if (es.getClass() != org.unipop.jdbc.schemas.RowEdgeSchema.class) return null; // inner/other edge schemas -> fall back
+                if (!this.traversalFilter.filter(es, uniQuery.getTraversal())) continue;
+                RowEdgeSchema edgeSchema = (RowEdgeSchema) es;
+                for (JdbcSchema<Vertex> vs : vertexSchemas) {
+                    for (Direction dir : dirs) {
+                        Select sel = edgeSchema.getJoinSearch(uniQuery, (JdbcVertexSchema) vs, dir);
+                        if (sel != null) selects.put(new Pair<>(new Pair<>(edgeSchema, vs), dir), sel);
+                    }
                 }
             }
+        } catch (org.unipop.jdbc.schemas.RowEdgeSchema.OrderNotPushableException e) {
+            return null; // order column missing on a surviving schema -> full fallback (spec: order+limit push together or not at all)
         }
         if (selects.isEmpty()) return Collections.emptyIterator();
 

--- a/unipop-jdbc/src/org/unipop/jdbc/controller/simple/RowController.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/controller/simple/RowController.java
@@ -180,6 +180,7 @@ public class RowController implements SimpleController {
         }
         if (selects.isEmpty()) return Collections.emptyIterator();
 
+        // NOTE: dedup is by edge id; join edges carry random ids on purpose (see RowEdgeSchema.fromJoinRow).
         Set<Edge> out = new HashSet<>();
         for (Map.Entry<Pair<Pair<RowEdgeSchema, JdbcSchema<Vertex>>, Direction>, Select> entry : selects.entrySet()) {
             RowEdgeSchema edgeSchema = entry.getKey().getValue0().getValue0();

--- a/unipop-jdbc/src/org/unipop/jdbc/controller/simple/RowController.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/controller/simple/RowController.java
@@ -14,10 +14,12 @@ import org.jooq.impl.DSL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.unipop.common.util.PredicatesTranslator;
+import org.javatuples.Pair;
 import org.unipop.jdbc.schemas.RowEdgeSchema;
 import org.unipop.jdbc.schemas.RowVertexSchema;
 import org.unipop.jdbc.schemas.jdbc.JdbcEdgeSchema;
 import org.unipop.jdbc.schemas.jdbc.JdbcSchema;
+import org.unipop.jdbc.schemas.jdbc.JdbcVertexSchema;
 import org.unipop.jdbc.utils.ContextManager;
 import org.unipop.jdbc.utils.TimingExecuterListener;
 import org.unipop.query.UniQuery;
@@ -122,6 +124,11 @@ public class RowController implements SimpleController {
 
     @Override
     public Iterator<Edge> search(SearchVertexQuery uniQuery) {
+        if (joinApplicable(uniQuery)) {
+            Iterator<Edge> joined = searchJoin(uniQuery);
+            if (joined != null) return joined;
+        }
+        // Fallback: existing id-only edge path (unchanged).
         SelectCollector<JdbcSchema<Edge>, Select, Edge> collector = new SelectCollector<>(
                 schema -> schema.getSearch(uniQuery,
                         ((JdbcEdgeSchema) schema).toPredicates(uniQuery.getVertices(), uniQuery.getDirection(), uniQuery.getPredicates())),
@@ -132,6 +139,49 @@ public class RowController implements SimpleController {
                 .filter(schema -> this.traversalFilter.filter(schema, uniQuery.getTraversal())).collect(collector);
 
         return this.search(uniQuery, selects, collector);
+    }
+
+    private boolean joinApplicable(SearchVertexQuery q) {
+        if (!graph.configuration().getBoolean("jdbc.joinPushdown", true)) return false;
+        if (!q.isHydrateTarget()) return false;
+        // BOTH is out of scope here (single-direction join, see getJoinSearch's contract): a joined
+        // row already carries a complete edge (source-shell endpoint + hydrated target endpoint), so
+        // edge.vertices(BOTH) fans out over both ends on its own. Running this once per direction for
+        // BOTH would double-fetch every edge, and since the join doesn't project the real edge id
+        // (fromJoinRow has no id column to key off), the duplicates can't be deduped by id either.
+        // BOTH keeps the existing OR-combined fallback query, which already handles this correctly.
+        if (q.getDirection().equals(Direction.BOTH)) return false;
+        boolean propertiesRequested = q.getPropertyKeys() == null || !q.getPropertyKeys().isEmpty();
+        boolean hasOrder = q.getTargetOrders() != null && !q.getTargetOrders().isEmpty();
+        return q.getTargetPredicates().notEmpty() || hasOrder || propertiesRequested;
+    }
+
+    /** Join fan-out over (edge schema x surviving vertex schema), single-direction only (see joinApplicable). Returns null to fall back. */
+    private Iterator<Edge> searchJoin(SearchVertexQuery uniQuery) {
+        Direction dir = uniQuery.getDirection();
+
+        Map<Pair<RowEdgeSchema, JdbcSchema<Vertex>>, Select> selects = new HashMap<>();
+        for (JdbcSchema<Edge> es : edgeSchemas) {
+            if (!(es instanceof RowEdgeSchema)) return null; // InnerRowEdgeSchema etc. -> fall back
+            if (!this.traversalFilter.filter(es, uniQuery.getTraversal())) continue;
+            RowEdgeSchema edgeSchema = (RowEdgeSchema) es;
+            for (JdbcSchema<Vertex> vs : vertexSchemas) {
+                Select sel = edgeSchema.getJoinSearch(uniQuery, (JdbcVertexSchema) vs, dir);
+                if (sel != null) selects.put(new Pair<>(edgeSchema, vs), sel);
+            }
+        }
+        if (selects.isEmpty()) return Collections.emptyIterator();
+
+        Set<Edge> out = new HashSet<>();
+        for (Map.Entry<Pair<RowEdgeSchema, JdbcSchema<Vertex>>, Select> entry : selects.entrySet()) {
+            RowEdgeSchema edgeSchema = entry.getKey().getValue0();
+            JdbcVertexSchema vs = (JdbcVertexSchema) entry.getKey().getValue1();
+            for (Map<String, Object> row : this.getContextManager().fetch(entry.getValue())) {
+                Edge edge = edgeSchema.fromJoinRow(row, vs, dir);
+                if (edge != null) out.add(edge);
+            }
+        }
+        return out.iterator();
     }
 
     @Override

--- a/unipop-jdbc/src/org/unipop/jdbc/schemas/AbstractRowSchema.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/schemas/AbstractRowSchema.java
@@ -86,27 +86,7 @@ public abstract class AbstractRowSchema<E extends Element> extends AbstractEleme
             return null;
         }
 
-        // The id column is VARCHAR; tell the translator so it stringifies numeric Gremlin ids
-        // (PostgreSQL won't compare varchar = bigint the way H2 did).
-        String idField = getFieldByPropertyKey(T.id.getAccessor());
-        Set<String> idFields = idField == null ? Collections.emptySet() : Collections.singleton(idField);
-        Set<String> jsonbColumns = getPropertySchemas().stream()
-                .filter(s -> s instanceof JsonbColumnSchema)
-                .map(s -> ((JsonbColumnSchema) s).getJsonbColumn())
-                .collect(Collectors.toSet());
-        Set<String> enumColumns = getPropertySchemas().stream()
-                .filter(s -> s instanceof EnumColumnSchema)
-                .map(s -> ((EnumColumnSchema) s).getEnumColumn())
-                .collect(Collectors.toSet());
-        Set<String> uuidColumns = getPropertySchemas().stream()
-                .filter(s -> s instanceof UuidColumnSchema)
-                .map(s -> ((UuidColumnSchema) s).getUuidColumn())
-                .collect(Collectors.toSet());
-        Set<String> timestamptzColumns = getPropertySchemas().stream()
-                .filter(s -> s instanceof TimestamptzColumnSchema)
-                .map(s -> ((TimestamptzColumnSchema) s).getTimestamptzColumn())
-                .collect(Collectors.toSet());
-        Condition conditions = new JdbcPredicatesTranslator(idFields, enumColumns, jsonbColumns, uuidColumns, timestamptzColumns).translate(predicatesHolder);
+        Condition conditions = buildTranslator(null).translate(predicatesHolder);
         int finalLimit = query.getLimit() < 0 ? Integer.MAX_VALUE : query.getLimit();
 
         SelectConditionStep<Record> where = createSqlQuery(query.getPropertyKeys())
@@ -125,6 +105,35 @@ public abstract class AbstractRowSchema<E extends Element> extends AbstractEleme
 
         return where.limit(finalLimit);
 
+    }
+
+    /**
+     * Builds a translator from this schema's own column sets (id/enum/jsonb/uuid/timestamptz),
+     * qualifying rendered columns with {@code alias} (e.g. {@code v.col}) when non-null — needed
+     * when this schema's table is joined against another that shares column names. The id column
+     * is VARCHAR; passing it as an id field tells the translator to stringify numeric Gremlin ids
+     * (PostgreSQL won't compare varchar = bigint the way H2 did).
+     */
+    protected JdbcPredicatesTranslator buildTranslator(String alias) {
+        String idField = getFieldByPropertyKey(T.id.getAccessor());
+        Set<String> idFields = idField == null ? Collections.emptySet() : Collections.singleton(idField);
+        Set<String> jsonbColumns = getPropertySchemas().stream()
+                .filter(s -> s instanceof JsonbColumnSchema)
+                .map(s -> ((JsonbColumnSchema) s).getJsonbColumn())
+                .collect(Collectors.toSet());
+        Set<String> enumColumns = getPropertySchemas().stream()
+                .filter(s -> s instanceof EnumColumnSchema)
+                .map(s -> ((EnumColumnSchema) s).getEnumColumn())
+                .collect(Collectors.toSet());
+        Set<String> uuidColumns = getPropertySchemas().stream()
+                .filter(s -> s instanceof UuidColumnSchema)
+                .map(s -> ((UuidColumnSchema) s).getUuidColumn())
+                .collect(Collectors.toSet());
+        Set<String> timestamptzColumns = getPropertySchemas().stream()
+                .filter(s -> s instanceof TimestamptzColumnSchema)
+                .map(s -> ((TimestamptzColumnSchema) s).getTimestamptzColumn())
+                .collect(Collectors.toSet());
+        return new JdbcPredicatesTranslator(idFields, enumColumns, jsonbColumns, uuidColumns, timestamptzColumns, alias);
     }
 
 

--- a/unipop-jdbc/src/org/unipop/jdbc/schemas/AbstractRowSchema.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/schemas/AbstractRowSchema.java
@@ -136,7 +136,6 @@ public abstract class AbstractRowSchema<E extends Element> extends AbstractEleme
         return new JdbcPredicatesTranslator(idFields, enumColumns, jsonbColumns, uuidColumns, timestamptzColumns, alias);
     }
 
-
     private <E extends Element> SelectJoinStep<Record> createSqlQuery(Set<String> columnsToRetrieve) {
         if (columnsToRetrieve == null) {
             return DSL.select().from(this.getTable());

--- a/unipop-jdbc/src/org/unipop/jdbc/schemas/RowEdgeSchema.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/schemas/RowEdgeSchema.java
@@ -155,25 +155,24 @@ public class RowEdgeSchema extends AbstractRowSchema<Edge> implements JdbcEdgeSc
         return sorts.isEmpty() ? where.limit(lim) : where.orderBy(sorts).limit(lim);
     }
 
-    /** Parse a join row into a UniEdge whose target endpoint is a hydrated vertex from vertexSchema. */
+    /**
+     * Parse a join row into a UniEdge under a uniform convention: out = source-shell (the query
+     * vertex, id only), in = hydrated target neighbour -- regardless of directedDir (which only
+     * chose src/target columns for getJoinSearch). The edge is flagged adjacencyJoinDirected so
+     * UniGraphVertexStep maps it by source (out) only, letting both() run as two directed joins
+     * without double-counting (see UniEdge.isAdjacencyJoinDirected).
+     */
     public Edge fromJoinRow(Map<String, Object> row, JdbcVertexSchema vertexSchema, Direction directedDir) {
         Vertex target = vertexSchema.createElement(row);
         if (target == null) return null;
         Object srcId = row.get(SRC_ALIAS);
-        Vertex source;
-        if (srcId == null) {
-            source = null;
-        } else {
-            // ponytail: must be a mutable map -- UniElement's ctor calls properties.remove(...) to
-            // pull out ~id/~label, which throws UnsupportedOperationException against
-            // Collections.singletonMap (its entrySet iterator refuses remove()).
-            Map<String, Object> sourceProps = new HashMap<>();
-            sourceProps.put(T.id.getAccessor(), srcId);
-            source = new UniVertex(sourceProps, null, graph);
-        }
-        Vertex outV = directedDir.equals(Direction.OUT) ? source : target;
-        Vertex inV = directedDir.equals(Direction.OUT) ? target : source;
-        return new UniEdge(Collections.emptyMap(), outV, inV, this, graph);
+        // ponytail: must be a mutable map -- UniElement's ctor calls properties.remove(...) to
+        // pull out ~id/~label, which throws UnsupportedOperationException against
+        // Collections.singletonMap (its entrySet iterator refuses remove()).
+        Map<String, Object> shellProps = new HashMap<>();
+        shellProps.put(T.id.getAccessor(), srcId);
+        Vertex source = new UniVertex(shellProps, null, graph);
+        return new UniEdge(new HashMap<>(), source, target, this, graph).asAdjacencyJoinDirected();
     }
 
     @Override

--- a/unipop-jdbc/src/org/unipop/jdbc/schemas/RowEdgeSchema.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/schemas/RowEdgeSchema.java
@@ -172,6 +172,10 @@ public class RowEdgeSchema extends AbstractRowSchema<Edge> implements JdbcEdgeSc
         Map<String, Object> shellProps = new HashMap<>();
         shellProps.put(T.id.getAccessor(), srcId);
         Vertex source = new UniVertex(shellProps, null, graph);
+        // ponytail: the empty props => random UniEdge id is load-bearing. both() returns the same
+        // physical edge twice (one OUT-directed copy, one IN-directed copy); searchJoin's HashSet
+        // dedups by id, so distinct random ids keep both copies alive. Projecting the real edge id
+        // here would collapse them and make both() under-count. Keep random ids (or dedup by identity).
         return new UniEdge(new HashMap<>(), source, target, this, graph).asAdjacencyJoinDirected();
     }
 

--- a/unipop-jdbc/src/org/unipop/jdbc/schemas/RowEdgeSchema.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/schemas/RowEdgeSchema.java
@@ -113,6 +113,11 @@ public class RowEdgeSchema extends AbstractRowSchema<Edge> implements JdbcEdgeSc
 
     public static final String SRC_ALIAS = "__unipop_src";
 
+    /** Thrown by getJoinSearch when a requested target order column is absent on this vertex
+     *  schema. Per spec, order+limit must push together or not at all, so the controller must fall
+     *  back the whole invocation to the deferred path rather than join a partial set of schemas. */
+    public static final class OrderNotPushableException extends RuntimeException {}
+
     /**
      * Single-direction adjacency JOIN that hydrates + filters + bounds the target vertex.
      * directedDir is OUT or IN (never BOTH). Returns null to skip this (edge,vertex) pair:
@@ -146,7 +151,7 @@ public class RowEdgeSchema extends AbstractRowSchema<Edge> implements JdbcEdgeSc
         if (query.getTargetOrders() != null) {
             for (Pair<String, Order> o : query.getTargetOrders()) {
                 String col = vSchema.getFieldByPropertyKey(o.getValue0());
-                if (col == null) return null;
+                if (col == null) throw new OrderNotPushableException();
                 Field<Object> f = field(name("v", col));
                 sorts.add(o.getValue1().equals(Order.desc) ? f.desc() : f.asc());
             }

--- a/unipop-jdbc/src/org/unipop/jdbc/schemas/RowEdgeSchema.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/schemas/RowEdgeSchema.java
@@ -120,8 +120,11 @@ public class RowEdgeSchema extends AbstractRowSchema<Edge> implements JdbcEdgeSc
 
     /**
      * Single-direction adjacency JOIN that hydrates + filters + bounds the target vertex.
-     * directedDir is OUT or IN (never BOTH). Returns null to skip this (edge,vertex) pair:
-     * the edge or target predicates aborted, or an order column is missing.
+     * directedDir is OUT or IN (never BOTH). Returns null to skip this (edge,vertex) pair when the
+     * edge or target predicates aborted (that schema matches nothing — correct pruning). Throws
+     * {@link OrderNotPushableException} when a requested order column is absent on this vertex
+     * schema, so the controller falls back the whole invocation to the deferred path (order+limit
+     * push together or not at all).
      */
     public Select getJoinSearch(SearchVertexQuery query, JdbcVertexSchema vertexSchema, Direction directedDir) {
         VertexSchema srcSchema = directedDir.equals(Direction.OUT) ? outVertexSchema : inVertexSchema;

--- a/unipop-jdbc/src/org/unipop/jdbc/schemas/RowEdgeSchema.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/schemas/RowEdgeSchema.java
@@ -2,23 +2,36 @@ package org.unipop.jdbc.schemas;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import org.apache.tinkerpop.gremlin.process.traversal.Order;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.javatuples.Pair;
+import org.jooq.*;
+import org.jooq.Record;
+import org.jooq.impl.DSL;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.unipop.jdbc.schemas.jdbc.JdbcEdgeSchema;
+import org.unipop.jdbc.schemas.jdbc.JdbcVertexSchema;
 import org.unipop.query.predicates.PredicatesHolder;
 import org.unipop.query.predicates.PredicatesHolderFactory;
+import org.unipop.query.search.SearchVertexQuery;
 import org.unipop.schema.element.ElementSchema;
 import org.unipop.schema.element.VertexSchema;
 import org.unipop.schema.property.PropertySchema;
 import org.unipop.schema.reference.ReferenceVertexSchema;
 import org.unipop.structure.UniEdge;
 import org.unipop.structure.UniGraph;
+import org.unipop.structure.UniVertex;
 import org.unipop.util.ConversionUtils;
 
 import java.util.*;
+
+import static org.jooq.impl.DSL.field;
+import static org.jooq.impl.DSL.name;
+import static org.jooq.impl.DSL.table;
 
 /**
  * @author Gur Ronen
@@ -96,6 +109,71 @@ public class RowEdgeSchema extends AbstractRowSchema<Edge> implements JdbcEdgeSc
         if(direction.equals(Direction.OUT)) return outPredicates;
         if(direction.equals(Direction.IN)) return inPredicates;
         return PredicatesHolderFactory.or(inPredicates, outPredicates);
+    }
+
+    public static final String SRC_ALIAS = "__unipop_src";
+
+    /**
+     * Single-direction adjacency JOIN that hydrates + filters + bounds the target vertex.
+     * directedDir is OUT or IN (never BOTH). Returns null to skip this (edge,vertex) pair:
+     * the edge or target predicates aborted, or an order column is missing.
+     */
+    public Select getJoinSearch(SearchVertexQuery query, JdbcVertexSchema vertexSchema, Direction directedDir) {
+        VertexSchema srcSchema = directedDir.equals(Direction.OUT) ? outVertexSchema : inVertexSchema;
+        VertexSchema tgtSchema = directedDir.equals(Direction.OUT) ? inVertexSchema : outVertexSchema;
+        String srcCol = srcSchema.getFieldByPropertyKey(T.id.getAccessor());
+        String endpointCol = tgtSchema.getFieldByPropertyKey(T.id.getAccessor());
+        AbstractRowSchema<?> vSchema = (AbstractRowSchema<?>) vertexSchema;
+        String vIdCol = vSchema.getFieldByPropertyKey(T.id.getAccessor());
+
+        PredicatesHolder tgtHolder = vertexSchema.toPredicates(query.getTargetPredicates());
+        if (tgtHolder.isAborted()) return null;
+        PredicatesHolder edgeHolder = this.toPredicates(query.getVertices(), directedDir, query.getPredicates());
+        if (edgeHolder.isAborted()) return null;
+
+        Condition edgeCond = this.buildTranslator("e").translate(edgeHolder);
+        Condition tgtCond = vSchema.buildTranslator("v").translate(tgtHolder);
+
+        Table<Record> e = table(name(getTable())).as("e");
+        Table<Record> v = table(name(vertexSchema.getTable())).as("v");
+        List<SelectFieldOrAsterisk> projection = Arrays.asList(v.asterisk(), field(name("e", srcCol)).as(SRC_ALIAS));
+
+        SelectConditionStep<Record> where = DSL.select(projection)
+                .from(e).join(v).on(field(name("e", endpointCol)).eq(field(name("v", vIdCol))))
+                .where(edgeCond.and(tgtCond));
+
+        List<SortField<Object>> sorts = new ArrayList<>();
+        if (query.getTargetOrders() != null) {
+            for (Pair<String, Order> o : query.getTargetOrders()) {
+                String col = vSchema.getFieldByPropertyKey(o.getValue0());
+                if (col == null) return null;
+                Field<Object> f = field(name("v", col));
+                sorts.add(o.getValue1().equals(Order.desc) ? f.desc() : f.asc());
+            }
+        }
+        int lim = query.getTargetLimit() < 0 ? Integer.MAX_VALUE : query.getTargetLimit();
+        return sorts.isEmpty() ? where.limit(lim) : where.orderBy(sorts).limit(lim);
+    }
+
+    /** Parse a join row into a UniEdge whose target endpoint is a hydrated vertex from vertexSchema. */
+    public Edge fromJoinRow(Map<String, Object> row, JdbcVertexSchema vertexSchema, Direction directedDir) {
+        Vertex target = vertexSchema.createElement(row);
+        if (target == null) return null;
+        Object srcId = row.get(SRC_ALIAS);
+        Vertex source;
+        if (srcId == null) {
+            source = null;
+        } else {
+            // ponytail: must be a mutable map -- UniElement's ctor calls properties.remove(...) to
+            // pull out ~id/~label, which throws UnsupportedOperationException against
+            // Collections.singletonMap (its entrySet iterator refuses remove()).
+            Map<String, Object> sourceProps = new HashMap<>();
+            sourceProps.put(T.id.getAccessor(), srcId);
+            source = new UniVertex(sourceProps, null, graph);
+        }
+        Vertex outV = directedDir.equals(Direction.OUT) ? source : target;
+        Vertex inV = directedDir.equals(Direction.OUT) ? target : source;
+        return new UniEdge(Collections.emptyMap(), outV, inV, this, graph);
     }
 
     @Override

--- a/unipop-jdbc/src/org/unipop/jdbc/utils/JdbcPredicatesTranslator.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/utils/JdbcPredicatesTranslator.java
@@ -9,8 +9,11 @@ import org.apache.tinkerpop.gremlin.process.traversal.util.ConnectiveP;
 import org.apache.tinkerpop.gremlin.process.traversal.util.OrP;
 import org.jooq.Condition;
 import org.jooq.Field;
+import org.jooq.Name;
 import org.jooq.QueryPart;
 import org.jooq.impl.DSL;
+
+import static org.jooq.impl.DSL.field;
 import org.unipop.common.util.PredicatesTranslator;
 import org.unipop.jdbc.schemas.property.TimestamptzPropertySchema;
 import org.unipop.process.predicate.Date;
@@ -77,7 +80,7 @@ public class JdbcPredicatesTranslator implements PredicatesTranslator<Condition>
     }
 
     /** Column name, qualified with {@link #alias} (e.g. {@code v.col}) when one is set. */
-    private org.jooq.Name col(String key) {
+    private Name col(String key) {
         return alias == null ? DSL.name(key) : DSL.name(alias, key);
     }
 
@@ -100,7 +103,7 @@ public class JdbcPredicatesTranslator implements PredicatesTranslator<Condition>
         }
         return (enumColumns.contains(key) || uuidColumns.contains(key))
                 ? DSL.field("{0}::text", Object.class, DSL.field(col(key)))
-                : DSL.field(col(key));
+                : (alias == null ? field(key) : DSL.field(col(key)));
     }
 
     /**

--- a/unipop-jdbc/src/org/unipop/jdbc/utils/JdbcPredicatesTranslator.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/utils/JdbcPredicatesTranslator.java
@@ -24,8 +24,6 @@ import java.util.*;
 import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
 
-import static org.jooq.impl.DSL.field;
-
 /**
  * @author Gur Ronen
  * @since 6/14/2016
@@ -37,6 +35,7 @@ public class JdbcPredicatesTranslator implements PredicatesTranslator<Condition>
     private final Set<String> jsonbColumns;
     private final Set<String> uuidColumns;
     private final Set<String> timestamptzColumns;
+    private final String alias;
 
     public JdbcPredicatesTranslator() {
         this(Collections.emptySet(), Collections.emptySet(), Collections.emptySet());
@@ -59,17 +58,27 @@ public class JdbcPredicatesTranslator implements PredicatesTranslator<Condition>
     }
 
     public JdbcPredicatesTranslator(Set<String> idFields, Set<String> enumColumns, Set<String> jsonbColumns, Set<String> uuidColumns, Set<String> timestamptzColumns) {
+        this(idFields, enumColumns, jsonbColumns, uuidColumns, timestamptzColumns, null);
+    }
+
+    public JdbcPredicatesTranslator(Set<String> idFields, Set<String> enumColumns, Set<String> jsonbColumns, Set<String> uuidColumns, Set<String> timestamptzColumns, String alias) {
         this.idFields = idFields == null ? Collections.emptySet() : idFields;
         this.enumColumns = enumColumns == null ? Collections.emptySet() : enumColumns;
         this.jsonbColumns = jsonbColumns == null ? Collections.emptySet() : jsonbColumns;
         this.uuidColumns = uuidColumns == null ? Collections.emptySet() : uuidColumns;
         this.timestamptzColumns = timestamptzColumns == null ? Collections.emptySet() : timestamptzColumns;
+        this.alias = alias;
     }
 
     /** A dotted key whose first segment is a JSONB column, e.g. {@code data.address.city}. */
     private boolean isJsonbKey(String key) {
         int dot = key.indexOf('.');
         return dot > 0 && jsonbColumns.contains(key.substring(0, dot));
+    }
+
+    /** Column name, qualified with {@link #alias} (e.g. {@code v.col}) when one is set. */
+    private org.jooq.Name col(String key) {
+        return alias == null ? DSL.name(key) : DSL.name(alias, key);
     }
 
     /**
@@ -81,7 +90,7 @@ public class JdbcPredicatesTranslator implements PredicatesTranslator<Condition>
         if (isJsonbKey(key)) {
             String[] parts = key.split("\\.", -1);
             QueryPart[] qps = new QueryPart[parts.length];
-            qps[0] = DSL.field(DSL.name(parts[0]));
+            qps[0] = DSL.field(col(parts[0]));
             StringBuilder sql = new StringBuilder("{0}");
             for (int i = 1; i < parts.length; i++) {
                 qps[i] = DSL.val(parts[i]);
@@ -90,8 +99,8 @@ public class JdbcPredicatesTranslator implements PredicatesTranslator<Condition>
             return DSL.field(sql.toString(), Object.class, qps);
         }
         return (enumColumns.contains(key) || uuidColumns.contains(key))
-                ? DSL.field("{0}::text", Object.class, DSL.field(DSL.name(key)))
-                : field(key);
+                ? DSL.field("{0}::text", Object.class, DSL.field(col(key)))
+                : DSL.field(col(key));
     }
 
     /**

--- a/unipop-jdbc/test-resources/configuration/joinpushdown/graph.json
+++ b/unipop-jdbc/test-resources/configuration/joinpushdown/graph.json
@@ -5,7 +5,7 @@
   "user": "postgres",
   "sqlDialect": "POSTGRES",
   "vertices": [
-    { "table": "jp_host",   "id": "@id", "label": "host",   "properties": { "status": "@status", "name": "@name" }, "dynamicProperties": false },
+    { "table": "jp_host",   "id": "@id", "label": "host",   "properties": { "status": "@status", "name": "@name", "rack": "@rack" }, "dynamicProperties": false },
     { "table": "jp_person", "id": "@id", "label": "person", "properties": { "status": "@status", "name": "@name" }, "dynamicProperties": false }
   ],
   "edges": [

--- a/unipop-jdbc/test-resources/configuration/joinpushdown/graph.json
+++ b/unipop-jdbc/test-resources/configuration/joinpushdown/graph.json
@@ -10,7 +10,7 @@
   ],
   "edges": [
     { "table": "jp_owns", "id": "@id", "label": "owns", "properties": {}, "dynamicProperties": false,
-      "outVertex": { "ref": "true", "id": "@src_id", "label": "host" },
-      "inVertex":  { "ref": "true", "id": "@dst_id", "label": "host" } }
+      "outVertex": { "ref": "true", "id": "@src_id", "label": "@src_label" },
+      "inVertex":  { "ref": "true", "id": "@dst_id", "label": "@dst_label" } }
   ]
 }

--- a/unipop-jdbc/test-resources/configuration/joinpushdown/graph.json
+++ b/unipop-jdbc/test-resources/configuration/joinpushdown/graph.json
@@ -1,0 +1,16 @@
+{
+  "class": "org.unipop.jdbc.JdbcSourceProvider",
+  "driver": "org.postgresql.Driver",
+  "address": ["jdbc:postgresql://localhost:54329/postgres"],
+  "user": "postgres",
+  "sqlDialect": "POSTGRES",
+  "vertices": [
+    { "table": "jp_host",   "id": "@id", "label": "host",   "properties": { "status": "@status", "name": "@name" }, "dynamicProperties": false },
+    { "table": "jp_person", "id": "@id", "label": "person", "properties": { "status": "@status", "name": "@name" }, "dynamicProperties": false }
+  ],
+  "edges": [
+    { "table": "jp_owns", "id": "@id", "label": "owns", "properties": {}, "dynamicProperties": false,
+      "outVertex": { "ref": "true", "id": "@src_id", "label": "host" },
+      "inVertex":  { "ref": "true", "id": "@dst_id", "label": "host" } }
+  ]
+}

--- a/unipop-jdbc/test/org/unipop/jdbc/join/JdbcJoinPushdownTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/join/JdbcJoinPushdownTest.java
@@ -33,11 +33,13 @@ public class JdbcJoinPushdownTest {
             s.execute("DROP TABLE IF EXISTS jp_host");
             s.execute("DROP TABLE IF EXISTS jp_person");
             s.execute("DROP TABLE IF EXISTS jp_owns");
-            s.execute("CREATE TABLE jp_host   (id varchar(100) primary key, status varchar(20), name varchar(50))");
+            s.execute("CREATE TABLE jp_host   (id varchar(100) primary key, status varchar(20), name varchar(50), rack varchar(20))");
             s.execute("CREATE TABLE jp_person (id varchar(100) primary key, status varchar(20), name varchar(50))");
             s.execute("CREATE TABLE jp_owns   (id varchar(100) primary key, src_id varchar(100), src_label varchar(20), dst_id varchar(100), dst_label varchar(20))");
             // root (host) owns 3 hosts + 2 persons; h1 additionally owns p1 (for both() tests).
-            s.execute("INSERT INTO jp_host VALUES ('root','open','root'),('h1','open','alpha'),('h2','open','bravo'),('h3','closed','charlie')");
+            // rack is host-only (asymmetric): jp_person has no such column, used to prove order-column
+            // fallback (see orderByColumnMissingOnFanOutSchemaFallsBack).
+            s.execute("INSERT INTO jp_host VALUES ('root','open','root','r0'),('h1','open','alpha','r1'),('h2','open','bravo','r2'),('h3','closed','charlie','r3')");
             s.execute("INSERT INTO jp_person VALUES ('p1','open','delta'),('p2','open','echo')");
             // dst is heterogeneous (host or person), so src/dst labels are stored per-row and the
             // reference vertex schemas below resolve them dynamically (@src_label/@dst_label) rather
@@ -157,6 +159,24 @@ public class JdbcJoinPushdownTest {
     public void bareLimitDoesNotJoin() {
         assertEquals(5L, (long) g.V("root").out("owns").limit(10).count().next());
         assertTrue("bare limit (no filter/order/props) must not take the join path", !joinedHost() && !joinedPerson());
+    }
+
+    @Test
+    public void orderByColumnMissingOnFanOutSchemaFallsBack() {
+        // Unlabelled fan-out over jp_host + jp_person; order by 'rack' which only jp_host maps.
+        // Spec: order+limit push together or not at all -> the whole hop must fall back to the
+        // deferred path (no join), NOT push a host-only partial join that drops person neighbours.
+        TimingExecuterListener.timing.clear();
+        g.V("root").out("owns").order().by("rack").limit(10).count().next();
+        // MECHANISM (non-negotiable): full fallback took over -- no join fired on either table.
+        assertTrue("order by a column missing on a fan-out schema must fall back (no join)",
+                !joinedHost() && !joinedPerson());
+        // NOTE: order().by("rack") itself drops jp_person vertices in this TinkerPop version (they
+        // lack the property, so OrderGlobalStep's by-modulator filters them out) -- that's ordering
+        // semantics unrelated to this fix, so the neighbour-count check below intentionally omits the
+        // order() to confirm the fallback path (not just the join-skip) still surfaces all 5 neighbours.
+        assertEquals("fan-out itself (sans order) must still return all 5 out-neighbours",
+                5L, (long) g.V("root").out("owns").count().next());
     }
 
     @Test

--- a/unipop-jdbc/test/org/unipop/jdbc/join/JdbcJoinPushdownTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/join/JdbcJoinPushdownTest.java
@@ -158,4 +158,20 @@ public class JdbcJoinPushdownTest {
         assertEquals(5L, (long) g.V("root").out("owns").limit(10).count().next());
         assertTrue("bare limit (no filter/order/props) must not take the join path", !joinedHost() && !joinedPerson());
     }
+
+    @Test
+    public void killSwitchDisablesJoin() throws Exception {
+        String dir = new File(getClass().getResource("/configuration/joinpushdown/graph.json").toURI()).getParent();
+        Configuration conf = new BaseConfiguration();
+        conf.setProperty(Graph.GRAPH, UniGraph.class.getName());
+        conf.setProperty("graphName", "joinpushdown");
+        conf.setProperty("providers", dir);
+        conf.setProperty("jdbc.joinPushdown", false);
+        try (Graph off = UniGraph.open(conf)) {
+            GraphTraversalSource gOff = off.traversal();
+            TimingExecuterListener.timing.clear();
+            assertEquals(2L, (long) gOff.V("root").out("owns").hasLabel("host").has("status", "open").limit(10).count().next());
+            assertTrue("flag off => no join, deferred path only", !joinedHost() && !joinedPerson());
+        }
+    }
 }

--- a/unipop-jdbc/test/org/unipop/jdbc/join/JdbcJoinPushdownTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/join/JdbcJoinPushdownTest.java
@@ -35,12 +35,17 @@ public class JdbcJoinPushdownTest {
             s.execute("DROP TABLE IF EXISTS jp_owns");
             s.execute("CREATE TABLE jp_host   (id varchar(100) primary key, status varchar(20), name varchar(50))");
             s.execute("CREATE TABLE jp_person (id varchar(100) primary key, status varchar(20), name varchar(50))");
-            s.execute("CREATE TABLE jp_owns   (id varchar(100) primary key, src_id varchar(100), dst_id varchar(100))");
+            s.execute("CREATE TABLE jp_owns   (id varchar(100) primary key, src_id varchar(100), src_label varchar(20), dst_id varchar(100), dst_label varchar(20))");
             // root (host) owns 3 hosts + 2 persons; h1 additionally owns p1 (for both() tests).
             s.execute("INSERT INTO jp_host VALUES ('root','open','root'),('h1','open','alpha'),('h2','open','bravo'),('h3','closed','charlie')");
             s.execute("INSERT INTO jp_person VALUES ('p1','open','delta'),('p2','open','echo')");
+            // dst is heterogeneous (host or person), so src/dst labels are stored per-row and the
+            // reference vertex schemas below resolve them dynamically (@src_label/@dst_label) rather
+            // than a single hardcoded label -- a static label would abort any batch whose real label
+            // doesn't match it (e.g. in("owns") from a person-labeled start vertex).
             s.execute("INSERT INTO jp_owns VALUES " +
-                    "('o1','root','h1'),('o2','root','h2'),('o3','root','h3'),('o4','root','p1'),('o5','root','p2'),('o6','h1','p1')");
+                    "('o1','root','host','h1','host'),('o2','root','host','h2','host'),('o3','root','host','h3','host')," +
+                    "('o4','root','host','p1','person'),('o5','root','host','p2','person'),('o6','h1','host','p1','person')");
         }
         String dir = new File(JdbcJoinPushdownTest.class.getResource("/configuration/joinpushdown/graph.json").toURI()).getParent();
         Configuration conf = new BaseConfiguration();
@@ -93,5 +98,36 @@ public class JdbcJoinPushdownTest {
         assertEquals(2L, n);
         assertTrue("expected a JOIN on jp_host", joinedHost());
         assertTrue("join path must not run a separate by-id vertex fetch", !ranDeferredVertexFetch());
+    }
+
+    @Test
+    public void inDirectionJoinPushes() {
+        // p1's in-neighbours via owns: root and h1 (both hosts, both open) -> 2
+        assertEquals(2L, (long) g.V("p1").in("owns").hasLabel("host").has("status","open").limit(10).count().next());
+        assertTrue("host table joined", joinedHost());
+    }
+
+    @Test
+    public void bothSingleSource() {
+        // h1: in-edge root->h1, out-edge h1->p1  => both = {root, p1} = 2
+        assertEquals(2L, (long) g.V("h1").both("owns").limit(10).count().next());
+        assertEquals(1L, (long) g.V("h1").both("owns").hasLabel("person").limit(10).count().next()); // only p1
+    }
+
+    @Test
+    public void bothWholeGraphNoDoubleCount() {
+        // 6 owns edges, each contributes 2 both()-traversers (once per direction) => 12, NOT 24.
+        assertEquals(12L, (long) g.V().both("owns").count().next());
+        // person neighbours only: root->p1, root->p2, h1->p1 => 3
+        assertEquals(3L, (long) g.V().both("owns").hasLabel("person").count().next());
+    }
+
+    @Test
+    public void orderByTargetPropPushesAndTrimsGlobally() {
+        // root owns hosts alpha(h1),bravo(h2),charlie(h3); order by name asc, limit 2 => alpha,bravo
+        java.util.List<Object> names = g.V("root").out("owns").hasLabel("host")
+                .order().by("name").limit(2).values("name").toList();
+        assertEquals(java.util.Arrays.asList("alpha","bravo"), names);
+        assertTrue("host table joined", joinedHost());
     }
 }

--- a/unipop-jdbc/test/org/unipop/jdbc/join/JdbcJoinPushdownTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/join/JdbcJoinPushdownTest.java
@@ -137,4 +137,25 @@ public class JdbcJoinPushdownTest {
         assertEquals(java.util.Arrays.asList("alpha","bravo"), names);
         assertTrue("host table joined", joinedHost());
     }
+
+    @Test
+    public void hasLabelNarrowsFanOutToOneTable() {
+        assertEquals(2L, (long) g.V("root").out("owns").hasLabel("host").has("status", "open").limit(10).count().next());
+        assertTrue("host table joined", joinedHost());
+        assertTrue("person table must NOT be joined when hasLabel('host') narrows", !joinedPerson());
+    }
+
+    @Test
+    public void noLabelFansOutOverAllVertexTables() {
+        // root owns open hosts h1,h2 (h3 closed) + open persons p1,p2 => 4.
+        assertEquals(4L, (long) g.V("root").out("owns").has("status", "open").limit(10).count().next());
+        assertTrue(joinedHost());
+        assertTrue(joinedPerson());
+    }
+
+    @Test
+    public void bareLimitDoesNotJoin() {
+        assertEquals(5L, (long) g.V("root").out("owns").limit(10).count().next());
+        assertTrue("bare limit (no filter/order/props) must not take the join path", !joinedHost() && !joinedPerson());
+    }
 }

--- a/unipop-jdbc/test/org/unipop/jdbc/join/JdbcJoinPushdownTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/join/JdbcJoinPushdownTest.java
@@ -1,0 +1,97 @@
+package org.unipop.jdbc.join;
+
+import org.apache.commons.configuration2.BaseConfiguration;
+import org.apache.commons.configuration2.Configuration;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.unipop.jdbc.suite.EmbeddedPostgresServer;
+import org.unipop.jdbc.utils.TimingExecuterListener;
+import org.unipop.structure.UniGraph;
+
+import java.io.File;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class JdbcJoinPushdownTest {
+
+    private static GraphTraversalSource g;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        EmbeddedPostgresServer.ensureStarted();
+        Class.forName("org.postgresql.Driver");
+        try (Connection c = DriverManager.getConnection(EmbeddedPostgresServer.URL, EmbeddedPostgresServer.USER, "");
+             Statement s = c.createStatement()) {
+            s.execute("DROP TABLE IF EXISTS jp_host");
+            s.execute("DROP TABLE IF EXISTS jp_person");
+            s.execute("DROP TABLE IF EXISTS jp_owns");
+            s.execute("CREATE TABLE jp_host   (id varchar(100) primary key, status varchar(20), name varchar(50))");
+            s.execute("CREATE TABLE jp_person (id varchar(100) primary key, status varchar(20), name varchar(50))");
+            s.execute("CREATE TABLE jp_owns   (id varchar(100) primary key, src_id varchar(100), dst_id varchar(100))");
+            // root (host) owns 3 hosts + 2 persons; h1 additionally owns p1 (for both() tests).
+            s.execute("INSERT INTO jp_host VALUES ('root','open','root'),('h1','open','alpha'),('h2','open','bravo'),('h3','closed','charlie')");
+            s.execute("INSERT INTO jp_person VALUES ('p1','open','delta'),('p2','open','echo')");
+            s.execute("INSERT INTO jp_owns VALUES " +
+                    "('o1','root','h1'),('o2','root','h2'),('o3','root','h3'),('o4','root','p1'),('o5','root','p2'),('o6','h1','p1')");
+        }
+        String dir = new File(JdbcJoinPushdownTest.class.getResource("/configuration/joinpushdown/graph.json").toURI()).getParent();
+        Configuration conf = new BaseConfiguration();
+        conf.setProperty(Graph.GRAPH, UniGraph.class.getName());
+        conf.setProperty("graphName", "joinpushdown");
+        conf.setProperty("providers", dir);
+        g = UniGraph.open(conf).traversal();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        if (g != null) g.close();
+    }
+
+    @Before
+    public void clearTiming() {
+        TimingExecuterListener.timing.clear();
+    }
+
+    /** True if any executed query joined jp_host (i.e. the join path ran on the host table). */
+    private static boolean joinedHost() {
+        return TimingExecuterListener.timing.keySet().stream()
+                .anyMatch(sql -> { String q = sql.toLowerCase(); return q.contains("join") && q.contains("jp_host"); });
+    }
+
+    /**
+     * True if any executed query is a deferred vertex-property fetch (the pre-join fallback hydration
+     * path) against a vertex table. Excludes the id-only "select id from ... where id in (...)" shape
+     * that g.V(id) always runs to resolve the traversal's start vertex across every vertex table --
+     * that lookup is orthogonal to whether the OUT-hop's target got hydrated via JOIN or a deferred
+     * property re-fetch, and would otherwise false-positive this check on every traversal.
+     */
+    private static boolean ranDeferredVertexFetch() {
+        return TimingExecuterListener.timing.keySet().stream()
+                .anyMatch(sql -> { String q = sql.toLowerCase().replaceAll("\\s+", " ").trim();
+                    return !q.contains("join") && (q.contains("from jp_host") || q.contains("from jp_person"))
+                            && q.contains("where") && q.contains("id") && !q.startsWith("select id from"); });
+    }
+
+    @Test
+    public void outHasLabelHasLimitPushesJoin() {
+        assertEquals(2L, (long) g.V("root").out("owns").hasLabel("host").has("status", "open").limit(10).count().next());
+        assertTrue("expected a JOIN on jp_host", joinedHost());
+    }
+
+    @Test
+    public void joinPathSkipsDeferredVertexFetch() {
+        long n = g.V("root").out("owns").hasLabel("host").has("status", "open").limit(10)
+                .values("name").count().next();
+        assertEquals(2L, n);
+        assertTrue("expected a JOIN on jp_host", joinedHost());
+        assertTrue("join path must not run a separate by-id vertex fetch", !ranDeferredVertexFetch());
+    }
+}

--- a/unipop-jdbc/test/org/unipop/jdbc/join/JdbcJoinPushdownTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/join/JdbcJoinPushdownTest.java
@@ -71,6 +71,12 @@ public class JdbcJoinPushdownTest {
                 .anyMatch(sql -> { String q = sql.toLowerCase(); return q.contains("join") && q.contains("jp_host"); });
     }
 
+    /** True if any executed query joined jp_person (i.e. the join path ran on the person table). */
+    private static boolean joinedPerson() {
+        return TimingExecuterListener.timing.keySet().stream()
+                .anyMatch(sql -> { String q = sql.toLowerCase(); return q.contains("join") && q.contains("jp_person"); });
+    }
+
     /**
      * True if any executed query is a deferred vertex-property fetch (the pre-join fallback hydration
      * path) against a vertex table. Excludes the id-only "select id from ... where id in (...)" shape
@@ -120,6 +126,7 @@ public class JdbcJoinPushdownTest {
         assertEquals(12L, (long) g.V().both("owns").count().next());
         // person neighbours only: root->p1, root->p2, h1->p1 => 3
         assertEquals(3L, (long) g.V().both("owns").hasLabel("person").count().next());
+        assertTrue("both() with target filter must use the join path", joinedPerson());
     }
 
     @Test

--- a/unipop-jdbc/test/org/unipop/jdbc/join/TranslatorAliasTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/join/TranslatorAliasTest.java
@@ -31,5 +31,6 @@ public class TranslatorAliasTest {
         Condition c = t.translate(PredicatesHolderFactory.predicate(new HasContainer("status", P.eq("open"))));
         String sql = DSL.using(SQLDialect.POSTGRES).renderInlined(c);
         assertTrue("expected unqualified column, got: " + sql, sql.contains("status") && !sql.contains("\"v\".\"status\""));
+        assertTrue("no-alias plain column must render UNquoted, got: " + sql, !sql.contains("\"status\""));
     }
 }

--- a/unipop-jdbc/test/org/unipop/jdbc/join/TranslatorAliasTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/join/TranslatorAliasTest.java
@@ -1,0 +1,35 @@
+package org.unipop.jdbc.join;
+
+import org.apache.tinkerpop.gremlin.process.traversal.P;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer;
+import org.jooq.Condition;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
+import org.junit.Test;
+import org.unipop.jdbc.utils.JdbcPredicatesTranslator;
+import org.unipop.query.predicates.PredicatesHolderFactory;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertTrue;
+
+public class TranslatorAliasTest {
+
+    @Test
+    public void aliasQualifiesColumns() {
+        JdbcPredicatesTranslator t = new JdbcPredicatesTranslator(
+                Collections.emptySet(), Collections.emptySet(), Collections.emptySet(),
+                Collections.emptySet(), Collections.emptySet(), "v");
+        Condition c = t.translate(PredicatesHolderFactory.predicate(new HasContainer("status", P.eq("open"))));
+        String sql = DSL.using(SQLDialect.POSTGRES).renderInlined(c);
+        assertTrue("expected qualified column, got: " + sql, sql.contains("\"v\".\"status\""));
+    }
+
+    @Test
+    public void noAliasIsUnqualified() {
+        JdbcPredicatesTranslator t = new JdbcPredicatesTranslator(Collections.emptySet());
+        Condition c = t.translate(PredicatesHolderFactory.predicate(new HasContainer("status", P.eq("open"))));
+        String sql = DSL.using(SQLDialect.POSTGRES).renderInlined(c);
+        assertTrue("expected unqualified column, got: " + sql, sql.contains("status") && !sql.contains("\"v\".\"status\""));
+    }
+}


### PR DESCRIPTION
## What

Pushes a vertex-return adjacency hop's target `has()` + `order().by()` + `limit()` into a **single SQL JOIN** (hydrate + filter + bound in the DB) instead of the current behaviour: fetch the *entire* adjacency, resolve the neighbours in a second deferred query, then filter/limit in memory. For `out()`/`in()`/`both()` with a target filter, ordering, or property read, the DB now bounds the result server-side.

Motivation: on the current path, `g.V(x).out('rel').has(...).limit(n)` reads all of `x`'s edges and hydrates every neighbour before trimming — `limit(n)` buys no early exit, and hub vertices materialize their whole edge set. This is `O(all matched adjacency)` regardless of the limit.

## Approach

Rides the codebase's existing **deferred-vs-hydrated seam** rather than adding a parallel path. `SearchVertexQuery` gains target intent (`targetPredicates` / `targetOrders` / `targetLimit` / `hydrateTarget`); the JDBC `RowController`, when the hop is joinable, returns `UniEdge`s whose target endpoint is **already hydrated and filtered** via a join, so the step's existing deferred-hydration becomes a no-op. Otherwise it returns id-only edges exactly as before. `RangeGlobalStep`/`OrderGlobalStep` stay in the traversal and re-trim/re-sort globally, so per-pair SQL `ORDER BY … LIMIT n` is a safe fetch-reduction.

Key design points:
- **Fan-out with narrowing.** One join per `(edge schema × surviving vertex schema × direction)`. A `hasLabel` (or PartitionStrategy's injected label `has`) prunes the fan-out to the matching vertex table(s) via the existing `toPredicates` abort→skip mechanism — same way `g.V().hasLabel()` narrows today.
- **`both()`** runs as two directed joins (OUT + IN). Each join edge is flagged `adjacencyJoinDirected` (out = source-shell, in = hydrated target); the vertex step maps flagged edges by the source only, eliminating the `edge.vertices(BOTH)` double-fan. Verified: `g.V().both('owns').count()` = 12, not 24.
- **All-or-nothing:** a join invocation either honours filter+order+limit in SQL, or ignores all three and returns id-only edges — never applies a limit/order to a plain edge fetch (which would under-produce).
- **Fallback matrix** (byte-for-byte the deferred path): bare `limit` (no filter/order/props — would conjure a fan-out where today there's none), an order column absent on a surviving fan-out schema (order+limit push together or not at all), an untranslatable predicate, `InnerRowEdgeSchema` (exact-class guard), and non-JDBC providers.
- **Kill-switch:** `jdbc.joinPushdown` (default on) disables the whole path.

## Core changes (small, guarded)

- `UniEdge` gains an `adjacencyJoinDirected` flag (default false); `UniGraphVertexStep` branches on it only for flagged edges — every other provider and the deferred fallback are untouched (`mapDir == direction`, original `vertexToVertex`).
- `AbstractRowSchema.getSearch` refactored to a `buildTranslator(alias)` helper (behaviour-preserving); `JdbcPredicatesTranslator` gains an optional column alias so join conditions qualify `e.`/`v.` (both tables can share a column like `org_id`). `alias == null` renders byte-for-byte as before.

## Testing

- New `JdbcJoinPushdownTest` (11) against embedded PostgreSQL: out/in/both correctness + multiplicity, `hasLabel` narrowing (only the matching table joined), fan-out union, `order().by()` global top-n, bare-limit fallback, kill-switch, inner-edge/order-column full-fallback, and mechanism assertions (a JOIN was emitted / the deferred fetch was skipped). Plus `TranslatorAliasTest` (2) and core `SearchVertexQueryTest` (2).
- Regression baselines **unchanged**: `JdbcAdjacencyFilterTest` 8/8; `JdbcFeatureTest` 20 fail / 0 err; `JdbcStructureSuite` 30 fail / 16 err (the core step change touches every vertex traversal — these confirm no shift). 1864 feature-suite tests pass, many of them `out().values()` queries now routed through the join path.

## Out of scope (documented follow-ups)

- Edge-side `LIMIT` pushdown for a *bare* vertex-return `limit` (no filter/order/props) — today it falls back.
- Per-source top-n (`ROW_NUMBER() OVER (PARTITION BY …)`) — v1 pushes only the global limit.
- Multi-hop chains; `InnerRowEdgeSchema` (denormalized) join; non-JDBC providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
