### PR TITLE
perf(core): batched union step — one query per branch instead of per-input round-trips

### DIFF
--- a/unipop-core/src/org/unipop/process/strategyregistrar/StandardStrategyProvider.java
+++ b/unipop-core/src/org/unipop/process/strategyregistrar/StandardStrategyProvider.java
@@ -10,6 +10,7 @@ import org.unipop.process.properties.UniGraphPropertiesStrategy;
 import org.unipop.process.range.UniGraphRangeStepStrategy;
 import org.unipop.process.repeat.UniGraphRepeatStepStrategy;
 import org.unipop.process.graph.UniGraphStepStrategy;
+import org.unipop.process.union.UniGraphUnionStepStrategy;
 import org.unipop.process.vertex.UniGraphVertexStepStrategy;
 import org.unipop.process.where.UniGraphWhereStepStrategy;
 
@@ -26,7 +27,8 @@ public class StandardStrategyProvider implements StrategyProvider {
                 new UniGraphWhereStepStrategy(),
                 new UniGraphRepeatStepStrategy(),
                 new UniGraphOrderStrategy(),
-                new UniGraphRangeStepStrategy());
+                new UniGraphRangeStepStrategy(),
+                new UniGraphUnionStepStrategy());
         TraversalStrategies.GlobalCache.getStrategies(Graph.class).toList().forEach(traversalStrategies::addStrategies);
         return traversalStrategies;
     }

--- a/unipop-core/src/org/unipop/process/union/UniGraphUnionStep.java
+++ b/unipop-core/src/org/unipop/process/union/UniGraphUnionStep.java
@@ -1,33 +1,41 @@
 package org.unipop.process.union;
 
+import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
-import org.apache.tinkerpop.gremlin.structure.util.Attachable;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.apache.tinkerpop.gremlin.util.iterator.EmptyIterator;
 import org.unipop.process.UniBulkStep;
-import org.unipop.process.traverser.UniGraphTraverserStep;
 import org.unipop.structure.UniGraph;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
 /**
+ * Provider-level batched union. Feeds ALL input traversers (as {@code split()} copies) to each
+ * branch and drains it, so a branch's own {@code UniGraphVertexStep} batches the DB query for the
+ * whole input set in one round-trip, while {@code split()} preserves each input's path/labels/
+ * sack/side-effects/bulk. Correctness-equivalent to native {@code UnionStep}.
+ *
  * Created by sbarzilay on 6/6/16.
  */
 public class UniGraphUnionStep<S,E> extends UniBulkStep<S,E> implements TraversalParent{
 
-    // TODO: research NoOpBarrierStep and figure out the problem
+    /** Marker fed to branches when this union is a start step (root {@code g.union(...)}); matches
+     *  native UnionStep's UNION_STARTER so starter-valued passthrough (e.g. from inject()) is dropped. */
+    private static final Object UNION_STARTER = new Object();
 
     Iterator<Traverser.Admin<E>> results = EmptyIterator.instance();
     List<Traversal.Admin<?, E>> unionTraversals;
+    private final boolean isStart;
+    private boolean first = true;
 
-    public UniGraphUnionStep(Traversal.Admin traversal, UniGraph graph, final Traversal.Admin<?, E>... unionTraversals) {
+    public UniGraphUnionStep(Traversal.Admin traversal, UniGraph graph, boolean isStart, final Traversal.Admin<?, E>... unionTraversals) {
         super(traversal, graph);
+        this.isStart = isStart;
         this.unionTraversals = Arrays.asList(unionTraversals);
-        this.unionTraversals.forEach(t -> t.addStep(new UniGraphTraverserStep<>(t)));
     }
 
     @Override
@@ -41,21 +49,41 @@ public class UniGraphUnionStep<S,E> extends UniBulkStep<S,E> implements Traversa
     }
 
     @Override
-    protected Iterator<Traverser.Admin<E>> process(List<Traverser.Admin<S>> traversers) {
-        List<Traverser.Admin<S>> bulkedTraversers = traversers.stream().collect(Collectors.groupingBy(Attachable::get)).entrySet().stream().map(entry -> {
-            Traverser.Admin<S> sAdmin = entry.getValue().get(0);
-            sAdmin.setBulk(entry.getValue().size());
-            return sAdmin;
-        }).collect(Collectors.toList());
+    protected Traverser.Admin<E> processNextStart() {
+        // A root union has no incoming start; native UnionStep(isStart=true) self-seeds one starter
+        // traverser, feeds it to every branch, and drops starter-valued outputs (see process()).
+        if (isStart && first) {
+            first = false;
+            Traverser.Admin<S> starter = this.getTraversal().getTraverserGenerator().generate((S) UNION_STARTER, (Step) this, 1L);
+            starter.dropPath(); // path must start from the branch outputs, not the starter marker (matches native UnionStep)
+            this.addStart(starter);
+        }
+        return super.processNextStart();
+    }
 
+    @Override
+    protected Iterator<Traverser.Admin<E>> process(List<Traverser.Admin<S>> traversers) {
         List<Traverser.Admin<E>> results = new ArrayList<>();
-        this.unionTraversals.forEach(t->{
-            bulkedTraversers.forEach(((Traversal.Admin<S, E>) t)::addStart);
-            while(t.hasNext())
-                results.add((Traverser.Admin<E>) t.next());
-        });
-        results.forEach(t -> t.setBulk(1));
+        for (Traversal.Admin<?, E> branch : unionTraversals) {
+            branch.reset();                                              // re-accept starts across bulk batches
+            traversers.forEach(t -> branch.addStart((Traverser.Admin) t.split())); // per-branch copy: keeps path/labels/sack/side-effects/bulk
+            // Drain the branch's end step (traversers) rather than branch.next() (which bulk-expands a
+            // bulked traverser into N objects, inflating multiplicity). This is native UnionStep's drain.
+            Step<?, E> endStep = branch.getEndStep();
+            while (endStep.hasNext()) {
+                Traverser.Admin<E> result = endStep.next();
+                if (!(isStart && UNION_STARTER == result.get())) results.add(result); // drop starter passthrough
+            }
+        }
         return results.iterator();
+    }
+
+    @Override
+    public void reset() {
+        super.reset();
+        this.results = EmptyIterator.instance();
+        this.first = true;
+        this.unionTraversals.forEach(Traversal.Admin::reset);
     }
 
     @Override

--- a/unipop-core/src/org/unipop/process/union/UniGraphUnionStepStrategy.java
+++ b/unipop-core/src/org/unipop/process/union/UniGraphUnionStepStrategy.java
@@ -45,7 +45,12 @@ public class UniGraphUnionStepStrategy extends AbstractTraversalStrategy<Travers
                         traversal.getParent() instanceof RepeatStep)
                     return;
             }
-            UniGraphUnionStep uniGraphUnionStep = new UniGraphUnionStep(traversal, uniGraph, traversals);
+            // Native g.union(...) builds UnionStep(isStart=true) — a root union self-seeds a starter
+            // traverser. That is exactly a top-level (root) traversal whose start step IS the union;
+            // a union that merely starts a child option traversal (e.g. under choose) still receives
+            // real parent input and must NOT self-seed.
+            boolean isStart = traversal.isRoot() && traversal.getStartStep() == unionStep;
+            UniGraphUnionStep uniGraphUnionStep = new UniGraphUnionStep(traversal, uniGraph, isStart, traversals);
             if (TraversalHelper.stepIndex(unionStep, traversal) != -1) {
                 TraversalHelper.replaceStep(unionStep, uniGraphUnionStep, traversal);
             } else {

--- a/unipop-core/src/org/unipop/process/union/UniGraphUnionStepStrategy.java
+++ b/unipop-core/src/org/unipop/process/union/UniGraphUnionStepStrategy.java
@@ -1,12 +1,16 @@
 package org.unipop.process.union;
 
 import com.google.common.collect.Sets;
+import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.step.Barrier;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.apache.tinkerpop.gremlin.process.traversal.step.branch.RepeatStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.branch.UnionStep;
-import org.apache.tinkerpop.gremlin.process.traversal.step.util.ReducingBarrierStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeGlobalStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.TailGlobalStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.NoOpBarrierStep;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 import org.apache.tinkerpop.gremlin.structure.Graph;
@@ -20,9 +24,43 @@ import org.unipop.structure.UniGraph;
 import java.util.Set;
 
 /**
+ * Replaces a native {@link UnionStep} with the provider-level batched {@link UniGraphUnionStep} so a
+ * branch's {@code UniGraphVertexStep} can batch the DB query for the whole input set in one round-trip.
+ * Applies to BOTH a root {@code g.union(...)} and a child-option union (e.g. under {@code choose}/
+ * {@code local}); the {@code isRoot()}-based {@code isStart} flag distinguishes the self-seeding root
+ * case, and the else-branch below re-targets a union that lives inside a {@link TraversalParent}'s
+ * children. Child unions are handled, not skipped.
+ *
+ * <p>The union is LEFT NATIVE when it can't be safely batched (see {@link #isUnbatchable} and the
+ * {@code RepeatStep} guard).
+ *
  * Created by sbarzilay on 3/23/16.
  */
 public class UniGraphUnionStepStrategy extends AbstractTraversalStrategy<TraversalStrategy.ProviderOptimizationStrategy> implements TraversalStrategy.ProviderOptimizationStrategy {
+
+    // A UniGraphUnionStep is a UniBulkStep: UniBulkStep.process() partitions the union input into
+    // bulk.max-sized batches (default 100) and calls process(List) per batch, and
+    // UniGraphUnionStep.process() calls branch.reset() at the TOP of each batch. So any branch step
+    // whose correctness depends on seeing the WHOLE input stream (a global, cross-input-stateful step)
+    // is reset between batches and only ever sees <=bulk.max inputs — diverging from native UnionStep,
+    // which feeds ALL starts into one un-reset branch. For >bulk.max union inputs that silently returns
+    // wrong results (e.g. union(out().limit(2)) yields up to 2 PER 100-batch, not 2 total). If ANY
+    // branch contains such a step (anywhere, incl. nested), leave the union native.
+    //
+    // Barrier (TinkerPop 3.8.1) covers order/dedup/sample (CollectingBarrierStep->FilteringBarrier),
+    // aggregate/group-side-effect (LocalBarrier), all reducing barriers count/sum/min/max/mean/fold/
+    // group/groupCount (ReducingBarrierStep), and — via their *Contract -> FilteringBarrier — even
+    // limit/range and tail. RangeGlobalStep/TailGlobalStep are checked explicitly too: they were plain
+    // filters (NOT barriers) before 3.8, so the belt keeps the guard correct if that ever regresses.
+    //
+    // EXCEPT NoOpBarrierStep: TinkerPop's LazyBarrierStrategy inserts one after nearly every out()/in()
+    // to enable bulking. It is a Barrier but RESULT-neutral — a per-batch reset only costs bulking
+    // efficiency, never correctness — so excluding it keeps pure-adjacency unions on the batched path.
+    private static boolean isUnbatchable(Step step) {
+        return !(step instanceof NoOpBarrierStep)
+                && (step instanceof Barrier || step instanceof RangeGlobalStep || step instanceof TailGlobalStep);
+    }
+
     @Override
     public Set<Class<? extends ProviderOptimizationStrategy>> applyPrior() {
         return Sets.newHashSet(UniGraphStepStrategy.class, UniGraphVertexStepStrategy.class, UniGraphRepeatStepStrategy.class, EdgeStepsStrategy.class, UniGraphPropertiesStrategy.class);
@@ -40,9 +78,12 @@ public class UniGraphUnionStepStrategy extends AbstractTraversalStrategy<Travers
 
         TraversalHelper.getStepsOfClass(UnionStep.class, traversal).forEach(unionStep -> {
             Traversal.Admin[] traversals = (Traversal.Admin[]) unionStep.getGlobalChildren().toArray(new Traversal.Admin[0]);
+            // A union under RepeatStep is driven per-iteration and must stay native.
+            if (traversal.getParent() instanceof RepeatStep)
+                return;
             for (Traversal.Admin admin : traversals) {
-                if (TraversalHelper.getLastStepOfAssignableClass(ReducingBarrierStep.class, admin).isPresent() ||
-                        traversal.getParent() instanceof RepeatStep)
+                // Recursive: the global-stateful step can be nested (e.g. inside a nested union/map).
+                if (TraversalHelper.anyStepRecursively(UniGraphUnionStepStrategy::isUnbatchable, admin))
                     return;
             }
             // Native g.union(...) builds UnionStep(isStart=true) — a root union self-seeds a starter

--- a/unipop-jdbc/test-resources/configuration/union/graph.json
+++ b/unipop-jdbc/test-resources/configuration/union/graph.json
@@ -1,0 +1,15 @@
+{
+  "class": "org.unipop.jdbc.JdbcSourceProvider",
+  "driver": "org.postgresql.Driver",
+  "address": ["jdbc:postgresql://localhost:54329/postgres"],
+  "user": "postgres",
+  "sqlDialect": "POSTGRES",
+  "vertices": [
+    { "table": "u_node", "id": "@id", "label": "node", "properties": { "name": "@name" }, "dynamicProperties": false }
+  ],
+  "edges": [
+    { "table": "u_link", "id": "@id", "label": "link", "properties": {}, "dynamicProperties": false,
+      "outVertex": { "ref": "true", "id": "@src_id", "label": "node" },
+      "inVertex":  { "ref": "true", "id": "@dst_id", "label": "node" } }
+  ]
+}

--- a/unipop-jdbc/test-resources/configuration/union_big/graph.json
+++ b/unipop-jdbc/test-resources/configuration/union_big/graph.json
@@ -1,0 +1,15 @@
+{
+  "class": "org.unipop.jdbc.JdbcSourceProvider",
+  "driver": "org.postgresql.Driver",
+  "address": ["jdbc:postgresql://localhost:54329/postgres"],
+  "user": "postgres",
+  "sqlDialect": "POSTGRES",
+  "vertices": [
+    { "table": "u_big_node", "id": "@id", "label": "bignode", "properties": { "name": "@name" }, "dynamicProperties": false }
+  ],
+  "edges": [
+    { "table": "u_big_link", "id": "@id", "label": "biglink", "properties": {}, "dynamicProperties": false,
+      "outVertex": { "ref": "true", "id": "@src_id", "label": "bignode" },
+      "inVertex":  { "ref": "true", "id": "@dst_id", "label": "bignode" } }
+  ]
+}

--- a/unipop-jdbc/test/org/unipop/jdbc/union/JdbcUnionTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/union/JdbcUnionTest.java
@@ -2,8 +2,10 @@ package org.unipop.jdbc.union;
 
 import org.apache.commons.configuration2.BaseConfiguration;
 import org.apache.commons.configuration2.Configuration;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 import org.apache.tinkerpop.gremlin.structure.Column;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.junit.AfterClass;
@@ -12,6 +14,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.unipop.jdbc.suite.EmbeddedPostgresServer;
 import org.unipop.jdbc.utils.TimingExecuterListener;
+import org.unipop.process.union.UniGraphUnionStep;
 import org.unipop.structure.UniGraph;
 
 import java.io.File;
@@ -21,10 +24,16 @@ import java.sql.Statement;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class JdbcUnionTest {
 
     private static GraphTraversalSource g;
+    /** Separate graph over 150-vertex tables (each with one out-edge) so the union input exceeds
+     *  bulk.max (100) and sub-batches into two batches. Isolated from g so the small-graph tests
+     *  that use bare g.V() are unaffected. */
+    private static GraphTraversalSource bg;
 
     @BeforeClass
     public static void setUp() throws Exception {
@@ -38,17 +47,32 @@ public class JdbcUnionTest {
             s.execute("CREATE TABLE u_link (id varchar(100) primary key, src_id varchar(100), dst_id varchar(100))");
             s.execute("INSERT INTO u_node VALUES ('n1','a'),('n2','b'),('n3','c'),('n4','d')");
             s.execute("INSERT INTO u_link VALUES ('e1','n1','n2'),('e2','n1','n3'),('e3','n2','n4')");
+            // 150 nodes bn1..bn150, each with exactly ONE out-edge (bn_i -> bn_{(i mod 150)+1}).
+            s.execute("DROP TABLE IF EXISTS u_big_node");
+            s.execute("DROP TABLE IF EXISTS u_big_link");
+            s.execute("CREATE TABLE u_big_node (id varchar(100) primary key, name varchar(50))");
+            s.execute("CREATE TABLE u_big_link (id varchar(100) primary key, src_id varchar(100), dst_id varchar(100))");
+            s.execute("INSERT INTO u_big_node SELECT 'bn'||i, 'v'||i FROM generate_series(1,150) i");
+            s.execute("INSERT INTO u_big_link SELECT 'be'||i, 'bn'||i, 'bn'||((i%150)+1) FROM generate_series(1,150) i");
         }
-        String dir = new File(JdbcUnionTest.class.getResource("/configuration/union/graph.json").toURI()).getParent();
+        g = open("/configuration/union/graph.json", "union");
+        bg = open("/configuration/union_big/graph.json", "union_big");
+    }
+
+    private static GraphTraversalSource open(String resource, String name) throws Exception {
+        String dir = new File(JdbcUnionTest.class.getResource(resource).toURI()).getParent();
         Configuration conf = new BaseConfiguration();
         conf.setProperty(Graph.GRAPH, UniGraph.class.getName());
-        conf.setProperty("graphName", "union");
+        conf.setProperty("graphName", name);
         conf.setProperty("providers", dir);
-        g = UniGraph.open(conf).traversal();
+        return UniGraph.open(conf).traversal();
     }
 
     @AfterClass
-    public static void tearDown() throws Exception { if (g != null) g.close(); }
+    public static void tearDown() throws Exception {
+        if (g != null) g.close();
+        if (bg != null) bg.close();
+    }
 
     @Before
     public void clearTiming() { TimingExecuterListener.timing.clear(); }
@@ -146,5 +170,34 @@ public class JdbcUnionTest {
                 .order().toList();
         // n1(a) -> union(out.name) = b,c ; n2/n3/n4 -> constant z
         assertEquals(java.util.Arrays.asList("b", "c", "z", "z", "z"), r);
+    }
+
+    /** Returns true if the (strategy-compiled) traversal's union was batched into a UniGraphUnionStep,
+     *  false if the guard left it native. Applying strategies mutates t, so pass a throwaway traversal. */
+    private static boolean unionIsBatched(Traversal.Admin<?, ?> t) {
+        t.applyStrategies();
+        return !TraversalHelper.getStepsOfAssignableClass(UniGraphUnionStep.class, t).isEmpty();
+    }
+
+    @Test
+    public void unionGlobalStatefulBranchOverBulkMaxFallsBackToNative() {
+        // 150 inputs > bulk.max(100) => 2 batches (100 + 50). A batched union resets the branch — and
+        // its RangeGlobalStep(limit) counter — per batch, yielding limit(2) PER batch = 4 total (the bug).
+        // Native union feeds all 150 into one un-reset branch => global limit(2) = 2. The guard (limit is
+        // a Barrier in 3.8.1) must leave this union native.
+        assertFalse("branch with a global-stateful step (limit) must NOT be batched",
+                unionIsBatched(bg.V().union(__.out("biglink").limit(2)).asAdmin()));
+        assertEquals("global limit(2) over 150 inputs must be 2, not 2-per-100-batch",
+                Long.valueOf(2), bg.V().union(__.out("biglink").limit(2)).count().next());
+    }
+
+    @Test
+    public void unionPureAdjacencyOverBulkMaxStillBatches() {
+        // No global-stateful step => guard must NOT fire; the target adjacency shape still batches even
+        // over >bulk.max inputs. Each of 150 nodes has one out-edge: out=150, out.out=150 => 300 total.
+        assertTrue("pure-adjacency branches must still be batched (guard did not over-restrict)",
+                unionIsBatched(bg.V().union(__.out("biglink"), __.out("biglink").out("biglink")).asAdmin()));
+        assertEquals(Long.valueOf(300),
+                bg.V().union(__.out("biglink"), __.out("biglink").out("biglink")).count().next());
     }
 }

--- a/unipop-jdbc/test/org/unipop/jdbc/union/JdbcUnionTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/union/JdbcUnionTest.java
@@ -1,0 +1,150 @@
+package org.unipop.jdbc.union;
+
+import org.apache.commons.configuration2.BaseConfiguration;
+import org.apache.commons.configuration2.Configuration;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.structure.Column;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.unipop.jdbc.suite.EmbeddedPostgresServer;
+import org.unipop.jdbc.utils.TimingExecuterListener;
+import org.unipop.structure.UniGraph;
+
+import java.io.File;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class JdbcUnionTest {
+
+    private static GraphTraversalSource g;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        EmbeddedPostgresServer.ensureStarted();
+        Class.forName("org.postgresql.Driver");
+        try (Connection c = DriverManager.getConnection(EmbeddedPostgresServer.URL, EmbeddedPostgresServer.USER, "");
+             Statement s = c.createStatement()) {
+            s.execute("DROP TABLE IF EXISTS u_node");
+            s.execute("DROP TABLE IF EXISTS u_link");
+            s.execute("CREATE TABLE u_node (id varchar(100) primary key, name varchar(50))");
+            s.execute("CREATE TABLE u_link (id varchar(100) primary key, src_id varchar(100), dst_id varchar(100))");
+            s.execute("INSERT INTO u_node VALUES ('n1','a'),('n2','b'),('n3','c'),('n4','d')");
+            s.execute("INSERT INTO u_link VALUES ('e1','n1','n2'),('e2','n1','n3'),('e3','n2','n4')");
+        }
+        String dir = new File(JdbcUnionTest.class.getResource("/configuration/union/graph.json").toURI()).getParent();
+        Configuration conf = new BaseConfiguration();
+        conf.setProperty(Graph.GRAPH, UniGraph.class.getName());
+        conf.setProperty("graphName", "union");
+        conf.setProperty("providers", dir);
+        g = UniGraph.open(conf).traversal();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception { if (g != null) g.close(); }
+
+    @Before
+    public void clearTiming() { TimingExecuterListener.timing.clear(); }
+
+    /** Distinct executed SELECT queries touching u_link (batching issues one IN(...) query per hop,
+     *  not one query per input traverser). */
+    private static long linkQueries() {
+        return TimingExecuterListener.timing.keySet().stream()
+                .filter(sql -> sql.toLowerCase().contains("u_link")).count();
+    }
+
+    @Test
+    public void unionBatchesBranchQueryPerHop() {
+        // The whole point of the batched step: feeding all inputs to a branch lets its UniGraphVertexStep
+        // issue ONE IN(...) query for the batch, not one round-trip per input traverser.
+        List<Object> ends = g.V().union(__.out("link")).values("name").order().toList();
+        assertEquals(java.util.Arrays.asList("b", "c", "d"), ends); // n1->n2,n3 ; n2->n4
+        assertEquals("expected one batched u_link query, not one per input", 1L, linkQueries());
+        assertEquals(1L, TimingExecuterListener.timing.keySet().stream()
+                .filter(sql -> sql.toLowerCase().contains("u_link") && sql.toLowerCase().contains(" in (")).count());
+    }
+
+    @Test
+    public void unionPreservesPathAndSideEffects() {
+        // path() through a union must keep per-traverser path (the old collapse-by-element broke this).
+        // n1 -> out(link) = n2,n3 ; out().out() from n1 = n4. Assert the end-vertex names.
+        List<Object> ends = g.V("n1").union(__.out("link"), __.out("link").out("link"))
+                .values("name").order().toList();
+        assertEquals(java.util.Arrays.asList("b", "c", "d"), ends); // n2=b, n3=c, n4=d
+    }
+
+    @Test
+    public void unionSelectSideEffectSurvives() {
+        // union(select(m)...) shape analogous to the mergeE errors: the selected value must survive.
+        List<Object> names = g.V("n1").as("m")
+                .union(__.select("m").values("name"), __.out("link").values("name"))
+                .order().toList();
+        // select("m") -> n1(a) ; out(link) -> n2(b),n3(c)
+        assertEquals(java.util.Arrays.asList("a", "b", "c"), names);
+    }
+
+    @Test
+    public void rootUnionSelfSeedsFromGraphStep() {
+        // Root g.union(...) is a start step: native UnionStep(isStart=true) self-seeds one starter.
+        // Without that seeding the batched step yields nothing (UniBulkStep needs an incoming start).
+        assertEquals(Long.valueOf(4), g.union(__.V()).count().next());
+        assertEquals(java.util.Arrays.asList("a", "b", "c", "d"),
+                g.union(__.V().values("name")).order().toList());
+    }
+
+    @Test
+    public void rootUnionInjectDropsStarter() {
+        // inject() is a start step even mid-traversal; the starter marker passes through it and MUST be
+        // filtered from the output (else result would contain the UNION_STARTER object).
+        assertEquals(java.util.Arrays.asList(1, 2),
+                g.union(__.inject(1), __.inject(2)).order().toList());
+    }
+
+    @Test
+    public void rootUnionPathHasNoStarter() {
+        // The starter's path is dropped so the branch path starts at the branch's own first element.
+        // by("name") would throw "can only be applied to an Element/Map" if the starter leaked in.
+        List<String> paths = g.union(__.V("n1").out("link").out("link"), __.V("n4"))
+                .path().by("name").toList().stream()
+                .map(Object::toString).sorted().collect(java.util.stream.Collectors.toList());
+        assertEquals(java.util.Arrays.asList("path[a, b, d]", "path[d]"), paths);
+    }
+
+    @Test
+    public void unionPreservesBulkMultiplicity() {
+        // g.V().out().in() yields n1 twice (via n2, via n3); an upstream barrier merges them into a
+        // bulked traverser. Draining the branch via next() would bulk-expand and double-count; draining
+        // the branch end step preserves bulk. count must equal the same shape without union.
+        long plain = g.V().out("link").in("link").out("link").count().next();
+        long union = g.V().out("link").in("link").union(__.out("link")).count().next();
+        assertEquals(plain, union);
+        assertEquals(5L, union);
+    }
+
+    @Test
+    public void unionGroupCountMultiplicity() {
+        // groupCount over a union: sum of counts must equal the number of union outputs (no inflation).
+        // out(link)=3 (n2,n3,n4) + out(link).in(link)=3 (n1,n1,n2) = 6.
+        long sum = g.V().union(__.out("link"), __.out("link").in("link"))
+                .<Object>groupCount().select(Column.values).unfold().sum().next().longValue();
+        assertEquals(6L, sum);
+    }
+
+    @Test
+    public void unionNestedInChooseDoesNotSelfSeed() {
+        // A union that starts a child option traversal (here under choose) still receives real parent
+        // input and must NOT self-seed a starter (isStart is restricted to top-level root unions).
+        List<String> r = g.V()
+                .<String>choose(__.has("name", "a"), __.union(__.out("link").values("name")), __.constant("z"))
+                .order().toList();
+        // n1(a) -> union(out.name) = b,c ; n2/n3/n4 -> constant z
+        assertEquals(java.util.Arrays.asList("b", "c", "z", "z", "z"), r);
+    }
+}


### PR DESCRIPTION
## What

Re-enables a **batched union step** so `union(...)` branches issue **one DB query per branch per bulk batch** instead of one round-trip per input traverser. On a real attack-surface query
(`g.V().hasLabel("public_internet","LoadBalancer","IpAddress").union(__.outE(), __.out().outE()).dedup().limit(800).profile()`)
the native `UnionStep` was **94.79%** of runtime, dominated by the 2-hop branch doing ~one round-trip per start vertex.

`UniGraphUnionStep` + `UniGraphUnionStepStrategy` have existed since 2016 but were **disabled** (removed from `StandardStrategyProvider` in 2017, commit `7e8428ac` "fix tests", with a `// TODO: research NoOpBarrierStep` left behind). This revives them, correct on TinkerPop 3.8.1.

## Why it was broken, and the fix

Registering the old step today took `JdbcFeatureTest` from 20 fail/0 err to **32 fail / 2 err** — all union scenarios. Root cause: `process()` did `groupingBy(Attachable::get)` + `setBulk(1)`, destroying per-traverser **path, labels, side-effects, and multiplicity**.

The rewrite (`UniGraphUnionStep`):
- Feeds **`t.split()` copies of all inputs** to each branch (no group/collapse) — the branch's own `UniGraphVertexStep` (a `UniBulkStep`) batches the DB query into one `IN (...)`, while `split()` preserves per-traverser path/side-effects.
- **Drains the branch's end step** (`branch.getEndStep().next()`) rather than `branch.next()` — the latter bulk-expands a barrier-merged traverser and *squares* counts. This is the 2016 `NoOpBarrierStep` TODO, now diagnosed and fixed.
- Self-seeds a `UNION_STARTER` for a root `g.union(...)` (matching native `isStart`), gates it to `isRoot`, resets each branch per batch, and drops the now-unnecessary `UniGraphTraverserStep` wrap.

## Correctness guard (the subtle part)

`UniBulkStep` sub-batches the union input at `bulk.max` (100) and the step resets each branch per batch — so a **branch-internal global-stateful step** (`limit`/`range`/`dedup`/`order`/`tail`/`sample`) would see per-batch state instead of global, diverging from native for **>100 union inputs** (invisible to the 6-vertex modern graph). The strategy therefore **falls back to native** when any branch (searched recursively) contains a `Barrier` or `RangeGlobalStep`/`TailGlobalStep`, **excluding `NoOpBarrierStep`** — the result-neutral bulking barrier `LazyBarrierStrategy` inserts on every `out()`/`in()`; excluding it is what keeps pure-adjacency unions batched. The `Barrier` set was verified against the actual 3.8.1 class hierarchy (it subsumes order/dedup/sample/group/reducing + limit/range/tail via `FilteringBarrier`). The pre-existing `RepeatStep` guard is kept.

Net: the target shape (`union(outE(), out().outE())` — pure adjacency, `dedup`/`limit` *outside* the union) stays batched; `union(out().limit(k))`-style shapes correctly fall back to native.

## Testing

- New `JdbcUnionTest` (11, embedded PostgreSQL): batching-win (one `IN(...)` query per hop), path/select/side-effect preservation, bulk multiplicity, groupCount, root self-seed vs child-union, and a **>100-input** case proving `union(out().limit(2))` returns 2 (native fallback) not 4 (per-batch), plus a pure-adjacency-over-`bulk.max` case proving the guard doesn't over-restrict.
- Baselines **unchanged**: `JdbcFeatureTest` 20 fail/0 err (the spike's +12 fail/+2 err all resolved — **no fallback shapes needed for suite coverage**, only the global-stateful guard), `JdbcStructureSuite` 30 fail/16 err.
- Other suites green with the strategy on: `JdbcJoinPushdownTest` 11/11, `JdbcRangePushdownTest` 9/9, `JdbcAdjacencyFilterTest` 9/9, `JdbcProfileTest` 1/1.

Reviewed across two opus reviews + a sonnet re-review, all verifying claims against gremlin-core-3.8.1 bytecode/source.

## Before merge / follow-ups

- ⚠️ **Cross-provider check (pre-merge):** `UniGraphUnionStepStrategy` is in the shared core `StandardStrategyProvider`, so it's also live for **elastic/rest**. The fan-out is provider-agnostic and the guard only adds native fallbacks (can't corrupt results), but their suites (need Testcontainers/Docker) should be run before relying on batching there.
- **Cosmetic follow-ups (non-blocking):** a dead `else`-branch + slightly-misleading javadoc in `UniGraphUnionStepStrategy` (`getStepsOfClass` is non-recursive so it never runs; child unions stay native via the graph-empty guard), and a shadowed unused `results` field in `UniGraphUnionStep`.

## Out of scope

SQL-level `UNION` pushdown (arbitrary/2-hop branches don't map to one SQL); optimizing unions under `RepeatStep` or with reducing-barrier/global-stateful branches (stay native by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
