### PR TITLE
fix(jdbc): profile child metrics report their own query's timing (#108)

### DIFF
--- a/unipop-jdbc/src/org/unipop/jdbc/controller/simple/RowController.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/controller/simple/RowController.java
@@ -294,18 +294,24 @@ public class RowController implements SimpleController {
     }
 
     private <E extends Element, S extends JdbcSchema<E>> void fillChildren(List<MutableMetrics> children, Map<S, Select> schemas) {
-        List<org.javatuples.Pair<Long, Integer>> timing = TimingExecuterListener.timing.values().stream().collect(Collectors.toList());
+        // Each schema-child metric must be filled from ITS OWN query's timing, keyed by that query's
+        // SQL. TimingExecuterListener.timing is a static, never-cleared, unordered map accumulating
+        // every query ever run, so indexing into its values() (the old behaviour) assigned children
+        // arbitrary/stale timings that didn't add up to the parent (issue #108). children.get(i)
+        // corresponds to sqls.get(i) — both iterate the same `schemas` map in order.
         List<Map.Entry<S, Select>> sqls = schemas.entrySet().stream().collect(Collectors.toList());
-        for (int i = 0; i < sqls.size(); i++) {
-            org.javatuples.Pair<Long, Integer> timingCount = timing.get(i);
-            if (i < children.size()) {
-                MutableMetrics child = children.get(i);
-                if (timingCount != null) {
-                    child.setCount(TraversalMetrics.ELEMENT_COUNT_ID, timingCount.getValue1());
-                    child.setDuration(timingCount.getValue0(), TimeUnit.NANOSECONDS);
-                }
-            }
-            timing.remove(sqls.get(i).getValue().getSQL());
+        for (int i = 0; i < sqls.size() && i < children.size(); i++) {
+            // Key by the query rendered inlined under this context's dialect — the exact same form
+            // TimingExecuterListener records (ctx.dsl().renderInlined(ctx.query())). A detached
+            // Select.toString()/getSQL() renders with the default dialect (limit vs Postgres
+            // "fetch next", and formatted vs single-line) and never matches the recorded key.
+            org.javatuples.Pair<Long, Integer> timingCount =
+                    TimingExecuterListener.timing.get(this.getContextManager().renderInlined(sqls.get(i).getValue()));
+            MutableMetrics child = children.get(i);
+            // Always set a count/duration (default 0 when no timing was recorded) so the parent
+            // controller metric's sum over children can't NPE on an unset child.
+            child.setCount(TraversalMetrics.ELEMENT_COUNT_ID, timingCount != null ? timingCount.getValue1() : 0L);
+            child.setDuration(timingCount != null ? timingCount.getValue0() : 0L, TimeUnit.NANOSECONDS);
         }
     }
 

--- a/unipop-jdbc/src/org/unipop/jdbc/utils/ContextManager.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/utils/ContextManager.java
@@ -114,6 +114,17 @@ public class ContextManager {
         return withRetry("render", () -> context.render(query));
     }
 
+    /**
+     * Render a query as inlined SQL under this context's dialect — the same form
+     * TimingExecuterListener keys its map by ({@code ctx.dsl().renderInlined(ctx.query())}). A
+     * detached query renders with the DEFAULT dialect (e.g. {@code limit}); this renders with the
+     * configured dialect (e.g. Postgres {@code fetch next ... rows only}) so a caller can reconstruct
+     * the exact timing-map key.
+     */
+    public String renderInlined(Query query) {
+        return withRetry("renderInlined", () -> context.renderInlined(query));
+    }
+
     public void batch(List<Query> bulk) {
         withRetry("batch", () -> {
             context.batch(bulk).execute();

--- a/unipop-jdbc/src/org/unipop/jdbc/utils/TimingExecuterListener.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/utils/TimingExecuterListener.java
@@ -14,20 +14,30 @@ import java.util.Map;
 public class TimingExecuterListener extends DefaultExecuteListener {
     public static Map<String, Pair<Long, Integer>> timing = new HashMap<>();
 
+    /**
+     * Key by the query rendered inlined under the executing context's dialect. Consumers
+     * (RowController.fillChildren) reconstruct the same key via ContextManager.renderInlined(select);
+     * ctx.query().toString() cannot be reproduced by a consumer because it renders formatted
+     * (multi-line) and against the query's own (possibly default-dialect) configuration.
+     */
+    private static String key(ExecuteContext ctx) {
+        return ctx.dsl().renderInlined(ctx.query());
+    }
+
     @Override
     public void fetchEnd(ExecuteContext ctx) {
         super.fetchEnd(ctx);
 
-        Pair<Long, Integer> stopWatchIntegerPair = timing.get(ctx.query().toString());
+        Pair<Long, Integer> stopWatchIntegerPair = timing.get(key(ctx));
         long duration = System.nanoTime() - stopWatchIntegerPair.getValue0();
-        timing.put(ctx.query().toString(), new Pair<>(duration, ctx.result().size()));
+        timing.put(key(ctx), new Pair<>(duration, ctx.result().size()));
     }
 
     @Override
     public void fetchStart(ExecuteContext ctx) {
         super.start(ctx);
         StopWatch stopWatch = new StopWatch();
-        timing.put(ctx.query().toString(), new Pair<>(System.nanoTime(), 0));
+        timing.put(key(ctx), new Pair<>(System.nanoTime(), 0));
         stopWatch.start();
     }
 }

--- a/unipop-jdbc/test-resources/configuration/profile/graph.json
+++ b/unipop-jdbc/test-resources/configuration/profile/graph.json
@@ -1,0 +1,12 @@
+{
+  "class": "org.unipop.jdbc.JdbcSourceProvider",
+  "driver": "org.postgresql.Driver",
+  "address": ["jdbc:postgresql://localhost:54329/postgres"],
+  "user": "postgres",
+  "sqlDialect": "POSTGRES",
+  "vertices": [
+    { "table": "pf_host",   "id": "@id", "label": "host",   "properties": { "name": "@name" }, "dynamicProperties": false },
+    { "table": "pf_person", "id": "@id", "label": "person", "properties": { "name": "@name" }, "dynamicProperties": false }
+  ],
+  "edges": []
+}

--- a/unipop-jdbc/test/org/unipop/jdbc/profile/JdbcProfileTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/profile/JdbcProfileTest.java
@@ -1,0 +1,116 @@
+package org.unipop.jdbc.profile;
+
+import org.apache.commons.configuration2.BaseConfiguration;
+import org.apache.commons.configuration2.Configuration;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.util.Metrics;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalMetrics;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.javatuples.Pair;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.unipop.jdbc.suite.EmbeddedPostgresServer;
+import org.unipop.jdbc.utils.TimingExecuterListener;
+import org.unipop.structure.UniGraph;
+
+import java.io.File;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Issue #108: under profile(), each schema's child metric must report ITS OWN query's count/duration.
+ * Bug: RowController.fillChildren assigned children by positional index into the static, never-cleared,
+ * unordered TimingExecuterListener.timing.values() (contaminated by every prior query) instead of
+ * keying by each schema's SQL — so child counts/durations were arbitrary/stale and didn't add up to
+ * the parent.
+ */
+public class JdbcProfileTest {
+
+    private static GraphTraversalSource g;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        EmbeddedPostgresServer.ensureStarted();
+        Class.forName("org.postgresql.Driver");
+        try (Connection c = DriverManager.getConnection(EmbeddedPostgresServer.URL, EmbeddedPostgresServer.USER, "");
+             Statement s = c.createStatement()) {
+            s.execute("DROP TABLE IF EXISTS pf_host");
+            s.execute("DROP TABLE IF EXISTS pf_person");
+            s.execute("CREATE TABLE pf_host   (id varchar(100) primary key, name varchar(50))");
+            s.execute("CREATE TABLE pf_person (id varchar(100) primary key, name varchar(50))");
+            s.execute("INSERT INTO pf_host VALUES ('h1','a'),('h2','b'),('h3','c'),('h4','d'),('h5','e')"); // 5 hosts
+            s.execute("INSERT INTO pf_person VALUES ('p1','f'),('p2','g'),('p3','h')");                       // 3 persons
+        }
+        String dir = new File(JdbcProfileTest.class.getResource("/configuration/profile/graph.json").toURI()).getParent();
+        Configuration conf = new BaseConfiguration();
+        conf.setProperty(Graph.GRAPH, UniGraph.class.getName());
+        conf.setProperty("graphName", "profile");
+        conf.setProperty("providers", dir);
+        g = UniGraph.open(conf).traversal();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception { if (g != null) g.close(); }
+
+    @Before
+    public void seedStaleTimings() {
+        // Real usage never clears the static global timing map, so it accumulates entries from every
+        // prior query. Simulate that contamination so the child<->schema association is exercised
+        // against a map that is NOT just this query's two entries.
+        TimingExecuterListener.timing.clear();
+        for (int i = 0; i < 16; i++) TimingExecuterListener.timing.put("POISON_" + i, new Pair<>(111L, 9999));
+    }
+
+    /** All leaf metrics (no further nesting) — the per-schema children. */
+    private static List<Metrics> leaves(TraversalMetrics tm) {
+        List<Metrics> out = new ArrayList<>();
+        for (Metrics m : tm.getMetrics()) collectLeaves(m, out);
+        return out;
+    }
+
+    private static void collectLeaves(Metrics m, List<Metrics> out) {
+        if (m.getNested().isEmpty()) out.add(m);
+        else for (Metrics n : m.getNested()) collectLeaves(n, out);
+    }
+
+    private static Metrics leafForTable(TraversalMetrics tm, String table) {
+        return leaves(tm).stream().filter(m -> m.getName().contains("table='" + table + "'")).findFirst().orElse(null);
+    }
+
+    private static Metrics controllerMetric(TraversalMetrics tm) {
+        for (Metrics step : tm.getMetrics())
+            for (Metrics nested : step.getNested())
+                if (nested.getName().contains("RowController")) return nested;
+        return null;
+    }
+
+    @Test
+    public void schemaChildMetricsReportTheirOwnSchemaCount() {
+        TraversalMetrics tm = g.V().profile().next();
+
+        Metrics host = leafForTable(tm, "pf_host");
+        Metrics person = leafForTable(tm, "pf_person");
+        assertNotNull("host schema child metric missing", host);
+        assertNotNull("person schema child metric missing", person);
+
+        assertEquals("host schema child must report its own row count (5), not a stale/other query's",
+                5L, host.getCount(TraversalMetrics.ELEMENT_COUNT_ID).longValue());
+        assertEquals("person schema child must report its own row count (3), not a stale/other query's",
+                3L, person.getCount(TraversalMetrics.ELEMENT_COUNT_ID).longValue());
+
+        // The controller (parent of the schema children) counts the sum of its children — which must
+        // therefore add up to the real total, not the poison total.
+        Metrics controller = controllerMetric(tm);
+        assertNotNull("controller metric missing", controller);
+        assertEquals("controller count must equal the sum of its schema children (5+3), not poison",
+                8L, controller.getCount(TraversalMetrics.ELEMENT_COUNT_ID).longValue());
+    }
+}


### PR DESCRIPTION
Fixes #108.

## Problem

Under `profile()`, each schema's child metric reported an arbitrary/stale duration and count, so the children didn't add up to their parent.

## Root cause

`RowController.fillChildren` filled each schema-child metric from `TimingExecuterListener.timing.values()` **by positional index**:

```java
List<Pair<Long,Integer>> timing = TimingExecuterListener.timing.values().stream().collect(toList());
...
Pair timingCount = timing.get(i);                 // i-th value of a global, unordered map
timing.remove(sqls.get(i).getValue().getSQL());   // no-op: removing a String from a List<Pair>
```

`TimingExecuterListener.timing` is a **static, never-cleared** `HashMap` keyed by SQL, accumulating *every* query ever executed, in arbitrary iteration order. `timing.get(i)` had no correspondence to `children.get(i)`'s schema, and the intended "consume this SQL's entry" dedup was dead code (removing a `String` from a `List<Pair>` matches nothing). So children got timings from unrelated/stale queries.

## Fix

Key each child by **its own query's** timing instead of by index:

```java
Pair timingCount = TimingExecuterListener.timing.get(contextManager.renderInlined(select));
```

To make that key reconstructable, `TimingExecuterListener` now records under `ctx.dsl().renderInlined(ctx.query())` instead of `ctx.query().toString()` — `toString()` renders *formatted* (multi-line) against the query's own (default) dialect, which a detached `Select` can't reproduce, whereas `renderInlined` under the shared `ContextManager` dialect (Postgres) is identical on both sides (guaranteed by jOOQ's execution contract: `fetch` attaches the query to the calling context, and `renderInlined` always renders in *that* context's dialect). A new `ContextManager.renderInlined(Query)` exposes it. An unmatched child now defaults to count/duration 0, closing a latent NPE in `MetricsRunner.stop` (summing an unset child's `null` count).

## Scope

This fixes the **mis-assignment** (the reported bug). Two related items are intentionally left out:
- The nested scopes are disjoint by construction (schema children = SQL fetch only; controller = fetch+parse+collect; step = search+hydrate+iterate), so children still sum to *less* than the parent even when each is correct — a metrics-model change, not this bug.
- `TimingExecuterListener.timing` is a static global that grows unboundedly and isn't thread-safe — pre-existing, untouched here.

## Testing

New `JdbcProfileTest` (embedded PostgreSQL): seeds the global timing map with stale "poison" entries (as real usage accumulates), runs `g.V().profile()` over two tables of distinct sizes (5 hosts, 3 persons), and asserts each schema child reports **its own** count (5 / 3) and the controller sums to **8** — fails pre-fix (children get poison `9999`), passes post-fix deterministically (keyed lookup is order-independent).

Regression: `JdbcJoinPushdownTest` 11/11, `JdbcRangePushdownTest` 9/9, `JdbcAdjacencyFilterTest` 9/9 (all read the timing map by SQL substring — unaffected by the single-line key format); `JdbcFeatureTest` 20 fail/0 err and `JdbcStructureSuite` 30 fail/16 err (baselines unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
