### PR TITLE
perf(jdbc): push RangeGlobalStep offset+limit into SQL for single-schema queries

### DIFF
--- a/unipop-core/src/org/unipop/process/Offsettable.java
+++ b/unipop-core/src/org/unipop/process/Offsettable.java
@@ -1,0 +1,8 @@
+package org.unipop.process;
+
+/** A search step that can receive a range low-bound (offset) and report how much of it the
+ *  provider pushed to the backend (0 if none). See UniGraphRangeStep. */
+public interface Offsettable {
+    void setOffset(int low);
+    int getPushedOffset();
+}

--- a/unipop-core/src/org/unipop/process/graph/UniGraphStep.java
+++ b/unipop-core/src/org/unipop/process/graph/UniGraphStep.java
@@ -10,6 +10,7 @@ import org.javatuples.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.unipop.process.order.Orderable;
+import org.unipop.process.Offsettable;
 import org.unipop.util.ConversionUtils;
 import org.unipop.process.predicate.ReceivesPredicatesHolder;
 import org.unipop.process.properties.PropertyFetcher;
@@ -23,13 +24,15 @@ import org.unipop.structure.UniGraph;
 import java.util.*;
 import java.util.stream.Stream;
 
-public class UniGraphStep<S,E extends Element> extends GraphStep<S,E> implements ReceivesPredicatesHolder<S, E>, PropertyFetcher, Orderable, Profiling{
+public class UniGraphStep<S,E extends Element> extends GraphStep<S,E> implements ReceivesPredicatesHolder<S, E>, PropertyFetcher, Orderable, Profiling, Offsettable{
     private static final Logger logger = LoggerFactory.getLogger(UniGraphStep.class);
     private StepDescriptor stepDescriptor;
     private List<SearchQuery.SearchController>  controllers;
     private PredicatesHolder predicates = PredicatesHolderFactory.empty();
     private Set<String> propertyKeys;
     private int limit;
+    private int offset = 0;
+    private SearchQuery<E> lastQuery;
     private List<Pair<String, Order>> orders;
 
     public UniGraphStep(GraphStep<S, E> originalStep, ControllerManager controllerManager) {
@@ -52,6 +55,10 @@ public class UniGraphStep<S,E extends Element> extends GraphStep<S,E> implements
         ).map(HasContainer::getKey).forEach(this::addPropertyKey);
 
         SearchQuery<E> searchQuery = new SearchQuery<>(returnClass, predicates, limit, propertyKeys, orders, stepDescriptor, traversal);
+        // Offset can only be pushed when a single controller resolves the query; otherwise results
+        // merge across providers and a per-controller OFFSET would drop rows from the global window.
+        searchQuery.setOffset(controllers.size() == 1 ? offset : 0);
+        this.lastQuery = searchQuery;
         logger.debug("Executing query: ", searchQuery);
         return controllers.stream().<Iterator<E>>map(controller -> controller.search(searchQuery)).flatMap(ConversionUtils::asStream).distinct().iterator();
     }
@@ -72,6 +79,11 @@ public class UniGraphStep<S,E extends Element> extends GraphStep<S,E> implements
         this.limit = limit;
     }
 
+    @Override
+    public void setOffset(int offset) { this.offset = offset; }
+
+    @Override
+    public int getPushedOffset() { return lastQuery == null ? 0 : lastQuery.getPushedOffset(); }
 
     @Override
     public void addPropertyKey(String key) {

--- a/unipop-core/src/org/unipop/process/range/UniGraphRangeStep.java
+++ b/unipop-core/src/org/unipop/process/range/UniGraphRangeStep.java
@@ -1,0 +1,86 @@
+package org.unipop.process.range;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Step;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.AbstractStep;
+import org.apache.tinkerpop.gremlin.process.traversal.util.FastNoSuchElementException;
+import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
+import org.unipop.process.Offsettable;
+
+import java.util.NoSuchElementException;
+
+/**
+ * Schema-aware replacement for a global RangeGlobalStep that follows a UniGraph search step.
+ * Applies the RESIDUAL range: range(low - pushed, high - pushed), where `pushed` is how much of the
+ * offset the provider already applied as SQL OFFSET (read from the source step lazily, once the first
+ * upstream element arrives -- by then the source's search has run and set pushedOffset). When the
+ * provider pushed nothing (fan-out, federated, non-JDBC, offset not applicable) pushed==0 and this is
+ * exactly a native range(low, high) in memory.
+ */
+public final class UniGraphRangeStep<S> extends AbstractStep<S, S> {
+
+    private final long low;
+    private final long high;   // -1 == unbounded
+    private final Step<?, ?> source;
+
+    private boolean resolved = false;
+    private long effLow;
+    private long effHigh;      // -1 == unbounded
+    private long counter = 0L;
+
+    public UniGraphRangeStep(Traversal.Admin traversal, long low, long high, Step<?, ?> source) {
+        super(traversal);
+        this.low = low;
+        this.high = high;
+        this.source = source;
+    }
+
+    private void resolve() {
+        int pushed = (source instanceof Offsettable) ? ((Offsettable) source).getPushedOffset() : 0;
+        this.effLow = Math.max(0L, low - pushed);
+        this.effHigh = (high == -1L) ? -1L : Math.max(0L, high - pushed);
+        this.resolved = true;
+    }
+
+    @Override
+    protected Traverser.Admin<S> processNextStart() throws NoSuchElementException {
+        while (true) {
+            // Pulling the first start triggers the upstream search, which sets pushedOffset.
+            final Traverser.Admin<S> start = this.starts.next();  // throws FastNoSuchElement when drained
+            if (!resolved) resolve();
+
+            if (effHigh != -1L && counter >= effHigh) {
+                throw FastNoSuchElementException.instance();      // window closed -> stop pulling
+            }
+
+            final long bulk = start.bulk();
+            // number of items in [counter, counter+bulk) that fall within [effLow, effHigh)
+            final long from = counter;
+            final long to = counter + bulk;
+            counter = to;
+
+            final long windowStart = effLow;
+            final long windowEnd = (effHigh == -1L) ? Long.MAX_VALUE : effHigh;
+            final long emitFrom = Math.max(from, windowStart);
+            final long emitTo = Math.min(to, windowEnd);
+            if (emitTo > emitFrom) {
+                start.setBulk(emitTo - emitFrom);
+                return start;
+            }
+            // else: entirely before the window -> skip, pull next
+        }
+    }
+
+    @Override
+    public void reset() {
+        super.reset();
+        this.resolved = false;
+        this.counter = 0L;
+    }
+
+    @Override
+    public String toString() {
+        return StringFactory.stepString(this, low, high);
+    }
+}

--- a/unipop-core/src/org/unipop/process/range/UniGraphRangeStepStrategy.java
+++ b/unipop-core/src/org/unipop/process/range/UniGraphRangeStepStrategy.java
@@ -4,12 +4,10 @@ import com.google.common.collect.Sets;
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
-import org.apache.tinkerpop.gremlin.process.traversal.step.filter.DedupGlobalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeGlobalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.OrderGlobalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
-import org.unipop.process.Offsettable;
 import org.unipop.process.graph.UniGraphStep;
 import org.unipop.process.graph.UniGraphStepStrategy;
 import org.unipop.process.order.UniGraphOrderStrategy;
@@ -40,10 +38,13 @@ public class UniGraphRangeStepStrategy extends AbstractTraversalStrategy<Travers
         }
     }
 
-    /** Walk back past intervening OrderGlobalStep/DedupGlobalStep to a UniGraphStep, else null. */
+    /** Walk back past an intervening OrderGlobalStep (also pushed to SQL, so OFFSET-after-ORDER-BY
+     *  stays correct) to a UniGraphStep, else null. Does NOT skip DedupGlobalStep: dedup() is not
+     *  pushed to SQL, so folding OFFSET over raw pre-dedup rows would skip the wrong rows -- a
+     *  dedup() between the source and range must leave the native RangeGlobalStep in place. */
     private UniGraphStep<?, ?> sourceGraphStep(RangeGlobalStep<?> range) {
         Step<?, ?> prev = range.getPreviousStep();
-        while (prev instanceof OrderGlobalStep || prev instanceof DedupGlobalStep) {
+        while (prev instanceof OrderGlobalStep) {
             prev = prev.getPreviousStep();
         }
         return (prev instanceof UniGraphStep) ? (UniGraphStep<?, ?>) prev : null;

--- a/unipop-core/src/org/unipop/process/range/UniGraphRangeStepStrategy.java
+++ b/unipop-core/src/org/unipop/process/range/UniGraphRangeStepStrategy.java
@@ -1,0 +1,51 @@
+package org.unipop.process.range;
+
+import com.google.common.collect.Sets;
+import org.apache.tinkerpop.gremlin.process.traversal.Step;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.DedupGlobalStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeGlobalStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.OrderGlobalStep;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
+import org.unipop.process.Offsettable;
+import org.unipop.process.graph.UniGraphStep;
+import org.unipop.process.graph.UniGraphStepStrategy;
+import org.unipop.process.order.UniGraphOrderStrategy;
+
+import java.util.Set;
+
+/** Replaces a GLOBAL RangeGlobalStep that follows a UniGraphStep with a schema-aware
+ *  UniGraphRangeStep, folding the range low-bound as an offset onto the UniGraphStep so the
+ *  controller can push SQL OFFSET when the query resolves to a single schema. */
+public class UniGraphRangeStepStrategy extends AbstractTraversalStrategy<TraversalStrategy.ProviderOptimizationStrategy>
+        implements TraversalStrategy.ProviderOptimizationStrategy {
+
+    @Override
+    public Set<Class<? extends ProviderOptimizationStrategy>> applyPrior() {
+        return Sets.newHashSet(UniGraphStepStrategy.class, UniGraphOrderStrategy.class);
+    }
+
+    @Override
+    public void apply(Traversal.Admin<?, ?> traversal) {
+        for (RangeGlobalStep<?> range : TraversalHelper.getStepsOfAssignableClass(RangeGlobalStep.class, traversal)) {
+            UniGraphStep<?, ?> source = sourceGraphStep(range);
+            if (source == null) continue;                 // not fed by a UniGraphStep -> leave native
+            long low = range.getLowRange();
+            long high = range.getHighRange();
+            source.setOffset(low > Integer.MAX_VALUE ? 0 : (int) low);
+            UniGraphRangeStep<?> uni = new UniGraphRangeStep<>(traversal, low, high, source);
+            TraversalHelper.replaceStep((Step) range, uni, traversal);
+        }
+    }
+
+    /** Walk back past intervening OrderGlobalStep/DedupGlobalStep to a UniGraphStep, else null. */
+    private UniGraphStep<?, ?> sourceGraphStep(RangeGlobalStep<?> range) {
+        Step<?, ?> prev = range.getPreviousStep();
+        while (prev instanceof OrderGlobalStep || prev instanceof DedupGlobalStep) {
+            prev = prev.getPreviousStep();
+        }
+        return (prev instanceof UniGraphStep) ? (UniGraphStep<?, ?>) prev : null;
+    }
+}

--- a/unipop-core/src/org/unipop/process/range/UniGraphRangeStepStrategy.java
+++ b/unipop-core/src/org/unipop/process/range/UniGraphRangeStepStrategy.java
@@ -34,6 +34,7 @@ public class UniGraphRangeStepStrategy extends AbstractTraversalStrategy<Travers
             long high = range.getHighRange();
             source.setOffset(low > Integer.MAX_VALUE ? 0 : (int) low);
             UniGraphRangeStep<?> uni = new UniGraphRangeStep<>(traversal, low, high, source);
+            TraversalHelper.copyLabels(range, uni, false);   // replaceStep does not transfer labels
             TraversalHelper.replaceStep((Step) range, uni, traversal);
         }
     }

--- a/unipop-core/src/org/unipop/process/strategyregistrar/StandardStrategyProvider.java
+++ b/unipop-core/src/org/unipop/process/strategyregistrar/StandardStrategyProvider.java
@@ -7,6 +7,7 @@ import org.unipop.process.coalesce.UniGraphCoalesceStepStrategy;
 import org.unipop.process.edge.EdgeStepsStrategy;
 import org.unipop.process.order.UniGraphOrderStrategy;
 import org.unipop.process.properties.UniGraphPropertiesStrategy;
+import org.unipop.process.range.UniGraphRangeStepStrategy;
 import org.unipop.process.repeat.UniGraphRepeatStepStrategy;
 import org.unipop.process.graph.UniGraphStepStrategy;
 import org.unipop.process.vertex.UniGraphVertexStepStrategy;
@@ -24,7 +25,8 @@ public class StandardStrategyProvider implements StrategyProvider {
                 new UniGraphCoalesceStepStrategy(),
                 new UniGraphWhereStepStrategy(),
                 new UniGraphRepeatStepStrategy(),
-                new UniGraphOrderStrategy());
+                new UniGraphOrderStrategy(),
+                new UniGraphRangeStepStrategy());
         TraversalStrategies.GlobalCache.getStrategies(Graph.class).toList().forEach(traversalStrategies::addStrategies);
         return traversalStrategies;
     }

--- a/unipop-core/src/org/unipop/query/search/SearchQuery.java
+++ b/unipop-core/src/org/unipop/query/search/SearchQuery.java
@@ -18,6 +18,8 @@ public class SearchQuery<E extends Element> extends PredicateQuery<E> {
     private final int limit;
     private Set<String> propertyKeys;
     private List<Pair<String, Order>> orders;
+    private int offset = 0;
+    private int pushedOffset = 0;
 
     public SearchQuery(Class<E> returnType, PredicatesHolder predicates, int limit, Set<String> propertyKeys, List<Pair<String, Order>> orders, StepDescriptor stepDescriptor, Traversal traversal) {
         super(predicates, stepDescriptor, traversal);
@@ -42,6 +44,11 @@ public class SearchQuery<E extends Element> extends PredicateQuery<E> {
     public List<Pair<String, Order>> getOrders() {
         return orders;
     }
+
+    public int getOffset() { return offset; }
+    public void setOffset(int offset) { this.offset = offset; }
+    public int getPushedOffset() { return pushedOffset; }
+    public void setPushedOffset(int pushedOffset) { this.pushedOffset = pushedOffset; }
 
     public interface SearchController extends UniQueryController {
         <E extends Element> Iterator<E> search(SearchQuery<E> uniQuery);

--- a/unipop-core/test/org/unipop/process/range/UniGraphRangeStepTest.java
+++ b/unipop-core/test/org/unipop/process/range/UniGraphRangeStepTest.java
@@ -1,0 +1,64 @@
+package org.unipop.process.range;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.ScalarMapStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.EmptyStep;
+import org.apache.tinkerpop.gremlin.process.traversal.traverser.B_O_Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.util.DefaultTraversal;
+import org.junit.Test;
+import org.unipop.process.Offsettable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class UniGraphRangeStepTest {
+
+    // A trivial source step that reports a fixed pushedOffset.
+    // TP 3.8.1 note: MapStep here is a bare marker class (no map()/processNextStart());
+    // those live on ScalarMapStep, which extends MapStep. Extend that instead.
+    static class FakeSource extends ScalarMapStep<Object, Object> implements Offsettable {
+        private final int pushed;
+        FakeSource(Traversal.Admin t, int pushed) { super(t); this.pushed = pushed; }
+        @Override protected Object map(Traverser.Admin<Object> t) { return t.get(); }
+        @Override public void setOffset(int low) {}
+        @Override public int getPushedOffset() { return pushed; }
+    }
+
+    private List<Object> run(long low, long high, int pushed, int count) {
+        DefaultTraversal t = new DefaultTraversal();
+        FakeSource source = new FakeSource(t, pushed);
+        UniGraphRangeStep<Object> step = new UniGraphRangeStep<>(t, low, high, source);
+        for (int i = 0; i < count; i++) {
+            step.addStart(new B_O_Traverser<>((Object) Integer.valueOf(i), 1L).asAdmin());
+        }
+        List<Object> out = new ArrayList<>();
+        // Unwrap the traverser's value: Traverser.Admin.equals() only matches other Traversers,
+        // so comparing raw next() results against plain Integers would always fail List.equals().
+        while (step.hasNext()) out.add(step.next().get());
+        return out;
+    }
+
+    @Test public void noPushAppliesFullRange() {
+        // range(2,4) over [0..9], pushed=0 -> elements 2,3
+        assertEquals(java.util.Arrays.asList(2, 3), run(2, 4, 0, 10));
+    }
+
+    @Test public void fullPushPassesThrough() {
+        // DB already did OFFSET 2 LIMIT 2, so upstream is the 2-row window [x,y]; pushed=2,
+        // residual range(0,2) -> pass through both.
+        assertEquals(java.util.Arrays.asList(0, 1), run(2, 4, 2, 2));
+    }
+
+    @Test public void unboundedHighSkipsLowTakesRest() {
+        // skip(3): range(3,-1), pushed=0 -> 3,4,5,6,7,8,9
+        assertEquals(java.util.Arrays.asList(3, 4, 5, 6, 7, 8, 9), run(3, -1, 0, 10));
+    }
+
+    @Test public void emptyUpstreamEmptyOut() {
+        assertEquals(java.util.Collections.emptyList(), run(2, 4, 0, 0));
+    }
+}

--- a/unipop-core/test/org/unipop/process/range/UniGraphRangeStepTest.java
+++ b/unipop-core/test/org/unipop/process/range/UniGraphRangeStepTest.java
@@ -2,9 +2,7 @@ package org.unipop.process.range;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.ScalarMapStep;
-import org.apache.tinkerpop.gremlin.process.traversal.step.util.EmptyStep;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.B_O_Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.util.DefaultTraversal;
 import org.junit.Test;

--- a/unipop-core/test/org/unipop/query/search/SearchQueryOffsetTest.java
+++ b/unipop-core/test/org/unipop/query/search/SearchQueryOffsetTest.java
@@ -1,0 +1,23 @@
+package org.unipop.query.search;
+
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.junit.Test;
+import org.unipop.query.predicates.PredicatesHolderFactory;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+public class SearchQueryOffsetTest {
+    @Test
+    public void offsetDefaultsZeroAndRoundTrips() {
+        SearchQuery<Vertex> q = new SearchQuery<>(Vertex.class, PredicatesHolderFactory.empty(),
+                60, Collections.emptySet(), null, null, null);
+        assertEquals(0, q.getOffset());
+        assertEquals(0, q.getPushedOffset());
+        q.setOffset(40);
+        q.setPushedOffset(40);
+        assertEquals(40, q.getOffset());
+        assertEquals(40, q.getPushedOffset());
+    }
+}

--- a/unipop-jdbc/src/org/unipop/jdbc/controller/simple/RowController.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/controller/simple/RowController.java
@@ -94,6 +94,13 @@ public class RowController implements SimpleController {
         Map<JdbcSchema<E>, Select> selects = schemas.stream()
                 .filter(schema -> this.traversalFilter.filter(schema, uniQuery.getTraversal())).collect(collector);
 
+        // Offset push: only safe when exactly one schema survives (single table, total order in SQL).
+        // Otherwise pushedOffset stays 0 and UniGraphRangeStep applies the full range in memory.
+        if (uniQuery.getOffset() > 0 && selects.size() == 1) {
+            uniQuery.setPushedOffset(uniQuery.getOffset());
+            JdbcSchema<E> only = selects.keySet().iterator().next();
+            selects.put(only, only.getSearch(uniQuery, only.toPredicates(uniQuery.getPredicates())));  // rebuild with OFFSET
+        }
 
         return this.search(uniQuery, selects, collector);
     }

--- a/unipop-jdbc/src/org/unipop/jdbc/schemas/AbstractRowSchema.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/schemas/AbstractRowSchema.java
@@ -87,7 +87,9 @@ public abstract class AbstractRowSchema<E extends Element> extends AbstractEleme
         }
 
         Condition conditions = buildTranslator(null).translate(predicatesHolder);
-        int finalLimit = query.getLimit() < 0 ? Integer.MAX_VALUE : query.getLimit();
+        int high = query.getLimit() < 0 ? Integer.MAX_VALUE : query.getLimit();
+        int off = query.getPushedOffset();   // >0 only when the controller decided to push (single schema)
+        int count = (high == Integer.MAX_VALUE) ? Integer.MAX_VALUE : Math.max(0, high - off);
 
         SelectConditionStep<Record> where = createSqlQuery(query.getPropertyKeys())
                 .where(conditions);
@@ -100,10 +102,10 @@ public abstract class AbstractRowSchema<E extends Element> extends AbstractEleme
                             field(getFieldByPropertyKey(order.getValue0())).asc() :
                             field(getFieldByPropertyKey(order.getValue0())).desc()).collect(Collectors.toList());
             if (orderValues.size() > 0)
-                return where.orderBy(orderValues).limit(finalLimit);
+                return off > 0 ? where.orderBy(orderValues).limit(off, count) : where.orderBy(orderValues).limit(high);
         }
 
-        return where.limit(finalLimit);
+        return off > 0 ? where.limit(off, count) : where.limit(high);
 
     }
 

--- a/unipop-jdbc/test-resources/configuration/rangepushdown/graph.json
+++ b/unipop-jdbc/test-resources/configuration/rangepushdown/graph.json
@@ -1,0 +1,12 @@
+{
+  "class": "org.unipop.jdbc.JdbcSourceProvider",
+  "driver": "org.postgresql.Driver",
+  "address": ["jdbc:postgresql://localhost:54329/postgres"],
+  "user": "postgres",
+  "sqlDialect": "POSTGRES",
+  "vertices": [
+    { "table": "jr_host",   "id": "@id", "label": "host",   "properties": { "name": "@name" }, "dynamicProperties": false },
+    { "table": "jr_person", "id": "@id", "label": "person", "properties": { "name": "@name" }, "dynamicProperties": false }
+  ],
+  "edges": []
+}

--- a/unipop-jdbc/test/org/unipop/jdbc/range/JdbcRangePushdownTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/range/JdbcRangePushdownTest.java
@@ -1,0 +1,73 @@
+package org.unipop.jdbc.range;
+
+import org.apache.commons.configuration2.BaseConfiguration;
+import org.apache.commons.configuration2.Configuration;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.unipop.jdbc.suite.EmbeddedPostgresServer;
+import org.unipop.jdbc.utils.TimingExecuterListener;
+import org.unipop.process.range.UniGraphRangeStep;
+import org.unipop.structure.UniGraph;
+
+import java.io.File;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class JdbcRangePushdownTest {
+
+    private static GraphTraversalSource g;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        EmbeddedPostgresServer.ensureStarted();
+        Class.forName("org.postgresql.Driver");
+        try (Connection c = DriverManager.getConnection(EmbeddedPostgresServer.URL, EmbeddedPostgresServer.USER, "");
+             Statement s = c.createStatement()) {
+            s.execute("DROP TABLE IF EXISTS jr_host");
+            s.execute("DROP TABLE IF EXISTS jr_person");
+            s.execute("CREATE TABLE jr_host   (id varchar(100) primary key, name varchar(50))");
+            s.execute("CREATE TABLE jr_person (id varchar(100) primary key, name varchar(50))");
+            // hosts sorted by name: alpha,bravo,charlie,delta,echo  (5 rows)
+            s.execute("INSERT INTO jr_host VALUES ('h1','alpha'),('h2','bravo'),('h3','charlie'),('h4','delta'),('h5','echo')");
+            s.execute("INSERT INTO jr_person VALUES ('p1','foxtrot'),('p2','golf'),('p3','hotel')");
+        }
+        String dir = new File(JdbcRangePushdownTest.class.getResource("/configuration/rangepushdown/graph.json").toURI()).getParent();
+        Configuration conf = new BaseConfiguration();
+        conf.setProperty(Graph.GRAPH, UniGraph.class.getName());
+        conf.setProperty("graphName", "rangepushdown");
+        conf.setProperty("providers", dir);
+        g = UniGraph.open(conf).traversal();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception { if (g != null) g.close(); }
+
+    @Before
+    public void clearTiming() { TimingExecuterListener.timing.clear(); }
+
+    /** Largest row count any executed query against a table fetched. */
+    private static int maxFetch(String table) {
+        return TimingExecuterListener.timing.entrySet().stream()
+                .filter(e -> e.getKey().toLowerCase().contains(table))
+                .mapToInt(e -> e.getValue().getValue1()).max().orElse(-1);
+    }
+
+    @Test
+    public void strategyReplacesGlobalRangeAfterGraphStep() {
+        GraphTraversal<?, ?> t = g.V().hasLabel("host").order().by("name").range(2, 4);
+        t.hasNext(); // force strategy application + execution
+        assertTrue("expected a UniGraphRangeStep in the compiled traversal",
+                TraversalHelper.hasStepOfAssignableClass(UniGraphRangeStep.class, t.asAdmin()));
+    }
+}

--- a/unipop-jdbc/test/org/unipop/jdbc/range/JdbcRangePushdownTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/range/JdbcRangePushdownTest.java
@@ -70,4 +70,38 @@ public class JdbcRangePushdownTest {
         assertTrue("expected a UniGraphRangeStep in the compiled traversal",
                 TraversalHelper.hasStepOfAssignableClass(UniGraphRangeStep.class, t.asAdmin()));
     }
+
+    @Test
+    public void singleSchemaPushesOffset() {
+        // hosts by name: alpha,bravo,charlie,delta,echo ; range(2,4) -> charlie,delta
+        List<Object> names = g.V().hasLabel("host").order().by("name").range(2, 4).values("name").toList();
+        assertEquals(java.util.Arrays.asList("charlie", "delta"), names);
+        // OFFSET pushed -> only 2 rows fetched from jr_host (not 4)
+        assertEquals("expected OFFSET pushed: 2 rows fetched, not 4", 2, maxFetch("jr_host"));
+    }
+
+    @Test
+    public void skipPushesOffsetUnbounded() {
+        // skip(3) -> delta,echo ; OFFSET 3 no limit -> 2 rows fetched
+        List<Object> names = g.V().hasLabel("host").order().by("name").skip(3).values("name").toList();
+        assertEquals(java.util.Arrays.asList("delta", "echo"), names);
+        assertEquals(2, maxFetch("jr_host"));
+    }
+
+    @Test
+    public void pureLimitUnchanged() {
+        // limit(2) -> alpha,bravo ; offset=0 -> today's fetch-reduction (LIMIT 2), 2 rows
+        List<Object> names = g.V().hasLabel("host").order().by("name").limit(2).values("name").toList();
+        assertEquals(java.util.Arrays.asList("alpha", "bravo"), names);
+        assertEquals(2, maxFetch("jr_host"));
+    }
+
+    @Test
+    public void dedupBetweenSourceAndRangeDoesNotPushOffset() {
+        // dedup() between g.V() and range() must NOT push OFFSET (dedup isn't pushed to SQL, so
+        // OFFSET over raw rows would skip the wrong rows). Correct window size, and OFFSET not pushed.
+        long n = g.V().hasLabel("host").dedup().range(1, 3).count().next();
+        assertEquals(2L, n);                       // window size (5 distinct hosts -> range(1,3) = 2)
+        assertTrue("dedup-intervening must not push OFFSET (fetches all, not 2)", maxFetch("jr_host") > 2);
+    }
 }

--- a/unipop-jdbc/test/org/unipop/jdbc/range/JdbcRangePushdownTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/range/JdbcRangePushdownTest.java
@@ -123,6 +123,14 @@ public class JdbcRangePushdownTest {
     }
 
     @Test
+    public void labelOnRangeStepIsPreserved() {
+        // If replaceStep dropped the 'a' label, select('a') would fail/empty.
+        List<Object> names = g.V().hasLabel("host").order().by("name").limit(2).as("a")
+                .select("a").values("name").toList();
+        assertEquals(java.util.Arrays.asList("alpha", "bravo"), names);
+    }
+
+    @Test
     public void localRangeStaysNative() {
         // range(local,...) must NOT be replaced -> no UniGraphRangeStep for the local range
         GraphTraversal<?, ?> t = g.V().hasLabel("host").fold()

--- a/unipop-jdbc/test/org/unipop/jdbc/range/JdbcRangePushdownTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/range/JdbcRangePushdownTest.java
@@ -104,4 +104,31 @@ public class JdbcRangePushdownTest {
         assertEquals(2L, n);                       // window size (5 distinct hosts -> range(1,3) = 2)
         assertTrue("dedup-intervening must not push OFFSET (fetches all, not 2)", maxFetch("jr_host") > 2);
     }
+
+    @Test
+    public void multiSchemaFanOutDoesNotPushOffset() {
+        // No hasLabel -> host(5)+person(3)=8 by name: alpha,bravo,charlie,delta,echo,foxtrot,golf,hotel
+        // range(2,4) -> charlie,delta
+        List<Object> names = g.V().order().by("name").range(2, 4).values("name").toList();
+        assertEquals(java.util.Arrays.asList("charlie", "delta"), names);
+        // offset NOT pushed: each schema fetch-reduces with LIMIT 4 (fetches up to 4, not 2)
+        assertTrue("multi-schema must not push OFFSET (in-memory residual)", maxFetch("jr_host") > 2);
+    }
+
+    @Test
+    public void orderlessSingleSchemaRangeReturnsWindowSize() {
+        // range(1,4) with no order() -> 3 elements (spec-correct arbitrary window)
+        long n = g.V().hasLabel("host").range(1, 4).count().next();
+        assertEquals(3L, n);
+    }
+
+    @Test
+    public void localRangeStaysNative() {
+        // range(local,...) must NOT be replaced -> no UniGraphRangeStep for the local range
+        GraphTraversal<?, ?> t = g.V().hasLabel("host").fold()
+                .range(org.apache.tinkerpop.gremlin.process.traversal.Scope.local, 0, 2);
+        t.hasNext();
+        assertTrue("local range must remain native",
+                !TraversalHelper.hasStepOfAssignableClass(UniGraphRangeStep.class, t.asAdmin()));
+    }
 }


### PR DESCRIPTION
## What

Pushes the **full** `RangeGlobalStep` (offset *and* limit) into SQL for the flat graph-step path, instead of only the high-range limit we push today. `g.V().hasLabel('host').order().by('name').range(40, 60)` now renders `ORDER BY name OFFSET 40 LIMIT 20` and fetches 20 rows, rather than fetching 60 and skipping 40 in memory.

Today only `rangeGlobalStep.getHighRange()` folds onto the search step as `limit`; the low bound (offset) is applied in-memory by a retained native `RangeGlobalStep`. Offset can't be a *fetch-reduction* the way limit is (skipping per-source/per-schema drops rows from the global window), so pushing it requires the in-memory range to stop applying the skip — which is only safe when the query resolves to a single schema.

## Approach (schema-aware replacement, no compile-time guess)

A `UniGraphRangeStepStrategy` replaces a global `RangeGlobalStep` that follows a `UniGraphStep` with a **`UniGraphRangeStep`** — a step that doesn't disappear, it *adapts at runtime*. The controller decides at execution time (when it knows how many schemas survived) whether it pushed a SQL `OFFSET`, reports how much via `pushedOffset` on the `SearchQuery`, and the step applies the **residual** in memory:

```
UniGraphRangeStep applies  range(low − pushedOffset, high − pushedOffset)
```

- **Single controller, single surviving schema, offset>0** → `RowController` renders `OFFSET low LIMIT (high−low)`, sets `pushedOffset=low` → residual `range(0, high−low)` = pass-through (DB did the skip; only `high−low` rows fetched).
- **Everything else** (multi-schema fan-out, multi-controller/federated, pure `limit()`, adjacency, dedup-intervening) → `pushedOffset=0` → residual `range(low, high)` in memory = **exactly today's behavior**.

Correctness never depends on a compile-time single-schema proof, and the non-pushing path produces byte-identical SQL to before.

## Key correctness points

- **`pushedOffset` read lazily** — the step reads it only after the first upstream element arrives (by then the source's search has run and set it); empty upstream → residual irrelevant.
- **Dedup blocks the offset fold** — the strategy's walk-back to the source `UniGraphStep` skips only `OrderGlobalStep` (order *is* pushed to the same SQL, so `OFFSET`-after-`ORDER BY` is correct), **not** `DedupGlobalStep` (dedup isn't pushed — an `OFFSET` over raw pre-dedup rows would skip the wrong rows). A dedup between source and range → native range, no push.
- **Labels preserved** — `TraversalHelper.copyLabels` transfers step labels on replacement, so `g.V().limit(2).as('a')…select('a')` keeps working.
- **`off==0` path is byte-identical** to the previous `getSearch` limit rendering; the single-schema gate lives in one controller (federated multi-provider never pushes).

## Testing

- New `JdbcRangePushdownTest` (9, embedded PostgreSQL): single-schema offset push proven via *rows-fetched* (`OFFSET`→2 fetched, not 4), `skip(k)` unbounded, pure-limit unchanged, dedup-blocks-offset, multi-schema fan-out fallback, order-less window, local-range-stays-native, label preservation, and the strategy-replacement assertion.
- Core `SearchQueryOffsetTest` (1) + `UniGraphRangeStepTest` (4, residual arithmetic incl. pass-through / unbounded / empty).
- Baselines **unchanged**: `JdbcFeatureTest` 20 fail/0 err, `JdbcStructureSuite` 30 fail/16 err (the strategy replaces every global range after a graph step — including every `limit(n)` — so these confirm no shift), plus `JdbcJoinPushdownTest` 11/11 and `JdbcAdjacencyFilterTest` 9/9.

## Scope / out of scope

- Offset pushes only for the flat graph-step path resolving to a single schema. Adjacency (batched) and multi-schema fan-out fall back to the in-memory residual (correct, unoptimized).
- No page-stability guarantee without `order()` (same as today's in-memory range).
- Accepted Minors (final review): `UniGraphRangeStep` doesn't declare `TraverserRequirement.BULK` (inputs are bulk-1; counting is bulk-aware defensively); one extra `getSearch` rebuild for the single pushed schema (pure, no DB round-trip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
