### PR TITLE
feat: schema catalog + multi-hop join pushdown

### DIFF
--- a/unipop-core/pom.xml
+++ b/unipop-core/pom.xml
@@ -18,6 +18,12 @@
             <artifactId>gremlin-core</artifactId>
             <version>${tinkerpop.version}</version>
         </dependency>
+        <!-- Internal schema catalog (type topology for pushdown / join pruning). -->
+        <dependency>
+            <groupId>org.apache.tinkerpop</groupId>
+            <artifactId>tinkergraph-gremlin</artifactId>
+            <version>${tinkerpop.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.tinkerpop</groupId>
             <artifactId>gremlin-groovy</artifactId>

--- a/unipop-core/src/org/unipop/process/multihop/UniGraphMultiHopStep.java
+++ b/unipop-core/src/org/unipop/process/multihop/UniGraphMultiHopStep.java
@@ -41,9 +41,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * Collapses two consecutive adjacency hops into one bulk query when a
+ * Collapses two consecutive {@code out}/{@code in} adjacency hops into one bulk query when a
  * {@link MultiHopQuery.MultiHopController} can answer; otherwise runs hops sequentially.
- * Final hop may return vertices ({@code out}/{@code in}) or edges ({@code outE}/{@code inE}).
  */
 public class UniGraphMultiHopStep<E extends Element> extends UniPredicatesStep<Vertex, E>
         implements ReceivesPredicatesHolder<Vertex, E>, Orderable, Profiling {
@@ -53,7 +52,6 @@ public class UniGraphMultiHopStep<E extends Element> extends UniPredicatesStep<V
     private static final String SRC_ALIAS = "__unipop_src";
 
     private final List<MultiHopQuery.HopSpec> hops;
-    private final boolean returnsVertex;
     private PredicatesHolder finalVertexPredicates = PredicatesHolderFactory.empty();
     private List<Pair<String, Order>> orders;
     private int limit = -1;
@@ -66,11 +64,9 @@ public class UniGraphMultiHopStep<E extends Element> extends UniPredicatesStep<V
                                 UniGraph graph,
                                 ControllerManager controllerManager,
                                 List<MultiHopQuery.HopSpec> hops,
-                                PredicatesHolder finalVertexPredicates,
-                                boolean returnsVertex) {
+                                PredicatesHolder finalVertexPredicates) {
         super(traversal, graph);
         this.hops = hops == null ? Collections.emptyList() : new ArrayList<>(hops);
-        this.returnsVertex = returnsVertex;
         this.finalVertexPredicates = finalVertexPredicates == null
                 ? PredicatesHolderFactory.empty() : finalVertexPredicates;
         this.multiHopControllers = controllerManager.getControllers(MultiHopQuery.MultiHopController.class);
@@ -91,7 +87,7 @@ public class UniGraphMultiHopStep<E extends Element> extends UniPredicatesStep<V
         }
 
         MultiHopQuery query = new MultiHopQuery(starts, hops, finalVertexPredicates, orders, limit,
-                propertyKeys, returnsVertex, stepDescriptor);
+                propertyKeys, stepDescriptor);
         logger.debug("MultiHop query: {}", query);
 
         Iterator<Edge> joined = null;
@@ -109,11 +105,9 @@ public class UniGraphMultiHopStep<E extends Element> extends UniPredicatesStep<V
             out = sequentialFallback(starts, idToTraverser);
         }
 
-        if (returnsVertex) {
-            boolean noProps = propertyKeys != null && propertyKeys.isEmpty();
-            if (finalVertexPredicates.notEmpty() || !noProps) {
-                return hydrateIfNeeded((Iterator) out);
-            }
+        boolean noProps = propertyKeys != null && propertyKeys.isEmpty();
+        if (finalVertexPredicates.notEmpty() || !noProps) {
+            return hydrateIfNeeded((Iterator) out);
         }
         return out;
     }
@@ -124,22 +118,13 @@ public class UniGraphMultiHopStep<E extends Element> extends UniPredicatesStep<V
         List<Traverser<Vertex>> starts = idToTraverser.get(startId);
         if (starts == null) return Stream.empty();
         Vertex mid = midOf(edge);
-        // Intermediate mid is always a Vertex; final may be Vertex or Edge — use raw split for mid.
         Step midStep = this;
-        if (returnsVertex) {
-            Vertex target = edge.inVertex();
-            return starts.stream().map(st -> {
-                Traverser.Admin t = st.asAdmin();
-                if (mid != null) t = t.split(mid, midStep);
-                return (Traverser.Admin<E>) t.split(target, this);
-            });
-        } else {
-            return starts.stream().map(st -> {
-                Traverser.Admin t = st.asAdmin();
-                if (mid != null) t = t.split(mid, midStep);
-                return (Traverser.Admin<E>) t.split(edge, this);
-            });
-        }
+        Vertex target = edge.inVertex();
+        return starts.stream().map(st -> {
+            Traverser.Admin t = st.asAdmin();
+            if (mid != null) t = t.split(mid, midStep);
+            return (Traverser.Admin<E>) t.split(target, this);
+        });
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
@@ -204,43 +189,13 @@ public class UniGraphMultiHopStep<E extends Element> extends UniPredicatesStep<V
         }
 
         List<Traverser.Admin<E>> results = new ArrayList<>();
-        if (returnsVertex) {
-            List<Edge> edges1 = hopEdges(mids, hop1, true);
-            for (Edge edge : edges1) {
-                for (Vertex[] st : endpoints(edge, hop1.getDirection())) {
-                    Vertex midShell = st[0];
-                    Vertex fin = st[1];
-                    if (fin == null) continue;
-                    List<Object[]> origins = midsById.get(midShell.id());
-                    if (origins == null) continue;
-                    for (Object[] row : origins) {
-                        Object originId = row[0];
-                        Vertex mid = (Vertex) row[1];
-                        List<Traverser<Vertex>> startsFor = idToTraverser.get(originId);
-                        if (startsFor == null) continue;
-                        for (Traverser<Vertex> st0 : startsFor) {
-                            results.add(pathSplit(st0.asAdmin(), mid, fin));
-                        }
-                    }
-                }
-            }
-        } else {
-            // Final hop returns edges from mids
-            SearchVertexQuery q = new SearchVertexQuery(Edge.class, mids, hop1.getDirection(),
-                    hop1.getEdgePredicates(), limit, propertyKeys, orders, stepDescriptor, traversal);
-            List<Edge> edges1 = vertexControllers.stream()
-                    .flatMap(c -> ConversionUtils.asStream(c.search(q)))
-                    .collect(Collectors.toList());
-            for (Edge edge : edges1) {
-                // source vertex of this edge is the mid
-                Vertex midShell = hop1.getDirection() == Direction.IN ? edge.inVertex() : edge.outVertex();
-                if (midShell == null) continue;
+        List<Edge> edges1 = hopEdges(mids, hop1, true);
+        for (Edge edge : edges1) {
+            for (Vertex[] st : endpoints(edge, hop1.getDirection())) {
+                Vertex midShell = st[0];
+                Vertex fin = st[1];
+                if (fin == null) continue;
                 List<Object[]> origins = midsById.get(midShell.id());
-                if (origins == null) {
-                    // both() not used; try other endpoint
-                    Vertex other = hop1.getDirection() == Direction.IN ? edge.outVertex() : edge.inVertex();
-                    if (other != null) origins = midsById.get(other.id());
-                }
                 if (origins == null) continue;
                 for (Object[] row : origins) {
                     Object originId = row[0];
@@ -248,7 +203,7 @@ public class UniGraphMultiHopStep<E extends Element> extends UniPredicatesStep<V
                     List<Traverser<Vertex>> startsFor = idToTraverser.get(originId);
                     if (startsFor == null) continue;
                     for (Traverser<Vertex> st0 : startsFor) {
-                        results.add(pathSplit(st0.asAdmin(), mid, edge));
+                        results.add(pathSplit(st0.asAdmin(), mid, fin));
                     }
                 }
             }
@@ -257,14 +212,6 @@ public class UniGraphMultiHopStep<E extends Element> extends UniPredicatesStep<V
     }
 
     private List<Edge> hopEdges(List<Vertex> vertices, MultiHopQuery.HopSpec hop, boolean last) {
-        if (!returnsVertex && last) {
-            // edge-return final hop
-            SearchVertexQuery q = new SearchVertexQuery(Edge.class, vertices, hop.getDirection(),
-                    hop.getEdgePredicates(), limit, propertyKeys, orders, stepDescriptor, traversal);
-            return vertexControllers.stream()
-                    .flatMap(c -> ConversionUtils.asStream(c.search(q)))
-                    .collect(Collectors.toList());
-        }
         PredicatesHolder targetPreds = last ? finalVertexPredicates : PredicatesHolderFactory.empty();
         List<Pair<String, Order>> hopOrders = last ? orders : null;
         int hopLimit = last ? limit : -1;
@@ -354,13 +301,9 @@ public class UniGraphMultiHopStep<E extends Element> extends UniPredicatesStep<V
         return Collections.singleton(TraverserRequirement.OBJECT);
     }
 
-    public boolean returnsVertex() {
-        return returnsVertex;
-    }
-
     @Override
     public String toString() {
         List<Direction> dirs = hops.stream().map(MultiHopQuery.HopSpec::getDirection).collect(Collectors.toList());
-        return StringFactory.stepString(this, dirs, returnsVertex ? "vertex" : "edge");
+        return StringFactory.stepString(this, dirs, "vertex");
     }
 }

--- a/unipop-core/src/org/unipop/process/multihop/UniGraphMultiHopStep.java
+++ b/unipop-core/src/org/unipop/process/multihop/UniGraphMultiHopStep.java
@@ -1,0 +1,366 @@
+package org.unipop.process.multihop;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Order;
+import org.apache.tinkerpop.gremlin.process.traversal.Step;
+import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.step.Profiling;
+import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
+import org.apache.tinkerpop.gremlin.process.traversal.util.MutableMetrics;
+import org.apache.tinkerpop.gremlin.structure.Direction;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Element;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
+import org.javatuples.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.unipop.process.UniPredicatesStep;
+import org.unipop.process.order.Orderable;
+import org.unipop.process.predicate.ReceivesPredicatesHolder;
+import org.unipop.query.StepDescriptor;
+import org.unipop.query.controller.ControllerManager;
+import org.unipop.query.predicates.PredicatesHolder;
+import org.unipop.query.predicates.PredicatesHolderFactory;
+import org.unipop.query.search.DeferredVertexQuery;
+import org.unipop.query.search.MultiHopQuery;
+import org.unipop.query.search.SearchVertexQuery;
+import org.unipop.schema.reference.DeferredVertex;
+import org.unipop.structure.UniEdge;
+import org.unipop.structure.UniGraph;
+import org.unipop.structure.UniVertex;
+import org.unipop.util.ConversionUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Collapses two consecutive adjacency hops into one bulk query when a
+ * {@link MultiHopQuery.MultiHopController} can answer; otherwise runs hops sequentially.
+ * Final hop may return vertices ({@code out}/{@code in}) or edges ({@code outE}/{@code inE}).
+ */
+public class UniGraphMultiHopStep<E extends Element> extends UniPredicatesStep<Vertex, E>
+        implements ReceivesPredicatesHolder<Vertex, E>, Orderable, Profiling {
+
+    private static final Logger logger = LoggerFactory.getLogger(UniGraphMultiHopStep.class);
+    private static final String MID_PROP = "__unipop_mid";
+    private static final String SRC_ALIAS = "__unipop_src";
+
+    private final List<MultiHopQuery.HopSpec> hops;
+    private final boolean returnsVertex;
+    private PredicatesHolder finalVertexPredicates = PredicatesHolderFactory.empty();
+    private List<Pair<String, Order>> orders;
+    private int limit = -1;
+    private StepDescriptor stepDescriptor;
+    private final List<MultiHopQuery.MultiHopController> multiHopControllers;
+    private final List<SearchVertexQuery.SearchVertexController> vertexControllers;
+    private final List<DeferredVertexQuery.DeferredVertexController> deferredVertexControllers;
+
+    public UniGraphMultiHopStep(org.apache.tinkerpop.gremlin.process.traversal.Traversal.Admin traversal,
+                                UniGraph graph,
+                                ControllerManager controllerManager,
+                                List<MultiHopQuery.HopSpec> hops,
+                                PredicatesHolder finalVertexPredicates,
+                                boolean returnsVertex) {
+        super(traversal, graph);
+        this.hops = hops == null ? Collections.emptyList() : new ArrayList<>(hops);
+        this.returnsVertex = returnsVertex;
+        this.finalVertexPredicates = finalVertexPredicates == null
+                ? PredicatesHolderFactory.empty() : finalVertexPredicates;
+        this.multiHopControllers = controllerManager.getControllers(MultiHopQuery.MultiHopController.class);
+        this.vertexControllers = controllerManager.getControllers(SearchVertexQuery.SearchVertexController.class);
+        this.deferredVertexControllers = controllerManager.getControllers(DeferredVertexQuery.DeferredVertexController.class);
+        this.stepDescriptor = new StepDescriptor(this);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Iterator<Traverser.Admin<E>> process(List<Traverser.Admin<Vertex>> traversers) {
+        Map<Object, List<Traverser<Vertex>>> idToTraverser = new HashMap<>();
+        List<Vertex> starts = new ArrayList<>(traversers.size());
+        for (Traverser.Admin<Vertex> t : traversers) {
+            Vertex v = t.get();
+            idToTraverser.computeIfAbsent(v.id(), k -> new ArrayList<>(1)).add(t);
+            starts.add(v);
+        }
+
+        MultiHopQuery query = new MultiHopQuery(starts, hops, finalVertexPredicates, orders, limit,
+                propertyKeys, returnsVertex, stepDescriptor);
+        logger.debug("MultiHop query: {}", query);
+
+        Iterator<Edge> joined = null;
+        for (MultiHopQuery.MultiHopController c : multiHopControllers) {
+            joined = c.search(query);
+            if (joined != null) break;
+        }
+
+        Iterator<Traverser.Admin<E>> out;
+        if (joined != null) {
+            out = ConversionUtils.asStream(joined)
+                    .flatMap(edge -> mapCarrier(edge, idToTraverser))
+                    .iterator();
+        } else {
+            out = sequentialFallback(starts, idToTraverser);
+        }
+
+        if (returnsVertex) {
+            boolean noProps = propertyKeys != null && propertyKeys.isEmpty();
+            if (finalVertexPredicates.notEmpty() || !noProps) {
+                return hydrateIfNeeded((Iterator) out);
+            }
+        }
+        return out;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private Stream<Traverser.Admin<E>> mapCarrier(Edge edge, Map<Object, List<Traverser<Vertex>>> idToTraverser) {
+        Object startId = startIdOf(edge);
+        List<Traverser<Vertex>> starts = idToTraverser.get(startId);
+        if (starts == null) return Stream.empty();
+        Vertex mid = midOf(edge);
+        // Intermediate mid is always a Vertex; final may be Vertex or Edge — use raw split for mid.
+        Step midStep = this;
+        if (returnsVertex) {
+            Vertex target = edge.inVertex();
+            return starts.stream().map(st -> {
+                Traverser.Admin t = st.asAdmin();
+                if (mid != null) t = t.split(mid, midStep);
+                return (Traverser.Admin<E>) t.split(target, this);
+            });
+        } else {
+            return starts.stream().map(st -> {
+                Traverser.Admin t = st.asAdmin();
+                if (mid != null) t = t.split(mid, midStep);
+                return (Traverser.Admin<E>) t.split(edge, this);
+            });
+        }
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private Traverser.Admin<E> pathSplit(Traverser.Admin start, Object mid, Object end) {
+        Step midStep = this;
+        Traverser.Admin t = start;
+        if (mid != null) t = t.split(mid, midStep);
+        return (Traverser.Admin<E>) t.split(end, this);
+    }
+
+    private static Object startIdOf(Edge edge) {
+        if (edge instanceof UniEdge && edge.properties(SRC_ALIAS).hasNext()) {
+            return edge.property(SRC_ALIAS).value();
+        }
+        // Vertex-final multi-hop uses adjacencyJoinDirected: out = start shell
+        if (edge instanceof UniEdge && ((UniEdge) edge).isAdjacencyJoinDirected()) {
+            return edge.outVertex().id();
+        }
+        return edge.outVertex() != null ? edge.outVertex().id() : null;
+    }
+
+    private static Vertex midOf(Edge edge) {
+        if (edge.properties(MID_PROP).hasNext()) {
+            Object m = edge.property(MID_PROP).value();
+            if (m instanceof Vertex) return (Vertex) m;
+        }
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Iterator<Traverser.Admin<E>> sequentialFallback(List<Vertex> starts,
+                                                            Map<Object, List<Traverser<Vertex>>> idToTraverser) {
+        if (hops.size() == 2) {
+            return sequentialTwoHop(starts, idToTraverser);
+        }
+        return Collections.emptyIterator();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Iterator<Traverser.Admin<E>> sequentialTwoHop(List<Vertex> starts,
+                                                          Map<Object, List<Traverser<Vertex>>> idToTraverser) {
+        MultiHopQuery.HopSpec hop0 = hops.get(0);
+        MultiHopQuery.HopSpec hop1 = hops.get(1);
+
+        List<Edge> edges0 = hopEdges(starts, hop0, false);
+        List<Object[]> midRows = new ArrayList<>();
+        List<Vertex> mids = new ArrayList<>();
+        for (Edge edge : edges0) {
+            for (Vertex[] st : endpoints(edge, hop0.getDirection())) {
+                Vertex sourceShell = st[0];
+                Vertex mid = st[1];
+                if (mid == null || !idToTraverser.containsKey(sourceShell.id())) continue;
+                midRows.add(new Object[]{sourceShell.id(), mid});
+                mids.add(mid);
+            }
+        }
+
+        Map<Object, List<Object[]>> midsById = new HashMap<>();
+        for (Object[] row : midRows) {
+            Vertex mid = (Vertex) row[1];
+            midsById.computeIfAbsent(mid.id(), k -> new ArrayList<>()).add(row);
+        }
+
+        List<Traverser.Admin<E>> results = new ArrayList<>();
+        if (returnsVertex) {
+            List<Edge> edges1 = hopEdges(mids, hop1, true);
+            for (Edge edge : edges1) {
+                for (Vertex[] st : endpoints(edge, hop1.getDirection())) {
+                    Vertex midShell = st[0];
+                    Vertex fin = st[1];
+                    if (fin == null) continue;
+                    List<Object[]> origins = midsById.get(midShell.id());
+                    if (origins == null) continue;
+                    for (Object[] row : origins) {
+                        Object originId = row[0];
+                        Vertex mid = (Vertex) row[1];
+                        List<Traverser<Vertex>> startsFor = idToTraverser.get(originId);
+                        if (startsFor == null) continue;
+                        for (Traverser<Vertex> st0 : startsFor) {
+                            results.add(pathSplit(st0.asAdmin(), mid, fin));
+                        }
+                    }
+                }
+            }
+        } else {
+            // Final hop returns edges from mids
+            SearchVertexQuery q = new SearchVertexQuery(Edge.class, mids, hop1.getDirection(),
+                    hop1.getEdgePredicates(), limit, propertyKeys, orders, stepDescriptor, traversal);
+            List<Edge> edges1 = vertexControllers.stream()
+                    .flatMap(c -> ConversionUtils.asStream(c.search(q)))
+                    .collect(Collectors.toList());
+            for (Edge edge : edges1) {
+                // source vertex of this edge is the mid
+                Vertex midShell = hop1.getDirection() == Direction.IN ? edge.inVertex() : edge.outVertex();
+                if (midShell == null) continue;
+                List<Object[]> origins = midsById.get(midShell.id());
+                if (origins == null) {
+                    // both() not used; try other endpoint
+                    Vertex other = hop1.getDirection() == Direction.IN ? edge.outVertex() : edge.inVertex();
+                    if (other != null) origins = midsById.get(other.id());
+                }
+                if (origins == null) continue;
+                for (Object[] row : origins) {
+                    Object originId = row[0];
+                    Vertex mid = (Vertex) row[1];
+                    List<Traverser<Vertex>> startsFor = idToTraverser.get(originId);
+                    if (startsFor == null) continue;
+                    for (Traverser<Vertex> st0 : startsFor) {
+                        results.add(pathSplit(st0.asAdmin(), mid, edge));
+                    }
+                }
+            }
+        }
+        return results.iterator();
+    }
+
+    private List<Edge> hopEdges(List<Vertex> vertices, MultiHopQuery.HopSpec hop, boolean last) {
+        if (!returnsVertex && last) {
+            // edge-return final hop
+            SearchVertexQuery q = new SearchVertexQuery(Edge.class, vertices, hop.getDirection(),
+                    hop.getEdgePredicates(), limit, propertyKeys, orders, stepDescriptor, traversal);
+            return vertexControllers.stream()
+                    .flatMap(c -> ConversionUtils.asStream(c.search(q)))
+                    .collect(Collectors.toList());
+        }
+        PredicatesHolder targetPreds = last ? finalVertexPredicates : PredicatesHolderFactory.empty();
+        List<Pair<String, Order>> hopOrders = last ? orders : null;
+        int hopLimit = last ? limit : -1;
+        SearchVertexQuery q = new SearchVertexQuery(Edge.class, vertices, hop.getDirection(),
+                hop.getEdgePredicates(), -1, last ? propertyKeys : Collections.emptySet(), null,
+                targetPreds, hopOrders, hopLimit, true, stepDescriptor, traversal);
+        return vertexControllers.stream()
+                .flatMap(c -> ConversionUtils.asStream(c.search(q)))
+                .collect(Collectors.toList());
+    }
+
+    private List<Vertex[]> endpoints(Edge edge, Direction direction) {
+        List<Vertex[]> out = new ArrayList<>();
+        Direction mapDir = (edge instanceof UniEdge && ((UniEdge) edge).isAdjacencyJoinDirected())
+                ? Direction.OUT : direction;
+        Iterator<Vertex> ends = edge.vertices(mapDir);
+        while (ends.hasNext()) {
+            Vertex sourceShell = ends.next();
+            Vertex target = (edge instanceof UniEdge && ((UniEdge) edge).isAdjacencyJoinDirected())
+                    ? edge.inVertex()
+                    : UniVertex.vertexToVertex(sourceShell, edge, direction);
+            out.add(new Vertex[]{sourceShell, target});
+        }
+        return out;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Iterator<Traverser.Admin<E>> hydrateIfNeeded(Iterator<Traverser.Admin<E>> traversers) {
+        List<Traverser.Admin<E>> copy = ConversionUtils.asStream(traversers).collect(Collectors.toList());
+        List<DeferredVertex> deferred = copy.stream()
+                .map(Traverser::get)
+                .filter(v -> v instanceof DeferredVertex)
+                .map(v -> (DeferredVertex) v)
+                .filter(DeferredVertex::isDeferred)
+                .collect(Collectors.toList());
+        if (!deferred.isEmpty()) {
+            Set<String> fetchKeys = (finalVertexPredicates.notEmpty() && propertyKeys != null && propertyKeys.isEmpty())
+                    ? null : propertyKeys;
+            DeferredVertexQuery q = new DeferredVertexQuery(deferred, finalVertexPredicates, fetchKeys, orders,
+                    stepDescriptor, traversal);
+            deferredVertexControllers.forEach(c -> c.fetchProperties(q));
+        }
+        if (!finalVertexPredicates.notEmpty()) return copy.iterator();
+        Set<Object> matched = copy.stream().map(Traverser::get)
+                .filter(v -> v instanceof DeferredVertex && !((DeferredVertex) v).isDeferred())
+                .map(v -> ((DeferredVertex) v).id())
+                .collect(Collectors.toSet());
+        return copy.stream()
+                .filter(t -> {
+                    Element e = t.get();
+                    if (!(e instanceof DeferredVertex)) return true;
+                    return matched.contains(e.id()) || !((DeferredVertex) e).isDeferred();
+                })
+                .iterator();
+    }
+
+    @Override
+    public void addPredicate(PredicatesHolder predicatesHolder) {
+    }
+
+    @Override
+    public PredicatesHolder getPredicates() {
+        return PredicatesHolderFactory.empty();
+    }
+
+    public void setVertexPredicates(PredicatesHolder vertexPredicates) {
+        this.finalVertexPredicates = vertexPredicates == null ? PredicatesHolderFactory.empty() : vertexPredicates;
+    }
+
+    @Override
+    public void setLimit(int limit) {
+        this.limit = limit;
+    }
+
+    @Override
+    public void setOrders(List<Pair<String, Order>> orders) {
+        this.orders = orders;
+    }
+
+    @Override
+    public void setMetrics(MutableMetrics metrics) {
+        this.stepDescriptor = new StepDescriptor(this, metrics);
+    }
+
+    @Override
+    public Set<TraverserRequirement> getRequirements() {
+        return Collections.singleton(TraverserRequirement.OBJECT);
+    }
+
+    public boolean returnsVertex() {
+        return returnsVertex;
+    }
+
+    @Override
+    public String toString() {
+        List<Direction> dirs = hops.stream().map(MultiHopQuery.HopSpec::getDirection).collect(Collectors.toList());
+        return StringFactory.stepString(this, dirs, returnsVertex ? "vertex" : "edge");
+    }
+}

--- a/unipop-core/src/org/unipop/process/multihop/UniGraphMultiHopStepStrategy.java
+++ b/unipop-core/src/org/unipop/process/multihop/UniGraphMultiHopStepStrategy.java
@@ -7,13 +7,11 @@ import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 import org.apache.tinkerpop.gremlin.structure.Direction;
-import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.unipop.process.vertex.UniGraphVertexStep;
 import org.unipop.process.vertex.UniGraphVertexStepStrategy;
 import org.unipop.query.predicates.PredicatesHolder;
-import org.unipop.query.predicates.PredicatesHolderFactory;
 import org.unipop.query.search.MultiHopQuery;
 import org.unipop.structure.UniGraph;
 
@@ -22,12 +20,11 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Folds two consecutive adjacency hops into a {@link UniGraphMultiHopStep}:
- * <ul>
- *   <li>{@code out/in} → {@code out/in} (vertex-final)</li>
- *   <li>{@code out/in} → {@code outE/inE} (edge-final)</li>
- * </ul>
- * BOTH and intermediate labels/filters are not folded (v1).
+ * Folds two consecutive <b>vertex-return</b> adjacency hops ({@code out}/{@code in}) into a
+ * {@link UniGraphMultiHopStep}. Edge-final chains ({@code out().outE()}) stay as two
+ * {@link UniGraphVertexStep}s — sequential single-hop joins are typically faster than an
+ * unbounded multi-edge join on open topologies.
+ * BOTH and intermediate labels/filters are not folded.
  */
 public class UniGraphMultiHopStepStrategy
         extends AbstractTraversalStrategy<TraversalStrategy.ProviderOptimizationStrategy>
@@ -57,8 +54,10 @@ public class UniGraphMultiHopStepStrategy
 
             // Hop1 must return vertices (mid of the chain)
             if (!hop1.returnsVertex()) continue;
-            // Hop2 may return vertex or edge
-            boolean hop2Vertex = hop2.returnsVertex();
+            // Only fold vertex-final chains (out/in → out/in).
+            // Edge-final (out → outE) multi-join is often slower than sequential single-hop
+            // joins on open topologies (unbounded e0⋈e1); leave as two UniGraphVertexSteps.
+            if (!hop2.returnsVertex()) continue;
             if (hop1.getDirection() == Direction.BOTH || hop2.getDirection() == Direction.BOTH) continue;
             if (hop1.getNextStep() != hop2) continue;
             if (!hop1.getLabels().isEmpty() || !hop2.getLabels().isEmpty()) continue;
@@ -71,15 +70,10 @@ public class UniGraphMultiHopStepStrategy
             hopSpecs.add(new MultiHopQuery.HopSpec(hop1.getDirection(), hop1.getPredicates()));
             hopSpecs.add(new MultiHopQuery.HopSpec(hop2.getDirection(), hop2.getPredicates()));
 
-            PredicatesHolder finalPreds = hop2Vertex
-                    ? hop2.getVertexPredicates()
-                    : PredicatesHolderFactory.empty();
-            // Edge-return: edge has() already collected into hop2.predicates
-            UniGraphMultiHopStep multi = hop2Vertex
-                    ? new UniGraphMultiHopStep<Vertex>(traversal, uniGraph, uniGraph.getControllerManager(),
-                    hopSpecs, finalPreds, true)
-                    : new UniGraphMultiHopStep<Edge>(traversal, uniGraph, uniGraph.getControllerManager(),
-                    hopSpecs, finalPreds, false);
+            PredicatesHolder finalPreds = hop2.getVertexPredicates();
+            UniGraphMultiHopStep multi = new UniGraphMultiHopStep<Vertex>(
+                    traversal, uniGraph, uniGraph.getControllerManager(),
+                    hopSpecs, finalPreds, true);
 
             if (hop2.getOrders() != null) multi.setOrders(hop2.getOrders());
             if (hop2.getLimit() >= 0) multi.setLimit(hop2.getLimit());

--- a/unipop-core/src/org/unipop/process/multihop/UniGraphMultiHopStepStrategy.java
+++ b/unipop-core/src/org/unipop/process/multihop/UniGraphMultiHopStepStrategy.java
@@ -43,6 +43,11 @@ public class UniGraphMultiHopStepStrategy
         if (!(graph instanceof UniGraph)) return;
         UniGraph uniGraph = (UniGraph) graph;
 
+        // Only fold when a backend can actually push the multi-hop join down (JDBC). Otherwise
+        // folding just reroutes ES/REST/virtual through the sequential path with no benefit and
+        // extra regression surface — leave the two vertex steps untouched.
+        if (uniGraph.getControllerManager().getControllers(MultiHopQuery.MultiHopController.class).isEmpty()) return;
+
         List<Step> steps = new ArrayList<>(traversal.getSteps());
         for (int i = 0; i < steps.size() - 1; i++) {
             Step a = steps.get(i);
@@ -73,7 +78,7 @@ public class UniGraphMultiHopStepStrategy
             PredicatesHolder finalPreds = hop2.getVertexPredicates();
             UniGraphMultiHopStep multi = new UniGraphMultiHopStep<Vertex>(
                     traversal, uniGraph, uniGraph.getControllerManager(),
-                    hopSpecs, finalPreds, true);
+                    hopSpecs, finalPreds);
 
             if (hop2.getOrders() != null) multi.setOrders(hop2.getOrders());
             if (hop2.getLimit() >= 0) multi.setLimit(hop2.getLimit());

--- a/unipop-core/src/org/unipop/process/multihop/UniGraphMultiHopStepStrategy.java
+++ b/unipop-core/src/org/unipop/process/multihop/UniGraphMultiHopStepStrategy.java
@@ -1,0 +1,96 @@
+package org.unipop.process.multihop;
+
+import com.google.common.collect.Sets;
+import org.apache.tinkerpop.gremlin.process.traversal.Step;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
+import org.apache.tinkerpop.gremlin.structure.Direction;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.unipop.process.vertex.UniGraphVertexStep;
+import org.unipop.process.vertex.UniGraphVertexStepStrategy;
+import org.unipop.query.predicates.PredicatesHolder;
+import org.unipop.query.predicates.PredicatesHolderFactory;
+import org.unipop.query.search.MultiHopQuery;
+import org.unipop.structure.UniGraph;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Folds two consecutive adjacency hops into a {@link UniGraphMultiHopStep}:
+ * <ul>
+ *   <li>{@code out/in} → {@code out/in} (vertex-final)</li>
+ *   <li>{@code out/in} → {@code outE/inE} (edge-final)</li>
+ * </ul>
+ * BOTH and intermediate labels/filters are not folded (v1).
+ */
+public class UniGraphMultiHopStepStrategy
+        extends AbstractTraversalStrategy<TraversalStrategy.ProviderOptimizationStrategy>
+        implements TraversalStrategy.ProviderOptimizationStrategy {
+
+    @Override
+    public Set<Class<? extends ProviderOptimizationStrategy>> applyPrior() {
+        return Sets.newHashSet(UniGraphVertexStepStrategy.class);
+    }
+
+    @Override
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public void apply(Traversal.Admin<?, ?> traversal) {
+        if (TraversalHelper.onGraphComputer(traversal)) return;
+        Graph graph = traversal.getGraph().orElse(null);
+        if (!(graph instanceof UniGraph)) return;
+        UniGraph uniGraph = (UniGraph) graph;
+
+        List<Step> steps = new ArrayList<>(traversal.getSteps());
+        for (int i = 0; i < steps.size() - 1; i++) {
+            Step a = steps.get(i);
+            Step b = steps.get(i + 1);
+            if (!(a instanceof UniGraphVertexStep) || !(b instanceof UniGraphVertexStep)) continue;
+
+            UniGraphVertexStep hop1 = (UniGraphVertexStep) a;
+            UniGraphVertexStep hop2 = (UniGraphVertexStep) b;
+
+            // Hop1 must return vertices (mid of the chain)
+            if (!hop1.returnsVertex()) continue;
+            // Hop2 may return vertex or edge
+            boolean hop2Vertex = hop2.returnsVertex();
+            if (hop1.getDirection() == Direction.BOTH || hop2.getDirection() == Direction.BOTH) continue;
+            if (hop1.getNextStep() != hop2) continue;
+            if (!hop1.getLabels().isEmpty() || !hop2.getLabels().isEmpty()) continue;
+            // Intermediate filters/order/limit would require mid pushdown
+            if (hop1.getVertexPredicates() != null && hop1.getVertexPredicates().notEmpty()) continue;
+            if (hop1.getOrders() != null && !hop1.getOrders().isEmpty()) continue;
+            if (hop1.getLimit() >= 0) continue;
+
+            List<MultiHopQuery.HopSpec> hopSpecs = new ArrayList<>(2);
+            hopSpecs.add(new MultiHopQuery.HopSpec(hop1.getDirection(), hop1.getPredicates()));
+            hopSpecs.add(new MultiHopQuery.HopSpec(hop2.getDirection(), hop2.getPredicates()));
+
+            PredicatesHolder finalPreds = hop2Vertex
+                    ? hop2.getVertexPredicates()
+                    : PredicatesHolderFactory.empty();
+            // Edge-return: edge has() already collected into hop2.predicates
+            UniGraphMultiHopStep multi = hop2Vertex
+                    ? new UniGraphMultiHopStep<Vertex>(traversal, uniGraph, uniGraph.getControllerManager(),
+                    hopSpecs, finalPreds, true)
+                    : new UniGraphMultiHopStep<Edge>(traversal, uniGraph, uniGraph.getControllerManager(),
+                    hopSpecs, finalPreds, false);
+
+            if (hop2.getOrders() != null) multi.setOrders(hop2.getOrders());
+            if (hop2.getLimit() >= 0) multi.setLimit(hop2.getLimit());
+            if (hop2.getKeys() == null) multi.fetchAllKeys();
+            else for (Object key : hop2.getKeys()) multi.addPropertyKey(key.toString());
+
+            TraversalHelper.replaceStep(hop1, multi, traversal);
+            traversal.removeStep(hop2);
+
+            steps = new ArrayList<>(traversal.getSteps());
+            i = steps.indexOf(multi);
+        }
+    }
+}

--- a/unipop-core/src/org/unipop/process/order/UniGraphOrderStrategy.java
+++ b/unipop-core/src/org/unipop/process/order/UniGraphOrderStrategy.java
@@ -16,10 +16,13 @@ import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversal
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 import org.javatuples.Pair;
 import org.unipop.process.edge.EdgeStepsStrategy;
+import org.unipop.process.multihop.UniGraphMultiHopStepStrategy;
 import org.unipop.process.predicate.ReceivesPredicatesHolder;
 import org.unipop.process.repeat.UniGraphRepeatStepStrategy;
 import org.unipop.process.graph.UniGraphStepStrategy;
 import org.unipop.process.vertex.UniGraphVertexStepStrategy;
+import org.unipop.schema.catalog.SchemaCatalog;
+import org.unipop.structure.UniGraph;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -31,7 +34,8 @@ import java.util.stream.Stream;
 public class UniGraphOrderStrategy extends AbstractTraversalStrategy<TraversalStrategy.ProviderOptimizationStrategy> implements TraversalStrategy.ProviderOptimizationStrategy{
     @Override
     public Set<Class<? extends ProviderOptimizationStrategy>> applyPrior() {
-        return Sets.newHashSet(UniGraphStepStrategy.class, UniGraphVertexStepStrategy.class, UniGraphRepeatStepStrategy.class, EdgeStepsStrategy.class);
+        return Sets.newHashSet(UniGraphStepStrategy.class, UniGraphVertexStepStrategy.class,
+                UniGraphMultiHopStepStrategy.class, UniGraphRepeatStepStrategy.class, EdgeStepsStrategy.class);
     }
 
     @Override
@@ -46,6 +50,11 @@ public class UniGraphOrderStrategy extends AbstractTraversalStrategy<TraversalSt
                     .collect(Collectors.toList());
             Collection<Orderable> orderableStepOf = getOrderableStepOf(orderGlobalStep, traversal);
             if (orderableStepOf != null && orderableStepOf.size() == 1) {
+                // Skip folding order into the provider step when the schema catalog knows that no
+                // type can push all order keys — leave the native OrderGlobalStep for in-memory sort.
+                if (!catalogAllowsOrder(traversal, collect)) {
+                    return;
+                }
                 Orderable step = orderableStepOf.iterator().next();
                 step.setOrders(collect);
                 Step nextStep = orderGlobalStep.getNextStep();
@@ -58,6 +67,21 @@ public class UniGraphOrderStrategy extends AbstractTraversalStrategy<TraversalSt
                 }
             }
         });
+    }
+
+    /**
+     * When a {@link SchemaCatalog} is present on the graph, require that at least one type can
+     * push every order key. Missing catalog → allow (legacy behavior).
+     */
+    private static boolean catalogAllowsOrder(Traversal.Admin<?, ?> traversal,
+                                              List<Pair<String, Order>> orders) {
+        if (orders == null || orders.isEmpty()) return true;
+        Optional<org.apache.tinkerpop.gremlin.structure.Graph> opt = traversal.getGraph();
+        if (!opt.isPresent() || !(opt.get() instanceof UniGraph)) return true;
+        SchemaCatalog catalog = ((UniGraph) opt.get()).getSchemaCatalog();
+        if (catalog == null) return true;
+        List<String> keys = orders.stream().map(Pair::getValue0).filter(Objects::nonNull).collect(Collectors.toList());
+        return catalog.canPushOrderAnywhere(keys);
     }
 
     private Collection<Orderable> getOrderableStepOf(Step step, Traversal.Admin<?, ?> traversal) {

--- a/unipop-core/src/org/unipop/process/strategyregistrar/StandardStrategyProvider.java
+++ b/unipop-core/src/org/unipop/process/strategyregistrar/StandardStrategyProvider.java
@@ -10,6 +10,7 @@ import org.unipop.process.properties.UniGraphPropertiesStrategy;
 import org.unipop.process.range.UniGraphRangeStepStrategy;
 import org.unipop.process.repeat.UniGraphRepeatStepStrategy;
 import org.unipop.process.graph.UniGraphStepStrategy;
+import org.unipop.process.multihop.UniGraphMultiHopStepStrategy;
 import org.unipop.process.union.UniGraphUnionStepStrategy;
 import org.unipop.process.vertex.UniGraphVertexStepStrategy;
 import org.unipop.process.where.UniGraphWhereStepStrategy;
@@ -21,6 +22,7 @@ public class StandardStrategyProvider implements StrategyProvider {
         traversalStrategies.addStrategies(
                 new UniGraphStepStrategy(),
                 new UniGraphVertexStepStrategy(),
+                new UniGraphMultiHopStepStrategy(),
                 new EdgeStepsStrategy(),
                 new UniGraphPropertiesStrategy(),
                 new UniGraphCoalesceStepStrategy(),

--- a/unipop-core/src/org/unipop/process/vertex/UniGraphVertexStep.java
+++ b/unipop-core/src/org/unipop/process/vertex/UniGraphVertexStep.java
@@ -181,6 +181,30 @@ public class UniGraphVertexStep<E extends Element> extends UniPredicatesStep<Ver
         this.vertexPredicates = vertexPredicates == null ? PredicatesHolderFactory.empty() : vertexPredicates;
     }
 
+    public PredicatesHolder getVertexPredicates() {
+        return vertexPredicates;
+    }
+
+    public Direction getDirection() {
+        return direction;
+    }
+
+    public boolean returnsVertex() {
+        return returnsVertex;
+    }
+
+    public String[] getEdgeLabels() {
+        return edgeLabels;
+    }
+
+    public int getLimit() {
+        return limit;
+    }
+
+    public List<Pair<String, Order>> getOrders() {
+        return orders;
+    }
+
     @Override
     public void setLimit(int limit) {
         this.limit = limit;

--- a/unipop-core/src/org/unipop/query/controller/ConfigurationControllerManager.java
+++ b/unipop-core/src/org/unipop/query/controller/ConfigurationControllerManager.java
@@ -2,6 +2,9 @@ package org.unipop.query.controller;
 
 import org.apache.commons.configuration2.Configuration;
 import org.json.JSONObject;
+import org.unipop.schema.catalog.SchemaCatalog;
+import org.unipop.schema.catalog.SchemaCatalogAware;
+import org.unipop.schema.catalog.SchemaContributor;
 import org.unipop.schema.property.PropertySchema;
 import org.unipop.structure.traversalfilter.TraversalFilter;
 import org.unipop.structure.UniGraph;
@@ -15,6 +18,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -28,6 +32,7 @@ public class ConfigurationControllerManager implements ControllerManager {
     protected UniGraph graph;
     protected List<PropertySchema.PropertySchemaBuilder> thirdPartyPropertySchemas;
     protected TraversalFilter filter;
+    protected final SchemaCatalog schemaCatalog = new SchemaCatalog();
 
     public ConfigurationControllerManager(UniGraph graph, Configuration configuration, List<PropertySchema.PropertySchemaBuilder> thirdPartyPropertySchemas, TraversalFilter filter) throws Exception {
         path = Paths.get(configuration.getString("providers"));
@@ -38,6 +43,13 @@ public class ConfigurationControllerManager implements ControllerManager {
                 (newPath) -> loadControllers());
         loadControllers();
         this.watcher.start();
+    }
+
+    /**
+     * Internal schema catalog (type topology). Not a user-facing Graph API.
+     */
+    public SchemaCatalog getSchemaCatalog() {
+        return schemaCatalog;
     }
 
     private void loadControllers() throws IOException {
@@ -62,6 +74,25 @@ public class ConfigurationControllerManager implements ControllerManager {
                 }
             }
         });
+        rebuildSchemaCatalog();
+    }
+
+    private void rebuildSchemaCatalog() {
+        List<SchemaContributor> contributors = new ArrayList<>();
+        for (UniQueryController controller : controllers) {
+            if (controller instanceof SchemaContributor) {
+                contributors.add((SchemaContributor) controller);
+            }
+        }
+        schemaCatalog.rebuild(contributors);
+        for (UniQueryController controller : controllers) {
+            if (controller instanceof SchemaCatalogAware) {
+                ((SchemaCatalogAware) controller).setSchemaCatalog(schemaCatalog);
+            }
+        }
+        if (graph != null) {
+            graph.setSchemaCatalog(schemaCatalog);
+        }
     }
 
     private static String readFile(String filename) {

--- a/unipop-core/src/org/unipop/query/search/MultiHopQuery.java
+++ b/unipop-core/src/org/unipop/query/search/MultiHopQuery.java
@@ -18,14 +18,9 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Multi-hop adjacency query: collapse a 2-hop chain into one backend request when possible.
- * <ul>
- *   <li>{@code returnsVertex=true}: final hop is {@code out}/{@code in} — carriers are
- *       adjacencyJoinDirected edges (shell source = start, hydrated in = final vertex).</li>
- *   <li>{@code returnsVertex=false}: final hop is {@code outE}/{@code inE} — carriers are real
- *       final edges with mid stashed for path reconstruction.</li>
- * </ul>
- * Controllers return {@code null} to signal sequential fallback.
+ * Multi-hop adjacency query: collapse a 2-hop {@code out}/{@code in} chain into one backend
+ * request when possible. Carriers are adjacencyJoinDirected edges (shell source = start,
+ * hydrated in = final vertex). Controllers return {@code null} to signal sequential fallback.
  */
 public class MultiHopQuery extends UniQuery {
 
@@ -53,8 +48,6 @@ public class MultiHopQuery extends UniQuery {
     private final List<Pair<String, Order>> finalOrders;
     private final int finalLimit;
     private final Set<String> propertyKeys;
-    /** true = final is vertex (out/in); false = final is edge (outE/inE). */
-    private final boolean returnsVertex;
 
     public MultiHopQuery(List<Vertex> starts,
                          List<HopSpec> hops,
@@ -62,17 +55,6 @@ public class MultiHopQuery extends UniQuery {
                          List<Pair<String, Order>> finalOrders,
                          int finalLimit,
                          Set<String> propertyKeys,
-                         StepDescriptor stepDescriptor) {
-        this(starts, hops, finalTargetPredicates, finalOrders, finalLimit, propertyKeys, true, stepDescriptor);
-    }
-
-    public MultiHopQuery(List<Vertex> starts,
-                         List<HopSpec> hops,
-                         PredicatesHolder finalTargetPredicates,
-                         List<Pair<String, Order>> finalOrders,
-                         int finalLimit,
-                         Set<String> propertyKeys,
-                         boolean returnsVertex,
                          StepDescriptor stepDescriptor) {
         super(stepDescriptor);
         this.starts = starts == null ? Collections.emptyList() : starts;
@@ -81,7 +63,6 @@ public class MultiHopQuery extends UniQuery {
         this.finalOrders = finalOrders;
         this.finalLimit = finalLimit;
         this.propertyKeys = propertyKeys;
-        this.returnsVertex = returnsVertex;
     }
 
     public List<Vertex> getStarts() {
@@ -106,10 +87,6 @@ public class MultiHopQuery extends UniQuery {
 
     public Set<String> getPropertyKeys() {
         return propertyKeys;
-    }
-
-    public boolean isReturnsVertex() {
-        return returnsVertex;
     }
 
     /**

--- a/unipop-core/src/org/unipop/query/search/MultiHopQuery.java
+++ b/unipop-core/src/org/unipop/query/search/MultiHopQuery.java
@@ -1,0 +1,122 @@
+package org.unipop.query.search;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Order;
+import org.apache.tinkerpop.gremlin.structure.Direction;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.javatuples.Pair;
+import org.unipop.query.StepDescriptor;
+import org.unipop.query.UniQuery;
+import org.unipop.query.controller.UniQueryController;
+import org.unipop.query.predicates.PredicatesHolder;
+import org.unipop.query.predicates.PredicatesHolderFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Multi-hop adjacency query: collapse a 2-hop chain into one backend request when possible.
+ * <ul>
+ *   <li>{@code returnsVertex=true}: final hop is {@code out}/{@code in} — carriers are
+ *       adjacencyJoinDirected edges (shell source = start, hydrated in = final vertex).</li>
+ *   <li>{@code returnsVertex=false}: final hop is {@code outE}/{@code inE} — carriers are real
+ *       final edges with mid stashed for path reconstruction.</li>
+ * </ul>
+ * Controllers return {@code null} to signal sequential fallback.
+ */
+public class MultiHopQuery extends UniQuery {
+
+    public static final class HopSpec {
+        private final Direction direction;
+        private final PredicatesHolder edgePredicates;
+
+        public HopSpec(Direction direction, PredicatesHolder edgePredicates) {
+            this.direction = direction == null ? Direction.OUT : direction;
+            this.edgePredicates = edgePredicates == null ? PredicatesHolderFactory.empty() : edgePredicates;
+        }
+
+        public Direction getDirection() {
+            return direction;
+        }
+
+        public PredicatesHolder getEdgePredicates() {
+            return edgePredicates;
+        }
+    }
+
+    private final List<Vertex> starts;
+    private final List<HopSpec> hops;
+    private final PredicatesHolder finalTargetPredicates;
+    private final List<Pair<String, Order>> finalOrders;
+    private final int finalLimit;
+    private final Set<String> propertyKeys;
+    /** true = final is vertex (out/in); false = final is edge (outE/inE). */
+    private final boolean returnsVertex;
+
+    public MultiHopQuery(List<Vertex> starts,
+                         List<HopSpec> hops,
+                         PredicatesHolder finalTargetPredicates,
+                         List<Pair<String, Order>> finalOrders,
+                         int finalLimit,
+                         Set<String> propertyKeys,
+                         StepDescriptor stepDescriptor) {
+        this(starts, hops, finalTargetPredicates, finalOrders, finalLimit, propertyKeys, true, stepDescriptor);
+    }
+
+    public MultiHopQuery(List<Vertex> starts,
+                         List<HopSpec> hops,
+                         PredicatesHolder finalTargetPredicates,
+                         List<Pair<String, Order>> finalOrders,
+                         int finalLimit,
+                         Set<String> propertyKeys,
+                         boolean returnsVertex,
+                         StepDescriptor stepDescriptor) {
+        super(stepDescriptor);
+        this.starts = starts == null ? Collections.emptyList() : starts;
+        this.hops = hops == null ? Collections.emptyList() : Collections.unmodifiableList(new ArrayList<>(hops));
+        this.finalTargetPredicates = finalTargetPredicates == null ? PredicatesHolderFactory.empty() : finalTargetPredicates;
+        this.finalOrders = finalOrders;
+        this.finalLimit = finalLimit;
+        this.propertyKeys = propertyKeys;
+        this.returnsVertex = returnsVertex;
+    }
+
+    public List<Vertex> getStarts() {
+        return starts;
+    }
+
+    public List<HopSpec> getHops() {
+        return hops;
+    }
+
+    public PredicatesHolder getFinalTargetPredicates() {
+        return finalTargetPredicates;
+    }
+
+    public List<Pair<String, Order>> getFinalOrders() {
+        return finalOrders;
+    }
+
+    public int getFinalLimit() {
+        return finalLimit;
+    }
+
+    public Set<String> getPropertyKeys() {
+        return propertyKeys;
+    }
+
+    public boolean isReturnsVertex() {
+        return returnsVertex;
+    }
+
+    /**
+     * Multi-hop capable controllers. Returning {@code null} means "not applicable — fall back to
+     * sequential single-hop execution".
+     */
+    public interface MultiHopController extends UniQueryController {
+        Iterator<Edge> search(MultiHopQuery query);
+    }
+}

--- a/unipop-core/src/org/unipop/schema/catalog/Hop.java
+++ b/unipop-core/src/org/unipop/schema/catalog/Hop.java
@@ -1,0 +1,71 @@
+package org.unipop.schema.catalog;
+
+import org.apache.tinkerpop.gremlin.structure.Direction;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * One hop in a multi-hop type-level path request (direction + optional closed label filters).
+ */
+public final class Hop {
+    private final Direction direction;
+    private final Set<String> edgeLabels;
+    private final Set<String> targetLabels;
+
+    public Hop(Direction direction, Set<String> edgeLabels, Set<String> targetLabels) {
+        this.direction = direction == null ? Direction.OUT : direction;
+        this.edgeLabels = edgeLabels == null || edgeLabels.isEmpty()
+                ? Collections.emptySet()
+                : Collections.unmodifiableSet(new LinkedHashSet<>(edgeLabels));
+        this.targetLabels = targetLabels == null || targetLabels.isEmpty()
+                ? Collections.emptySet()
+                : Collections.unmodifiableSet(new LinkedHashSet<>(targetLabels));
+    }
+
+    public static Hop of(Direction direction) {
+        return new Hop(direction, null, null);
+    }
+
+    public static Hop of(Direction direction, Set<String> edgeLabels) {
+        return new Hop(direction, edgeLabels, null);
+    }
+
+    public static Hop of(Direction direction, Set<String> edgeLabels, Set<String> targetLabels) {
+        return new Hop(direction, edgeLabels, targetLabels);
+    }
+
+    public Direction getDirection() {
+        return direction;
+    }
+
+    public Set<String> getEdgeLabels() {
+        return edgeLabels;
+    }
+
+    public Set<String> getTargetLabels() {
+        return targetLabels;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Hop)) return false;
+        Hop hop = (Hop) o;
+        return direction == hop.direction
+                && edgeLabels.equals(hop.edgeLabels)
+                && targetLabels.equals(hop.targetLabels);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(direction, edgeLabels, targetLabels);
+    }
+
+    @Override
+    public String toString() {
+        return "Hop{" + direction + ", edgeLabels=" + edgeLabels + ", targetLabels=" + targetLabels + '}';
+    }
+}

--- a/unipop-core/src/org/unipop/schema/catalog/PathHop.java
+++ b/unipop-core/src/org/unipop/schema/catalog/PathHop.java
@@ -1,0 +1,53 @@
+package org.unipop.schema.catalog;
+
+import org.apache.tinkerpop.gremlin.structure.Direction;
+import org.unipop.schema.element.ElementSchema;
+
+import java.util.Objects;
+
+/**
+ * One resolved hop in a {@link PathPlan}: edge schema + direction + target vertex schema.
+ */
+public final class PathHop {
+    private final ElementSchema edgeSchema;
+    private final Direction direction;
+    private final ElementSchema targetVertexSchema;
+
+    public PathHop(ElementSchema edgeSchema, Direction direction, ElementSchema targetVertexSchema) {
+        this.edgeSchema = edgeSchema;
+        this.direction = direction;
+        this.targetVertexSchema = targetVertexSchema;
+    }
+
+    public ElementSchema getEdgeSchema() {
+        return edgeSchema;
+    }
+
+    public Direction getDirection() {
+        return direction;
+    }
+
+    public ElementSchema getTargetVertexSchema() {
+        return targetVertexSchema;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof PathHop)) return false;
+        PathHop pathHop = (PathHop) o;
+        return Objects.equals(edgeSchema, pathHop.edgeSchema)
+                && direction == pathHop.direction
+                && Objects.equals(targetVertexSchema, pathHop.targetVertexSchema);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(edgeSchema, direction, targetVertexSchema);
+    }
+
+    @Override
+    public String toString() {
+        return "PathHop{" + direction + ", edge=" + edgeSchema + ", target=" + targetVertexSchema + '}';
+    }
+}

--- a/unipop-core/src/org/unipop/schema/catalog/PathPlan.java
+++ b/unipop-core/src/org/unipop/schema/catalog/PathPlan.java
@@ -1,0 +1,50 @@
+package org.unipop.schema.catalog;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Ordered list of {@link PathHop}s forming one type-level multi-hop path.
+ */
+public final class PathPlan {
+    private final List<PathHop> hops;
+
+    public PathPlan(List<PathHop> hops) {
+        this.hops = hops == null
+                ? Collections.emptyList()
+                : Collections.unmodifiableList(new ArrayList<>(hops));
+    }
+
+    public List<PathHop> getHops() {
+        return hops;
+    }
+
+    public int size() {
+        return hops.size();
+    }
+
+    public PathPlan append(PathHop hop) {
+        List<PathHop> next = new ArrayList<>(hops);
+        next.add(hop);
+        return new PathPlan(next);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof PathPlan)) return false;
+        return hops.equals(((PathPlan) o).hops);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(hops);
+    }
+
+    @Override
+    public String toString() {
+        return "PathPlan" + hops;
+    }
+}

--- a/unipop-core/src/org/unipop/schema/catalog/SchemaCatalog.java
+++ b/unipop-core/src/org/unipop/schema/catalog/SchemaCatalog.java
@@ -1,0 +1,538 @@
+package org.unipop.schema.catalog;
+
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer;
+import org.apache.tinkerpop.gremlin.structure.Direction;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Element;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.VertexProperty;
+import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
+import org.unipop.query.predicates.PredicatesHolder;
+import org.unipop.schema.element.ElementSchema;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Internal schema catalog backed by a TinkerGraph of types (not instance data).
+ * Controllers and optimizers consult this for join fan-out pruning and pushdown eligibility.
+ * Not exposed as a user-facing Graph API.
+ */
+public final class SchemaCatalog {
+
+    public static final String V_SOURCE = "source";
+    public static final String V_VTYPE = "vtype";
+    public static final String V_ETYPE = "etype";
+
+    public static final String E_BOUND_TO = "boundTo";
+    public static final String E_OUT = "out";
+    public static final String E_IN = "in";
+
+    public static final String P_SCHEMA = "schema";
+    public static final String P_LABEL_OPEN = "labelOpen";
+    public static final String P_LABELS = "labels";
+    public static final String P_DYNAMIC_PROPS = "dynamicProps";
+    public static final String P_PROPERTY_KEYS = "propertyKeys";
+    public static final String P_SUPPORTS_JOIN = "supportsJoin";
+    public static final String P_SUPPORTS_ORDER = "supportsOrder";
+    public static final String P_SUPPORTS_RANGE = "supportsRange";
+    public static final String P_OUT_OPEN = "outOpen";
+    public static final String P_IN_OPEN = "inOpen";
+    public static final String P_SOURCE_ID = "id";
+    public static final String P_PROVIDER_CLASS = "providerClass";
+
+    private final Graph graph;
+
+    public SchemaCatalog() {
+        this.graph = TinkerGraph.open();
+    }
+
+    /** Test / advanced: wrap an existing graph (must be empty or already a catalog). */
+    SchemaCatalog(Graph graph) {
+        this.graph = graph;
+    }
+
+    /**
+     * Replace catalog contents from controller contributions (load / hot-reload).
+     */
+    public synchronized void rebuild(Collection<? extends SchemaContributor> contributors) {
+        clearGraph();
+        SchemaCatalogBuilder.build(graph, contributors);
+    }
+
+    private void clearGraph() {
+        List<Edge> edges = new ArrayList<>();
+        graph.edges().forEachRemaining(edges::add);
+        edges.forEach(Edge::remove);
+        List<Vertex> vertices = new ArrayList<>();
+        graph.vertices().forEachRemaining(vertices::add);
+        vertices.forEach(Vertex::remove);
+    }
+
+    /**
+     * Vertex schemas whose closed labels intersect {@code closedLabels}, plus every label-open vtype.
+     * Empty {@code closedLabels} returns all vertex schemas.
+     */
+    public Set<ElementSchema> vertexSchemas(Set<String> closedLabels) {
+        return typeSchemas(V_VTYPE, closedLabels);
+    }
+
+    /**
+     * Edge schemas whose closed labels intersect {@code closedLabels}, plus every label-open etype.
+     * Empty {@code closedLabels} returns all edge schemas.
+     */
+    public Set<ElementSchema> edgeSchemas(Set<String> closedLabels) {
+        return typeSchemas(V_ETYPE, closedLabels);
+    }
+
+    private Set<ElementSchema> typeSchemas(String kind, Set<String> closedLabels) {
+        Set<ElementSchema> out = new HashSet<>();
+        boolean anyFilter = closedLabels != null && !closedLabels.isEmpty();
+        graph.traversal().V().hasLabel(kind).toList().forEach(v -> {
+            if (!anyFilter || bool(v, P_LABEL_OPEN) || intersects(labelSet(v), closedLabels)) {
+                ElementSchema schema = schemaOf(v);
+                if (schema != null) out.add(schema);
+            }
+        });
+        return out;
+    }
+
+    /**
+     * Candidate target vertex schemas for an adjacency join on {@code edgeSchema} in {@code dir}.
+     * <ul>
+     *   <li>Open endpoint (or missing topology link) → all same-source vertex schemas
+     *       (optionally filtered by closed {@code targetLabels}).</li>
+     *   <li>Closed linked endpoints → only catalog-linked vtypes, then target-label filter.</li>
+     * </ul>
+     * Always includes label-open same-source vtypes when a target-label filter is applied.
+     */
+    public Set<ElementSchema> joinTargets(ElementSchema edgeSchema, Direction dir, Set<String> targetLabels) {
+        Vertex etype = findTypeVertex(V_ETYPE, edgeSchema);
+        if (etype == null) {
+            // Catalog miss: safe fallback — no pruning signal
+            return vertexSchemas(targetLabels);
+        }
+
+        boolean out = dir == Direction.OUT;
+        // Target endpoint is the opposite of the source endpoint of the hop.
+        // OUT hop: source=out, target=in. IN hop: source=in, target=out.
+        String targetEdgeLabel = out ? E_IN : E_OUT;
+        boolean targetOpen = out ? bool(etype, P_IN_OPEN) : bool(etype, P_OUT_OPEN);
+
+        Set<ElementSchema> candidates = new HashSet<>();
+        if (targetOpen) {
+            candidates.addAll(sameSourceVertexSchemas(etype));
+        } else {
+            Iterator<Edge> links = etype.edges(Direction.OUT, targetEdgeLabel);
+            boolean anyLink = false;
+            while (links.hasNext()) {
+                anyLink = true;
+                Vertex vtype = links.next().inVertex();
+                ElementSchema schema = schemaOf(vtype);
+                if (schema != null) candidates.add(schema);
+            }
+            // No resolved links (closed labels that matched no vtype) → empty is correct.
+            // If flags say closed but we never linked (builder couldn't), fall back to same-source.
+            if (!anyLink) {
+                candidates.addAll(sameSourceVertexSchemas(etype));
+            }
+        }
+
+        if (targetLabels == null || targetLabels.isEmpty()) {
+            return candidates;
+        }
+        return candidates.stream()
+                .filter(s -> {
+                    Vertex v = findTypeVertex(V_VTYPE, s);
+                    if (v == null) return true;
+                    return bool(v, P_LABEL_OPEN) || intersects(labelSet(v), targetLabels);
+                })
+                .collect(Collectors.toSet());
+    }
+
+    public boolean sameSource(ElementSchema a, ElementSchema b) {
+        Vertex va = findTypeVertexAny(a);
+        Vertex vb = findTypeVertexAny(b);
+        if (va == null || vb == null) return false;
+        Vertex sa = sourceOf(va);
+        Vertex sb = sourceOf(vb);
+        return sa != null && sa.equals(sb);
+    }
+
+    public boolean canJoin(ElementSchema edgeSchema) {
+        Vertex etype = findTypeVertex(V_ETYPE, edgeSchema);
+        return etype != null && bool(etype, P_SUPPORTS_JOIN);
+    }
+
+    /**
+     * True if the type declares the key, has dynamic properties, or is unknown to the catalog.
+     */
+    public boolean hasProperty(ElementSchema type, String key) {
+        Vertex v = findTypeVertexAny(type);
+        if (v == null) return true;
+        if (bool(v, P_DYNAMIC_PROPS)) return true;
+        return propertyKeys(v).contains(key);
+    }
+
+    /**
+     * True when every order key is pushable on this type (declared property or dynamic).
+     * Unknown types return true (do not block pushdown).
+     */
+    public boolean canPushOrder(ElementSchema type, Collection<String> orderKeys) {
+        if (orderKeys == null || orderKeys.isEmpty()) return true;
+        for (String key : orderKeys) {
+            if (key == null) continue;
+            if (!hasProperty(type, key)) return false;
+        }
+        return true;
+    }
+
+    /**
+     * True when at least one catalog type (vertex or edge) can push all order keys.
+     * Used by {@link org.unipop.process.order.UniGraphOrderStrategy} to skip folding when
+     * no backend schema can honor the order columns.
+     */
+    public boolean canPushOrderAnywhere(Collection<String> orderKeys) {
+        if (orderKeys == null || orderKeys.isEmpty()) return true;
+        for (ElementSchema s : vertexSchemas(Collections.emptySet())) {
+            if (canPushOrder(s, orderKeys)) return true;
+        }
+        for (ElementSchema s : edgeSchemas(Collections.emptySet())) {
+            if (canPushOrder(s, orderKeys)) return true;
+        }
+        // Empty catalog → don't block
+        return vertexSchemas(Collections.emptySet()).isEmpty()
+                && edgeSchemas(Collections.emptySet()).isEmpty();
+    }
+
+    /**
+     * Keep schemas that can match the closed label set. Open-label and catalog-unknown schemas
+     * always survive. Empty {@code closedLabels} returns the input unchanged (as a new set).
+     */
+    public <S extends ElementSchema> Set<S> filterByLabels(Collection<? extends S> schemas, Set<String> closedLabels) {
+        if (schemas == null || schemas.isEmpty()) return Collections.emptySet();
+        if (closedLabels == null || closedLabels.isEmpty()) return new LinkedHashSet<>(schemas);
+        Set<S> out = new LinkedHashSet<>();
+        for (S schema : schemas) {
+            if (matchesLabels(schema, closedLabels)) out.add(schema);
+        }
+        return out;
+    }
+
+    /**
+     * Whether {@code schema} can produce elements with any of the closed labels.
+     * Unknown / open-label types return true.
+     */
+    public boolean matchesLabels(ElementSchema schema, Set<String> closedLabels) {
+        if (closedLabels == null || closedLabels.isEmpty()) return true;
+        Vertex v = findTypeVertexAny(schema);
+        if (v == null) return true;
+        return bool(v, P_LABEL_OPEN) || intersects(labelSet(v), closedLabels);
+    }
+
+    /**
+     * Closed ~label values from a predicates holder (and nested children). Empty = unconstrained.
+     */
+    public static Set<String> extractClosedLabels(PredicatesHolder predicates) {
+        Set<String> labels = new HashSet<>();
+        if (predicates == null || predicates.isAborted()) return labels;
+        for (HasContainer has : predicates.getPredicates()) {
+            if (has == null || !Objects.equals(T.label.getAccessor(), has.getKey())) continue;
+            Object v = has.getValue();
+            if (v instanceof Collection) {
+                for (Object o : (Collection<?>) v) {
+                    if (o != null) labels.add(o.toString());
+                }
+            } else if (v != null) {
+                labels.add(v.toString());
+            }
+        }
+        if (predicates.getChildren() != null) {
+            for (PredicatesHolder child : predicates.getChildren()) {
+                labels.addAll(extractClosedLabels(child));
+            }
+        }
+        return labels;
+    }
+
+    /**
+     * Labels of concrete graph elements (e.g. deferred vertices) for fetch pruning.
+     */
+    public static Set<String> labelsOf(Collection<? extends Element> elements) {
+        Set<String> labels = new HashSet<>();
+        if (elements == null) return labels;
+        for (Element e : elements) {
+            if (e != null && e.label() != null) labels.add(e.label());
+        }
+        return labels;
+    }
+
+    /**
+     * Edge types that leave vertices whose labels intersect {@code fromLabels} (or all edges if
+     * fromLabels is empty / open endpoints apply).
+     */
+    public Set<ElementSchema> edgesFrom(Set<String> fromLabels, Direction dir) {
+        Set<ElementSchema> out = new LinkedHashSet<>();
+        boolean constrain = fromLabels != null && !fromLabels.isEmpty();
+        for (Vertex etype : graph.traversal().V().hasLabel(V_ETYPE).toList()) {
+            ElementSchema edgeSchema = schemaOf(etype);
+            if (edgeSchema == null) continue;
+            if (!constrain) {
+                out.add(edgeSchema);
+                continue;
+            }
+            // Source endpoint for the hop direction
+            boolean sourceOpen = dir == Direction.IN ? bool(etype, P_IN_OPEN) : bool(etype, P_OUT_OPEN);
+            if (dir == Direction.BOTH) {
+                sourceOpen = bool(etype, P_OUT_OPEN) || bool(etype, P_IN_OPEN);
+            }
+            if (sourceOpen) {
+                out.add(edgeSchema);
+                continue;
+            }
+            String linkLabel = dir == Direction.IN ? E_IN : E_OUT;
+            if (dir == Direction.BOTH) {
+                if (endpointIntersects(etype, E_OUT, fromLabels) || endpointIntersects(etype, E_IN, fromLabels)) {
+                    out.add(edgeSchema);
+                }
+            } else if (endpointIntersects(etype, linkLabel, fromLabels)) {
+                out.add(edgeSchema);
+            }
+        }
+        return out;
+    }
+
+    /**
+     * Vertex types reachable in at most {@code maxHops} hops from {@code fromLabels}
+     * (undirected catalog edges: out/in treated as bidirectional reachability).
+     * Includes start types when their labels intersect {@code fromLabels}.
+     * Open-label vtypes are always included in the frontier expansion.
+     */
+    public Set<ElementSchema> reachableVertexTypes(Set<String> fromLabels, int maxHops) {
+        if (maxHops < 0) return Collections.emptySet();
+        Set<ElementSchema> start = vertexSchemas(fromLabels == null ? Collections.emptySet() : fromLabels);
+        if (maxHops == 0) return start;
+
+        Set<ElementSchema> reached = new LinkedHashSet<>(start);
+        Queue<ElementSchema> frontier = new ArrayDeque<>(start);
+        for (int hop = 0; hop < maxHops && !frontier.isEmpty(); hop++) {
+            int size = frontier.size();
+            for (int i = 0; i < size; i++) {
+                ElementSchema v = frontier.poll();
+                Vertex vtype = findTypeVertex(V_VTYPE, v);
+                if (vtype == null) continue;
+                Set<String> labels = bool(vtype, P_LABEL_OPEN) ? Collections.emptySet() : labelSet(vtype);
+                // Neighbors via OUT hop (leave v on out endpoint) and IN hop (leave v on in endpoint)
+                for (ElementSchema edge : edgesFrom(labels.isEmpty() ? null : labels, Direction.BOTH)) {
+                    for (Direction d : new Direction[]{Direction.OUT, Direction.IN}) {
+                        for (ElementSchema nbr : joinTargets(edge, d, Collections.emptySet())) {
+                            if (reached.add(nbr)) frontier.add(nbr);
+                        }
+                    }
+                }
+            }
+        }
+        return reached;
+    }
+
+    /**
+     * True if any path of length ≤ {@code maxHops} exists from {@code fromLabels} to {@code toLabels}
+     * in the type topology.
+     */
+    public boolean pathExists(Set<String> fromLabels, Set<String> toLabels, int maxHops) {
+        Set<ElementSchema> reachable = reachableVertexTypes(fromLabels, maxHops);
+        if (toLabels == null || toLabels.isEmpty()) return !reachable.isEmpty();
+        for (ElementSchema s : reachable) {
+            if (matchesLabels(s, toLabels)) return true;
+        }
+        // Open-label targets: any reachability counts
+        for (ElementSchema s : reachable) {
+            Vertex v = findTypeVertex(V_VTYPE, s);
+            if (v != null && bool(v, P_LABEL_OPEN)) return true;
+        }
+        return false;
+    }
+
+    /**
+     * Enumerate type-level paths for a hop chain starting from vertices matching {@code startLabels}.
+     * Empty start labels → all vertex types. Caps at {@code maxPlans} results (0 or negative → 32).
+     * Returns empty when the closed topology admits no path; open endpoints expand candidacy.
+     */
+    public List<PathPlan> findPaths(Set<String> startLabels, List<Hop> hops, int maxPlans) {
+        int cap = maxPlans <= 0 ? 32 : maxPlans;
+        if (hops == null || hops.isEmpty()) return Collections.emptyList();
+
+        Set<ElementSchema> starts = vertexSchemas(startLabels == null ? Collections.emptySet() : startLabels);
+        // Frontier: current path plan so far + current vertex type at end of path
+        List<PathPlan> complete = new ArrayList<>();
+        List<PathPlan> frontierPlans = new ArrayList<>();
+        List<ElementSchema> frontierVerts = new ArrayList<>();
+        for (ElementSchema start : starts) {
+            frontierPlans.add(new PathPlan(Collections.emptyList()));
+            frontierVerts.add(start);
+        }
+
+        for (int hi = 0; hi < hops.size(); hi++) {
+            Hop hop = hops.get(hi);
+            if (hop.getDirection() == Direction.BOTH) {
+                // Expand BOTH as OUT ∪ IN for planning
+                List<PathPlan> nextPlans = new ArrayList<>();
+                List<ElementSchema> nextVerts = new ArrayList<>();
+                expandHop(frontierPlans, frontierVerts, Hop.of(Direction.OUT, hop.getEdgeLabels(), hop.getTargetLabels()),
+                        nextPlans, nextVerts, cap);
+                if (nextPlans.size() < cap) {
+                    expandHop(frontierPlans, frontierVerts, Hop.of(Direction.IN, hop.getEdgeLabels(), hop.getTargetLabels()),
+                            nextPlans, nextVerts, cap);
+                }
+                frontierPlans = nextPlans;
+                frontierVerts = nextVerts;
+            } else {
+                List<PathPlan> nextPlans = new ArrayList<>();
+                List<ElementSchema> nextVerts = new ArrayList<>();
+                expandHop(frontierPlans, frontierVerts, hop, nextPlans, nextVerts, cap);
+                frontierPlans = nextPlans;
+                frontierVerts = nextVerts;
+            }
+            if (frontierPlans.isEmpty()) return Collections.emptyList();
+            if (hi == hops.size() - 1) {
+                complete.addAll(frontierPlans);
+            }
+        }
+        return complete.size() > cap ? complete.subList(0, cap) : complete;
+    }
+
+    private void expandHop(List<PathPlan> frontierPlans, List<ElementSchema> frontierVerts, Hop hop,
+                           List<PathPlan> nextPlans, List<ElementSchema> nextVerts, int cap) {
+        Direction dir = hop.getDirection();
+        for (int i = 0; i < frontierPlans.size() && nextPlans.size() < cap; i++) {
+            PathPlan plan = frontierPlans.get(i);
+            ElementSchema from = frontierVerts.get(i);
+            Vertex vtype = findTypeVertex(V_VTYPE, from);
+            Set<String> fromLabels = (vtype != null && !bool(vtype, P_LABEL_OPEN))
+                    ? labelSet(vtype) : Collections.emptySet();
+            Set<ElementSchema> edges = edgesFrom(fromLabels.isEmpty() ? null : fromLabels, dir);
+            for (ElementSchema edge : edges) {
+                if (!hop.getEdgeLabels().isEmpty() && !matchesLabels(edge, hop.getEdgeLabels())) continue;
+                // Same-source only when both endpoints are catalogued
+                if (findTypeVertexAny(from) != null && findTypeVertexAny(edge) != null && !sameSource(from, edge)) {
+                    continue;
+                }
+                for (ElementSchema target : joinTargets(edge, dir, hop.getTargetLabels())) {
+                    if (findTypeVertexAny(edge) != null && findTypeVertexAny(target) != null && !sameSource(edge, target)) {
+                        continue;
+                    }
+                    if (nextPlans.size() >= cap) return;
+                    PathPlan extended = plan.append(new PathHop(edge, dir, target));
+                    nextPlans.add(extended);
+                    nextVerts.add(target);
+                }
+            }
+        }
+    }
+
+    /** Package-visible for tests. */
+    Graph graph() {
+        return graph;
+    }
+
+    // ---- helpers ----
+
+    private boolean endpointIntersects(Vertex etype, String catalogEdgeLabel, Set<String> labels) {
+        Iterator<Edge> links = etype.edges(Direction.OUT, catalogEdgeLabel);
+        boolean any = false;
+        while (links.hasNext()) {
+            any = true;
+            Vertex vtype = links.next().inVertex();
+            if (bool(vtype, P_LABEL_OPEN) || intersects(labelSet(vtype), labels)) return true;
+        }
+        // Closed endpoint with no links → does not match
+        return !any && bool(etype, catalogEdgeLabel.equals(E_OUT) ? P_OUT_OPEN : P_IN_OPEN);
+    }
+
+    private Set<ElementSchema> sameSourceVertexSchemas(Vertex etype) {
+        Vertex source = sourceOf(etype);
+        Set<ElementSchema> out = new HashSet<>();
+        if (source == null) {
+            return vertexSchemas(Collections.emptySet());
+        }
+        source.edges(Direction.IN, E_BOUND_TO).forEachRemaining(e -> {
+            Vertex type = e.outVertex();
+            if (V_VTYPE.equals(type.label())) {
+                ElementSchema schema = schemaOf(type);
+                if (schema != null) out.add(schema);
+            }
+        });
+        return out;
+    }
+
+    private Vertex sourceOf(Vertex typeVertex) {
+        Iterator<Edge> it = typeVertex.edges(Direction.OUT, E_BOUND_TO);
+        return it.hasNext() ? it.next().inVertex() : null;
+    }
+
+    private Vertex findTypeVertex(String kind, ElementSchema schema) {
+        if (schema == null) return null;
+        for (Vertex v : graph.traversal().V().hasLabel(kind).toList()) {
+            if (Objects.equals(schemaOf(v), schema)) return v;
+        }
+        return null;
+    }
+
+    private Vertex findTypeVertexAny(ElementSchema schema) {
+        Vertex v = findTypeVertex(V_VTYPE, schema);
+        return v != null ? v : findTypeVertex(V_ETYPE, schema);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ElementSchema schemaOf(Vertex v) {
+        VertexProperty<Object> p = v.property(P_SCHEMA);
+        if (!p.isPresent()) return null;
+        Object val = p.value();
+        return val instanceof ElementSchema ? (ElementSchema) val : null;
+    }
+
+    private static boolean bool(Vertex v, String key) {
+        VertexProperty<Object> p = v.property(key);
+        return p.isPresent() && Boolean.TRUE.equals(p.value());
+    }
+
+    @SuppressWarnings("unchecked")
+    static Set<String> labelSet(Vertex v) {
+        Set<String> labels = new HashSet<>();
+        v.properties(P_LABELS).forEachRemaining(p -> {
+            Object val = p.value();
+            if (val instanceof String) labels.add((String) val);
+        });
+        return labels;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Set<String> propertyKeys(Vertex v) {
+        Set<String> keys = new HashSet<>();
+        v.properties(P_PROPERTY_KEYS).forEachRemaining(p -> {
+            Object val = p.value();
+            if (val instanceof String) keys.add((String) val);
+        });
+        return keys;
+    }
+
+    private static boolean intersects(Set<String> a, Set<String> b) {
+        if (a == null || a.isEmpty() || b == null || b.isEmpty()) return false;
+        for (String s : a) {
+            if (b.contains(s)) return true;
+        }
+        return false;
+    }
+}

--- a/unipop-core/src/org/unipop/schema/catalog/SchemaCatalog.java
+++ b/unipop-core/src/org/unipop/schema/catalog/SchemaCatalog.java
@@ -53,7 +53,7 @@ public final class SchemaCatalog {
     public static final String P_SOURCE_ID = "id";
     public static final String P_PROVIDER_CLASS = "providerClass";
 
-    private final Graph graph;
+    private volatile Graph graph;
 
     public SchemaCatalog() {
         this.graph = TinkerGraph.open();
@@ -66,19 +66,14 @@ public final class SchemaCatalog {
 
     /**
      * Replace catalog contents from controller contributions (load / hot-reload).
+     * Builds a fresh graph and atomically swaps it in, so concurrent readers on the
+     * request path always see a fully-built graph (never a half-cleared one) without
+     * locking. {@code synchronized} only serializes competing rebuilds.
      */
     public synchronized void rebuild(Collection<? extends SchemaContributor> contributors) {
-        clearGraph();
-        SchemaCatalogBuilder.build(graph, contributors);
-    }
-
-    private void clearGraph() {
-        List<Edge> edges = new ArrayList<>();
-        graph.edges().forEachRemaining(edges::add);
-        edges.forEach(Edge::remove);
-        List<Vertex> vertices = new ArrayList<>();
-        graph.vertices().forEachRemaining(vertices::add);
-        vertices.forEach(Vertex::remove);
+        Graph fresh = TinkerGraph.open();
+        SchemaCatalogBuilder.build(fresh, contributors);
+        this.graph = fresh;
     }
 
     /**
@@ -143,10 +138,13 @@ public final class SchemaCatalog {
                 ElementSchema schema = schemaOf(vtype);
                 if (schema != null) candidates.add(schema);
             }
-            // No resolved links (closed labels that matched no vtype) → empty is correct.
-            // If flags say closed but we never linked (builder couldn't), fall back to same-source.
             if (!anyLink) {
+                // Closed flags but the builder linked nothing → safe fallback to all same-source.
                 candidates.addAll(sameSourceVertexSchemas(etype));
+            } else {
+                // Open-label vtypes are never linked (they match any label) yet can still hold the
+                // endpoint's labels — include same-source open-label vtypes so they aren't pruned.
+                candidates.addAll(sameSourceOpenLabelVertexSchemas(etype));
             }
         }
 
@@ -477,11 +475,28 @@ public final class SchemaCatalog {
         return out;
     }
 
+    /** Same-source vtypes whose label domain is open (accept any label). */
+    private Set<ElementSchema> sameSourceOpenLabelVertexSchemas(Vertex etype) {
+        Vertex source = sourceOf(etype);
+        Set<ElementSchema> out = new HashSet<>();
+        if (source == null) return out;
+        source.edges(Direction.IN, E_BOUND_TO).forEachRemaining(e -> {
+            Vertex type = e.outVertex();
+            if (V_VTYPE.equals(type.label()) && bool(type, P_LABEL_OPEN)) {
+                ElementSchema schema = schemaOf(type);
+                if (schema != null) out.add(schema);
+            }
+        });
+        return out;
+    }
+
     private Vertex sourceOf(Vertex typeVertex) {
         Iterator<Edge> it = typeVertex.edges(Direction.OUT, E_BOUND_TO);
         return it.hasNext() ? it.next().inVertex() : null;
     }
 
+    // ponytail: O(types) scan + a fresh traversal per call, fine while the catalog is type-sized.
+    // Memoize schema->vertex in a per-rebuild map if a large-schema profile ever shows it hurts.
     private Vertex findTypeVertex(String kind, ElementSchema schema) {
         if (schema == null) return null;
         for (Vertex v : graph.traversal().V().hasLabel(kind).toList()) {

--- a/unipop-core/src/org/unipop/schema/catalog/SchemaCatalogAware.java
+++ b/unipop-core/src/org/unipop/schema/catalog/SchemaCatalogAware.java
@@ -1,0 +1,9 @@
+package org.unipop.schema.catalog;
+
+/**
+ * Controllers that use the internal schema catalog for pruning / pushdown decisions.
+ */
+public interface SchemaCatalogAware {
+
+    void setSchemaCatalog(SchemaCatalog catalog);
+}

--- a/unipop-core/src/org/unipop/schema/catalog/SchemaCatalogBuilder.java
+++ b/unipop-core/src/org/unipop/schema/catalog/SchemaCatalogBuilder.java
@@ -1,0 +1,237 @@
+package org.unipop.schema.catalog;
+
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.VertexProperty;
+import org.unipop.schema.element.EdgeSchema;
+import org.unipop.schema.element.ElementSchema;
+import org.unipop.schema.element.VertexSchema;
+import org.unipop.schema.property.DynamicPropertySchema;
+import org.unipop.schema.property.NonDynamicPropertySchema;
+import org.unipop.schema.property.PropertySchema;
+import org.unipop.schema.property.StaticPropertySchema;
+import org.unipop.schema.reference.ReferenceVertexSchema;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Populates a TinkerGraph schema catalog from {@link SchemaContributor}s.
+ */
+final class SchemaCatalogBuilder {
+
+    private SchemaCatalogBuilder() {}
+
+    static void build(Graph graph, Collection<? extends SchemaContributor> contributors) {
+        if (contributors == null) return;
+        for (SchemaContributor contributor : contributors) {
+            if (contributor == null) continue;
+            addContribution(graph, contributor);
+        }
+    }
+
+    private static void addContribution(Graph graph, SchemaContributor contributor) {
+        Vertex source = graph.addVertex(T.label, SchemaCatalog.V_SOURCE);
+        source.property(SchemaCatalog.P_SOURCE_ID, contributor.sourceId());
+        source.property(SchemaCatalog.P_PROVIDER_CLASS, contributor.providerClass());
+
+        // schema instance → catalog vertex (vtype or etype)
+        Map<ElementSchema, Vertex> typeBySchema = new IdentityHashMap<>();
+        // Only true joinable / searchable roots from the controller — not pure ref endpoints.
+        List<ElementSchema> roots = new ArrayList<>(contributor.contributedSchemas());
+
+        for (ElementSchema schema : roots) {
+            if (schema == null || typeBySchema.containsKey(schema)) continue;
+            Vertex typeVertex = addTypeVertex(graph, schema, contributor, source);
+            if (typeVertex != null) typeBySchema.put(schema, typeVertex);
+        }
+
+        // Link edge endpoints to same-source vtypes by closed label intersection.
+        for (ElementSchema schema : roots) {
+            if (!(schema instanceof EdgeSchema)) continue;
+            Vertex etype = typeBySchema.get(schema);
+            if (etype == null) continue;
+            EdgeSchema edgeSchema = (EdgeSchema) schema;
+            linkEndpoint(etype, edgeSchema.getOutVertexSchema(), SchemaCatalog.E_OUT, SchemaCatalog.P_OUT_OPEN, typeBySchema, source);
+            linkEndpoint(etype, edgeSchema.getInVertexSchema(), SchemaCatalog.E_IN, SchemaCatalog.P_IN_OPEN, typeBySchema, source);
+        }
+    }
+
+    private static Vertex addTypeVertex(Graph graph, ElementSchema schema, SchemaContributor contributor, Vertex source) {
+        String kind;
+        if (schema instanceof VertexSchema) {
+            // Skip pure reference endpoints if somehow contributed — they are not join targets.
+            if (schema instanceof ReferenceVertexSchema) return null;
+            kind = SchemaCatalog.V_VTYPE;
+        } else if (schema instanceof EdgeSchema) {
+            kind = SchemaCatalog.V_ETYPE;
+        } else {
+            return null;
+        }
+
+        LabelInfo labelInfo = extractLabels(schema);
+        PropInfo propInfo = extractProperties(schema);
+
+        Vertex v = graph.addVertex(T.label, kind);
+        v.property(SchemaCatalog.P_SCHEMA, schema);
+        v.property(SchemaCatalog.P_LABEL_OPEN, labelInfo.open);
+        for (String label : labelInfo.labels) {
+            v.property(VertexProperty.Cardinality.set, SchemaCatalog.P_LABELS, label);
+        }
+        v.property(SchemaCatalog.P_DYNAMIC_PROPS, propInfo.dynamic);
+        for (String key : propInfo.keys) {
+            v.property(VertexProperty.Cardinality.set, SchemaCatalog.P_PROPERTY_KEYS, key);
+        }
+        v.property(SchemaCatalog.P_SUPPORTS_ORDER, true);
+        v.property(SchemaCatalog.P_SUPPORTS_RANGE, true);
+        if (SchemaCatalog.V_ETYPE.equals(kind)) {
+            v.property(SchemaCatalog.P_SUPPORTS_JOIN, contributor.supportsJoin(schema));
+            // Default open until linkEndpoint resolves; overwritten there.
+            v.property(SchemaCatalog.P_OUT_OPEN, true);
+            v.property(SchemaCatalog.P_IN_OPEN, true);
+        } else {
+            v.property(SchemaCatalog.P_SUPPORTS_JOIN, false);
+        }
+        v.addEdge(SchemaCatalog.E_BOUND_TO, source);
+        return v;
+    }
+
+    private static void linkEndpoint(Vertex etype, VertexSchema endpoint, String catalogEdgeLabel,
+                                     String openFlag, Map<ElementSchema, Vertex> typeBySchema, Vertex source) {
+        if (endpoint == null) {
+            etype.property(openFlag, true);
+            return;
+        }
+
+        // Nested non-ref vertex schema that is also a contributed vtype — link directly.
+        Vertex direct = typeBySchema.get(endpoint);
+        if (direct != null && SchemaCatalog.V_VTYPE.equals(direct.label())) {
+            etype.property(openFlag, false);
+            etype.addEdge(catalogEdgeLabel, direct);
+            return;
+        }
+
+        LabelInfo info = extractLabels(endpoint);
+        if (info.open || info.labels.isEmpty()) {
+            etype.property(openFlag, true);
+            return;
+        }
+
+        etype.property(openFlag, false);
+        // Link to every same-source vtype whose closed labels intersect the endpoint labels.
+        for (Map.Entry<ElementSchema, Vertex> e : typeBySchema.entrySet()) {
+            Vertex vtype = e.getValue();
+            if (!SchemaCatalog.V_VTYPE.equals(vtype.label())) continue;
+            if (!sameSource(vtype, source)) continue;
+            if (Boolean.TRUE.equals(vtype.property(SchemaCatalog.P_LABEL_OPEN).orElse(false))) {
+                // Open vtypes on the same source remain candidates via joinTargets fallback path;
+                // still add a link so closed-endpoint topology includes them? Prefer not — open
+                // vtypes are pulled in by joinTargets when target labels empty / via sameSource.
+                continue;
+            }
+            Set<String> vLabels = SchemaCatalog.labelSet(vtype);
+            if (intersects(vLabels, info.labels)) {
+                etype.addEdge(catalogEdgeLabel, vtype);
+            }
+        }
+    }
+
+    private static boolean sameSource(Vertex typeVertex, Vertex source) {
+        Iterator<org.apache.tinkerpop.gremlin.structure.Edge> it =
+                typeVertex.edges(org.apache.tinkerpop.gremlin.structure.Direction.OUT, SchemaCatalog.E_BOUND_TO);
+        return it.hasNext() && it.next().inVertex().equals(source);
+    }
+
+    static LabelInfo extractLabels(ElementSchema schema) {
+        LabelInfo info = new LabelInfo();
+        if (!(schema instanceof org.unipop.schema.property.AbstractPropertyContainer)) {
+            info.open = true;
+            return info;
+        }
+        List<PropertySchema> props = ((org.unipop.schema.property.AbstractPropertyContainer) schema).getPropertySchemas();
+        PropertySchema labelSchema = null;
+        for (PropertySchema p : props) {
+            if (p != null && Objects.equals(p.getKey(), T.label.getAccessor())) {
+                labelSchema = p;
+                break;
+            }
+        }
+        if (labelSchema == null) {
+            info.open = true;
+            return info;
+        }
+        // Closed domains: static label, FieldPropertySchema include, EnumPropertySchema values/include, …
+        Set<Object> known = labelSchema.knownValues();
+        if (known != null && !known.isEmpty()) {
+            info.open = false;
+            for (Object v : known) {
+                if (v != null) info.labels.add(v.toString());
+            }
+            if (info.labels.isEmpty()) info.open = true;
+            return info;
+        }
+        // Legacy path for StaticPropertySchema if knownValues ever empty
+        if (labelSchema instanceof StaticPropertySchema) {
+            info.open = false;
+            Object value = ((StaticPropertySchema) labelSchema).toProperties(java.util.Collections.emptyMap())
+                    .get(T.label.getAccessor());
+            if (value != null) info.labels.add(value.toString());
+            if (info.labels.isEmpty()) info.open = true;
+            return info;
+        }
+        info.open = true;
+        return info;
+    }
+
+    static PropInfo extractProperties(ElementSchema schema) {
+        PropInfo info = new PropInfo();
+        if (!(schema instanceof org.unipop.schema.property.AbstractPropertyContainer)) {
+            info.dynamic = true;
+            return info;
+        }
+        List<PropertySchema> props = ((org.unipop.schema.property.AbstractPropertyContainer) schema).getPropertySchemas();
+        for (PropertySchema p : props) {
+            if (p == null) continue;
+            if (p instanceof NonDynamicPropertySchema) {
+                info.dynamic = false;
+                continue;
+            }
+            if (p instanceof DynamicPropertySchema) {
+                info.dynamic = true;
+                continue;
+            }
+            String key = p.getKey();
+            if (key != null
+                    && !key.equals(T.id.getAccessor())
+                    && !key.equals(T.label.getAccessor())) {
+                info.keys.add(key);
+            }
+        }
+        return info;
+    }
+
+    private static boolean intersects(Set<String> a, Set<String> b) {
+        for (String s : a) {
+            if (b.contains(s)) return true;
+        }
+        return false;
+    }
+
+    static final class LabelInfo {
+        boolean open;
+        final Set<String> labels = new HashSet<>();
+    }
+
+    static final class PropInfo {
+        boolean dynamic;
+        final Set<String> keys = new HashSet<>();
+    }
+}

--- a/unipop-core/src/org/unipop/schema/catalog/SchemaContributor.java
+++ b/unipop-core/src/org/unipop/schema/catalog/SchemaContributor.java
@@ -1,0 +1,38 @@
+package org.unipop.schema.catalog;
+
+import org.unipop.schema.element.ElementSchema;
+
+import java.util.Set;
+
+/**
+ * Controllers that own {@link ElementSchema}s contribute them so the internal schema catalog
+ * can materialize type topology. Not a user-facing Graph API.
+ */
+public interface SchemaContributor {
+
+    /**
+     * Root (and search-relevant) element schemas this controller will query.
+     */
+    Set<? extends ElementSchema> contributedSchemas();
+
+    /**
+     * Stable source id for catalog {@code boundTo} edges (e.g. provider file path or class name).
+     */
+    default String sourceId() {
+        return getClass().getName();
+    }
+
+    /**
+     * Provider / controller class name recorded on the catalog source vertex.
+     */
+    default String providerClass() {
+        return getClass().getName();
+    }
+
+    /**
+     * Whether this edge schema supports adjacency JOIN pushdown (exact class checks live here).
+     */
+    default boolean supportsJoin(ElementSchema schema) {
+        return false;
+    }
+}

--- a/unipop-core/src/org/unipop/schema/element/EdgeSchema.java
+++ b/unipop-core/src/org/unipop/schema/element/EdgeSchema.java
@@ -6,4 +6,20 @@ import org.apache.tinkerpop.gremlin.structure.Edge;
  * An element schema which represents an edge
  */
 public interface EdgeSchema extends ElementSchema<Edge> {
+
+    /**
+     * Out-endpoint vertex schema when the edge mapping declares one (ref or nested).
+     * Default null — catalog treats the out endpoint as unresolved/open.
+     */
+    default VertexSchema getOutVertexSchema() {
+        return null;
+    }
+
+    /**
+     * In-endpoint vertex schema when the edge mapping declares one (ref or nested).
+     * Default null — catalog treats the in endpoint as unresolved/open.
+     */
+    default VertexSchema getInVertexSchema() {
+        return null;
+    }
 }

--- a/unipop-core/src/org/unipop/schema/property/FieldPropertySchema.java
+++ b/unipop-core/src/org/unipop/schema/property/FieldPropertySchema.java
@@ -100,6 +100,15 @@ public class FieldPropertySchema implements PropertySchema {
         return value.isPresent() ? Collections.singleton(value.get()) : null;
     }
 
+    /**
+     * When config declares {@code include}, that set is a closed domain (used e.g. for label
+     * columns that only hold a fixed set of values).
+     */
+    @Override
+    public Set<Object> knownValues() {
+        return include != null ? Collections.unmodifiableSet(include) : Collections.emptySet();
+    }
+
     @Override
     public PredicatesHolder toPredicate(HasContainer has) {
         P predicate;

--- a/unipop-core/src/org/unipop/schema/property/PropertySchema.java
+++ b/unipop-core/src/org/unipop/schema/property/PropertySchema.java
@@ -50,6 +50,15 @@ public interface PropertySchema {
     Set<Object> getValues(PredicatesHolder predicatesHolder);
 
     /**
+     * Closed domain of this property when known at config time (static value, include list,
+     * enum values, …). Empty means the domain is open / unknown — optimizers must not over-prune.
+     * Distinct from {@link #getValues(PredicatesHolder)}, which extracts values from a query predicate.
+     */
+    default Set<Object> knownValues() {
+        return Collections.emptySet();
+    }
+
+    /**
      * Converts a predicate to match the source field
      * @param predicatesHolder Predicates holder
      * @return A converted predicates holder

--- a/unipop-core/src/org/unipop/schema/property/StaticPropertySchema.java
+++ b/unipop-core/src/org/unipop/schema/property/StaticPropertySchema.java
@@ -47,6 +47,11 @@ public class StaticPropertySchema implements PropertySchema {
     }
 
     @Override
+    public Set<Object> knownValues() {
+        return Collections.singleton(value);
+    }
+
+    @Override
     public PredicatesHolder toPredicates(PredicatesHolder predicatesHolder) {
         Set<PredicatesHolder> predicates = predicatesHolder.findKey(this.key).map(has -> {
             if (has != null && !test(has.getPredicate())) {

--- a/unipop-core/src/org/unipop/structure/UniGraph.java
+++ b/unipop-core/src/org/unipop/structure/UniGraph.java
@@ -18,6 +18,7 @@ import org.unipop.query.mutation.AddVertexQuery;
 import org.unipop.query.predicates.PredicatesHolder;
 import org.unipop.query.predicates.PredicatesHolderFactory;
 import org.unipop.query.search.SearchQuery;
+import org.unipop.schema.catalog.SchemaCatalog;
 import org.unipop.schema.property.PropertySchema;
 import org.unipop.schema.property.type.*;
 import org.unipop.structure.traversalfilter.DefaultTraversalFilter;
@@ -101,6 +102,8 @@ public class UniGraph implements Graph {
     protected TraversalStrategies strategies;
     private ControllerManager controllerManager;
     private List<SearchQuery.SearchController> queryControllers;
+    /** Internal type-topology catalog; not part of the public Graph contract. */
+    private SchemaCatalog schemaCatalog;
 
     public UniGraph(Configuration configuration) throws Exception {
         configuration.setProperty(Graph.GRAPH, UniGraph.class.getName());
@@ -177,6 +180,18 @@ public class UniGraph implements Graph {
 
     public ControllerManager getControllerManager() {
         return controllerManager;
+    }
+
+    /**
+     * Internal schema catalog used by controllers/optimizers. Not a user-facing Graph API.
+     */
+    public SchemaCatalog getSchemaCatalog() {
+        return schemaCatalog;
+    }
+
+    /** Called by the controller manager after provider load/reload. */
+    public void setSchemaCatalog(SchemaCatalog schemaCatalog) {
+        this.schemaCatalog = schemaCatalog;
     }
 
     @Override

--- a/unipop-core/src/org/unipop/virtual/VirtualController.java
+++ b/unipop-core/src/org/unipop/virtual/VirtualController.java
@@ -17,6 +17,7 @@ import org.unipop.query.predicates.PredicatesHolder;
 import org.unipop.query.search.DeferredVertexQuery;
 import org.unipop.query.search.SearchQuery;
 import org.unipop.query.search.SearchVertexQuery;
+import org.unipop.schema.catalog.SchemaContributor;
 import org.unipop.schema.element.ElementSchema;
 import org.unipop.structure.UniEdge;
 import org.unipop.structure.UniGraph;
@@ -29,7 +30,7 @@ import java.util.stream.Stream;
 /**
  * Created by sbarzilay on 9/6/16.
  */
-public class VirtualController implements SimpleController {
+public class VirtualController implements SimpleController, SchemaContributor {
     private final UniGraph graph;
 
     private Set<? extends VirtualVertexSchema> vertexSchemas = new HashSet<>();
@@ -38,6 +39,11 @@ public class VirtualController implements SimpleController {
         this.graph = graph;
         vertexSchemas = schemas.stream().filter(schema -> schema instanceof VirtualVertexSchema)
                 .map(schema -> ((VirtualVertexSchema) schema)).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<? extends ElementSchema> contributedSchemas() {
+        return vertexSchemas != null ? new HashSet<>(vertexSchemas) : Collections.emptySet();
     }
 
     @Override

--- a/unipop-core/test/org/unipop/schema/catalog/SchemaCatalogTest.java
+++ b/unipop-core/test/org/unipop/schema/catalog/SchemaCatalogTest.java
@@ -125,6 +125,26 @@ public class SchemaCatalogTest {
     }
 
     @Test
+    public void joinTargetsIncludeSameSourceOpenLabelVtype() {
+        FakeVertex host = vertex("host", "status", "name");
+        FakeVertex person = vertex("person", "status", "name");
+        FakeVertex anything = openLabelVertex("status"); // open-label vtype, same source
+        FakeEdge owns = edge("owns",
+                new ReferenceVertexSchema(endpointJson("@src_id", "person"), null),
+                new ReferenceVertexSchema(endpointJson("@dst_id", "host"), null),
+                true);
+
+        SchemaCatalog catalog = catalogOf(host, person, anything, owns);
+
+        // OUT hop → closed endpoint "host"; the open-label vtype can also hold host-labeled rows,
+        // so it must survive pruning alongside the closed-linked host.
+        Set<ElementSchema> outTargets = catalog.joinTargets(owns, Direction.OUT, Collections.emptySet());
+        assertTrue("closed-linked host present", outTargets.contains(host));
+        assertTrue("same-source open-label vtype must not be pruned", outTargets.contains(anything));
+        assertFalse("person is the OUT source, not an OUT target", outTargets.contains(person));
+    }
+
+    @Test
     public void openEndpointFallsBackToSameSourceVertices() {
         FakeVertex host = vertex("host", "status");
         FakeVertex person = vertex("person", "status");

--- a/unipop-core/test/org/unipop/schema/catalog/SchemaCatalogTest.java
+++ b/unipop-core/test/org/unipop/schema/catalog/SchemaCatalogTest.java
@@ -1,0 +1,435 @@
+package org.unipop.schema.catalog;
+
+import org.apache.tinkerpop.gremlin.structure.Direction;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.json.JSONObject;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.unipop.schema.element.AbstractElementSchema;
+import org.unipop.schema.element.EdgeSchema;
+import org.unipop.schema.element.ElementSchema;
+import org.unipop.schema.element.VertexSchema;
+import org.unipop.schema.property.type.DateType;
+import org.unipop.schema.property.type.DoubleType;
+import org.unipop.schema.property.type.FloatType;
+import org.unipop.schema.property.type.IntType;
+import org.unipop.schema.property.type.LongType;
+import org.unipop.schema.property.type.NumberType;
+import org.unipop.schema.property.type.TextType;
+import org.unipop.schema.reference.ReferenceVertexSchema;
+import org.unipop.util.PropertySchemaFactory;
+import org.unipop.util.PropertyTypeFactory;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SchemaCatalogTest {
+
+    @BeforeClass
+    public static void initPropertyTypes() {
+        PropertyTypeFactory.init(Arrays.asList(
+                TextType.class.getCanonicalName(),
+                DateType.class.getCanonicalName(),
+                NumberType.class.getCanonicalName(),
+                DoubleType.class.getCanonicalName(),
+                FloatType.class.getCanonicalName(),
+                IntType.class.getCanonicalName(),
+                LongType.class.getCanonicalName()));
+        PropertySchemaFactory.build(Collections.emptyList(), Collections.emptyList());
+    }
+
+    @Test
+    public void closedLabelsIndexVertexAndEdgeTypes() {
+        FakeVertex host = vertex("host", "status", "name");
+        FakeVertex person = vertex("person", "status", "name");
+        FakeEdge owns = edge("owns", ref("@src_id", "person"), ref("@dst_id", "host"), true);
+
+        SchemaCatalog catalog = catalogOf(host, person, owns);
+
+        assertEquals(1, catalog.vertexSchemas(Collections.singleton("host")).size());
+        assertTrue(catalog.vertexSchemas(Collections.singleton("host")).contains(host));
+        assertEquals(1, catalog.vertexSchemas(Collections.singleton("person")).size());
+        assertTrue(catalog.edgeSchemas(Collections.singleton("owns")).contains(owns));
+        assertTrue(catalog.canJoin(owns));
+    }
+
+    @Test
+    public void openLabelTypesAlwaysIncluded() {
+        FakeVertex openV = openLabelVertex("status");
+        FakeVertex host = vertex("host", "name");
+        SchemaCatalog catalog = catalogOf(openV, host);
+
+        Set<ElementSchema> forHost = catalog.vertexSchemas(Collections.singleton("host"));
+        assertTrue(forHost.contains(host));
+        assertTrue("open-label vtype must not be pruned", forHost.contains(openV));
+    }
+
+    @Test
+    public void includeListOnLabelIsClosedDomain() {
+        // Field label with include — same pattern as jdbc inneredge modern config.
+        FakeVertex personOnly = fieldLabelVertex(Collections.singleton("person"), "name");
+        FakeVertex softwareOnly = fieldLabelVertex(Collections.singleton("software"), "lang");
+        SchemaCatalog catalog = catalogOf(personOnly, softwareOnly);
+
+        assertEquals(Collections.singleton(personOnly), catalog.vertexSchemas(Collections.singleton("person")));
+        assertEquals(Collections.singleton(softwareOnly), catalog.vertexSchemas(Collections.singleton("software")));
+        assertFalse(catalog.vertexSchemas(Collections.singleton("person")).contains(softwareOnly));
+    }
+
+    @Test
+    public void knownValuesOnLabelClosesJoinTargets() {
+        FakeVertex person = fieldLabelVertex(Collections.singleton("person"), "name");
+        FakeVertex host = fieldLabelVertex(Collections.singleton("host"), "status");
+        FakeEdge owns = edge("owns",
+                new ReferenceVertexSchema(endpointJsonWithInclude("@src", Collections.singleton("person")), null),
+                new ReferenceVertexSchema(endpointJsonWithInclude("@dst", Collections.singleton("host")), null),
+                true);
+
+        SchemaCatalog catalog = catalogOf(person, host, owns);
+        assertEquals(Collections.singleton(host), catalog.joinTargets(owns, Direction.OUT, Collections.emptySet()));
+        assertEquals(Collections.singleton(person), catalog.joinTargets(owns, Direction.IN, Collections.emptySet()));
+    }
+
+    @Test
+    public void joinTargetsUseClosedEndpointLinks() {
+        FakeVertex host = vertex("host", "status", "name");
+        FakeVertex person = vertex("person", "status", "name");
+        FakeEdge owns = edge("owns",
+                new ReferenceVertexSchema(endpointJson("@src_id", "person"), null),
+                new ReferenceVertexSchema(endpointJson("@dst_id", "host"), null),
+                true);
+
+        SchemaCatalog catalog = catalogOf(host, person, owns);
+
+        Set<ElementSchema> outTargets = catalog.joinTargets(owns, Direction.OUT, Collections.emptySet());
+        assertEquals(Collections.singleton(host), outTargets);
+
+        Set<ElementSchema> inTargets = catalog.joinTargets(owns, Direction.IN, Collections.emptySet());
+        assertEquals(Collections.singleton(person), inTargets);
+
+        Set<ElementSchema> outHostOnly = catalog.joinTargets(owns, Direction.OUT, Collections.singleton("host"));
+        assertEquals(Collections.singleton(host), outHostOnly);
+
+        Set<ElementSchema> outPersonFilter = catalog.joinTargets(owns, Direction.OUT, Collections.singleton("person"));
+        assertTrue("target label filter should drop non-matching closed vtypes", outPersonFilter.isEmpty());
+    }
+
+    @Test
+    public void openEndpointFallsBackToSameSourceVertices() {
+        FakeVertex host = vertex("host", "status");
+        FakeVertex person = vertex("person", "status");
+        FakeEdge knows = edge("knows",
+                new ReferenceVertexSchema(endpointJsonOpen("@outid"), null),
+                new ReferenceVertexSchema(endpointJsonOpen("@inid"), null),
+                true);
+
+        SchemaCatalog catalog = catalogOf(host, person, knows);
+
+        Set<ElementSchema> targets = catalog.joinTargets(knows, Direction.OUT, Collections.emptySet());
+        assertEquals(2, targets.size());
+        assertTrue(targets.contains(host));
+        assertTrue(targets.contains(person));
+    }
+
+    @Test
+    public void supportsJoinFalseWhenContributorSaysSo() {
+        FakeVertex host = vertex("host");
+        FakeEdge inner = edge("embedded",
+                new ReferenceVertexSchema(endpointJson("@o", "host"), null),
+                new ReferenceVertexSchema(endpointJson("@i", "host"), null),
+                false);
+
+        SchemaCatalog catalog = new SchemaCatalog();
+        catalog.rebuild(Collections.singletonList(contributor(false, host, inner)));
+        assertFalse(catalog.canJoin(inner));
+    }
+
+    @Test
+    public void hasPropertyRespectsDeclaredKeysAndDynamic() {
+        FakeVertex host = vertex("host", "status", "name");
+        FakeVertex dyn = dynamicVertex("blob");
+        SchemaCatalog catalog = catalogOf(host, dyn);
+
+        assertTrue(catalog.hasProperty(host, "status"));
+        assertFalse(catalog.hasProperty(host, "missing"));
+        assertTrue(catalog.hasProperty(dyn, "anything"));
+    }
+
+    @Test
+    public void sameSourceTrueWithinContribution() {
+        FakeVertex host = vertex("host");
+        FakeEdge owns = edge("owns",
+                new ReferenceVertexSchema(endpointJson("@s", "host"), null),
+                new ReferenceVertexSchema(endpointJson("@d", "host"), null),
+                true);
+        SchemaCatalog catalog = catalogOf(host, owns);
+        assertTrue(catalog.sameSource(host, owns));
+    }
+
+    @Test
+    public void filterByLabelsDropsClosedMismatches() {
+        FakeVertex host = vertex("host");
+        FakeVertex person = vertex("person");
+        SchemaCatalog catalog = catalogOf(host, person);
+        Set<ElementSchema> onlyHost = catalog.filterByLabels(Arrays.asList(host, person), Collections.singleton("host"));
+        assertEquals(Collections.singleton(host), onlyHost);
+    }
+
+    @Test
+    public void canPushOrderRespectsDeclaredProperties() {
+        FakeVertex host = vertex("host", "status", "name");
+        SchemaCatalog catalog = catalogOf(host);
+        assertTrue(catalog.canPushOrder(host, Arrays.asList("status", "name")));
+        assertFalse(catalog.canPushOrder(host, Collections.singletonList("missing")));
+        assertTrue(catalog.canPushOrderAnywhere(Collections.singletonList("status")));
+        assertFalse(catalog.canPushOrderAnywhere(Collections.singletonList("missing")));
+    }
+
+    @Test
+    public void edgesFromAndReachability() {
+        FakeVertex host = vertex("host", "status");
+        FakeVertex person = vertex("person", "name");
+        FakeEdge owns = edge("owns",
+                new ReferenceVertexSchema(endpointJson("@src", "person"), null),
+                new ReferenceVertexSchema(endpointJson("@dst", "host"), null),
+                true);
+        SchemaCatalog catalog = catalogOf(host, person, owns);
+
+        Set<ElementSchema> fromPerson = catalog.edgesFrom(Collections.singleton("person"), Direction.OUT);
+        assertTrue(fromPerson.contains(owns));
+
+        Set<ElementSchema> fromHostOut = catalog.edgesFrom(Collections.singleton("host"), Direction.OUT);
+        assertFalse("host is not an out-endpoint of owns", fromHostOut.contains(owns));
+
+        assertTrue(catalog.pathExists(Collections.singleton("person"), Collections.singleton("host"), 1));
+        // Reachability treats catalog edges as bidirectional for multi-hop planning.
+        assertTrue(catalog.pathExists(Collections.singleton("host"), Collections.singleton("person"), 1));
+
+        Set<ElementSchema> reachable = catalog.reachableVertexTypes(Collections.singleton("person"), 1);
+        assertTrue(reachable.contains(person));
+        assertTrue(reachable.contains(host));
+    }
+
+    @Test
+    public void findPathsTwoHopClosedTopology() {
+        FakeVertex host = vertex("host", "status");
+        FakeVertex person = vertex("person", "name");
+        FakeEdge owns = edge("owns",
+                new ReferenceVertexSchema(endpointJson("@src", "person"), null),
+                new ReferenceVertexSchema(endpointJson("@dst", "host"), null),
+                true);
+        // host -runs-> person (second hop type)
+        FakeEdge runs = edge("runs",
+                new ReferenceVertexSchema(endpointJson("@src", "host"), null),
+                new ReferenceVertexSchema(endpointJson("@dst", "person"), null),
+                true);
+        SchemaCatalog catalog = catalogOf(host, person, owns, runs);
+
+        List<Hop> hops = Arrays.asList(
+                Hop.of(Direction.OUT, Collections.singleton("owns")),
+                Hop.of(Direction.OUT, Collections.singleton("runs"), Collections.singleton("person")));
+        List<PathPlan> plans = catalog.findPaths(Collections.singleton("person"), hops, 32);
+        assertFalse(plans.isEmpty());
+        assertEquals(2, plans.get(0).size());
+        assertEquals(owns, plans.get(0).getHops().get(0).getEdgeSchema());
+        assertEquals(runs, plans.get(0).getHops().get(1).getEdgeSchema());
+
+        // Impossible: person -runs-> ...
+        List<PathPlan> none = catalog.findPaths(Collections.singleton("person"),
+                Collections.singletonList(Hop.of(Direction.OUT, Collections.singleton("runs"))), 32);
+        assertTrue(none.isEmpty());
+    }
+
+    @Test
+    public void extractClosedLabelsFromPredicates() {
+        org.unipop.query.predicates.PredicatesHolder ph =
+                org.unipop.query.predicates.PredicatesHolderFactory.predicate(
+                        new org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer(
+                                org.apache.tinkerpop.gremlin.structure.T.label.getAccessor(),
+                                org.apache.tinkerpop.gremlin.process.traversal.P.within("a", "b")));
+        Set<String> labels = SchemaCatalog.extractClosedLabels(ph);
+        assertEquals(new HashSet<>(Arrays.asList("a", "b")), labels);
+    }
+
+    @Test
+    public void rebuildReplacesContents() {
+        FakeVertex host = vertex("host");
+        SchemaCatalog catalog = catalogOf(host);
+        assertEquals(1, catalog.vertexSchemas(Collections.emptySet()).size());
+
+        FakeVertex person = vertex("person");
+        catalog.rebuild(Collections.singletonList(contributor(false, person)));
+        assertEquals(1, catalog.vertexSchemas(Collections.emptySet()).size());
+        assertTrue(catalog.vertexSchemas(Collections.singleton("person")).contains(person));
+        assertTrue(catalog.vertexSchemas(Collections.singleton("host")).isEmpty()
+                || !catalog.vertexSchemas(Collections.singleton("host")).contains(host));
+    }
+
+    // ---- helpers ----
+
+    private static SchemaCatalog catalogOf(ElementSchema... schemas) {
+        SchemaCatalog catalog = new SchemaCatalog();
+        catalog.rebuild(Collections.singletonList(contributor(true, schemas)));
+        return catalog;
+    }
+
+    private static SchemaContributor contributor(boolean joinAllEdges, ElementSchema... schemas) {
+        Set<ElementSchema> set = new HashSet<>(Arrays.asList(schemas));
+        return new SchemaContributor() {
+            @Override
+            public Set<? extends ElementSchema> contributedSchemas() {
+                return set;
+            }
+
+            @Override
+            public String sourceId() {
+                return "test-source";
+            }
+
+            @Override
+            public boolean supportsJoin(ElementSchema schema) {
+                return joinAllEdges && schema instanceof EdgeSchema;
+            }
+        };
+    }
+
+    private static FakeVertex vertex(String label, String... props) {
+        JSONObject json = new JSONObject()
+                .put("id", "@id")
+                .put("label", label)
+                .put("dynamicProperties", false);
+        JSONObject properties = new JSONObject();
+        for (String p : props) properties.put(p, "@" + p);
+        json.put("properties", properties);
+        return new FakeVertex(json);
+    }
+
+    private static FakeVertex openLabelVertex(String... props) {
+        JSONObject json = new JSONObject()
+                .put("id", "@id")
+                .put("label", "@label")
+                .put("dynamicProperties", false);
+        JSONObject properties = new JSONObject();
+        for (String p : props) properties.put(p, "@" + p);
+        json.put("properties", properties);
+        return new FakeVertex(json);
+    }
+
+    private static FakeVertex fieldLabelVertex(Set<String> includeLabels, String... props) {
+        JSONObject label = new JSONObject().put("field", "label");
+        org.json.JSONArray include = new org.json.JSONArray();
+        for (String l : includeLabels) include.put(l);
+        label.put("include", include);
+        JSONObject json = new JSONObject()
+                .put("id", "@id")
+                .put("label", label)
+                .put("dynamicProperties", false);
+        JSONObject properties = new JSONObject();
+        for (String p : props) properties.put(p, "@" + p);
+        json.put("properties", properties);
+        return new FakeVertex(json);
+    }
+
+    private static JSONObject endpointJsonWithInclude(String idField, Set<String> includeLabels) {
+        JSONObject label = new JSONObject().put("field", "label");
+        org.json.JSONArray include = new org.json.JSONArray();
+        for (String l : includeLabels) include.put(l);
+        label.put("include", include);
+        return new JSONObject()
+                .put("ref", true)
+                .put("id", idField)
+                .put("label", label)
+                .put("properties", new JSONObject());
+    }
+
+    private static FakeVertex dynamicVertex(String label) {
+        JSONObject json = new JSONObject()
+                .put("id", "@id")
+                .put("label", label)
+                .put("dynamicProperties", true)
+                .put("properties", new JSONObject());
+        return new FakeVertex(json);
+    }
+
+    private static FakeEdge edge(String label, VertexSchema out, VertexSchema in, boolean supportsJoinMarker) {
+        JSONObject json = new JSONObject()
+                .put("id", "@id")
+                .put("label", label)
+                .put("dynamicProperties", false)
+                .put("properties", new JSONObject());
+        // supportsJoin is decided by contributor, not schema; marker unused on schema itself
+        return new FakeEdge(json, out, in);
+    }
+
+    private static VertexSchema ref(String idField, String label) {
+        return new ReferenceVertexSchema(endpointJson(idField, label), null);
+    }
+
+    private static JSONObject endpointJson(String idField, String label) {
+        return new JSONObject()
+                .put("ref", true)
+                .put("id", idField)
+                .put("label", label)
+                .put("properties", new JSONObject());
+    }
+
+    private static JSONObject endpointJsonOpen(String idField) {
+        return new JSONObject()
+                .put("ref", true)
+                .put("id", idField)
+                .put("label", "@label")
+                .put("properties", new JSONObject());
+    }
+
+    private static final class FakeVertex extends AbstractElementSchema<Vertex> implements VertexSchema {
+        FakeVertex(JSONObject configuration) {
+            super(configuration, null);
+        }
+
+        @Override
+        public Vertex createElement(Map<String, Object> fields) {
+            return null;
+        }
+
+        @Override
+        public Collection<Vertex> fromFields(Map<String, Object> fields) {
+            return null;
+        }
+    }
+
+    private static final class FakeEdge extends AbstractElementSchema<Edge> implements EdgeSchema {
+        private final VertexSchema out;
+        private final VertexSchema in;
+
+        FakeEdge(JSONObject configuration, VertexSchema out, VertexSchema in) {
+            super(configuration, null);
+            this.out = out;
+            this.in = in;
+        }
+
+        @Override
+        public VertexSchema getOutVertexSchema() {
+            return out;
+        }
+
+        @Override
+        public VertexSchema getInVertexSchema() {
+            return in;
+        }
+
+        @Override
+        public Collection<Edge> fromFields(Map<String, Object> fields) {
+            return null;
+        }
+    }
+}

--- a/unipop-elastic/src/org/unipop/elastic/document/DocumentController.java
+++ b/unipop-elastic/src/org/unipop/elastic/document/DocumentController.java
@@ -21,6 +21,9 @@ import org.unipop.query.mutation.RemoveQuery;
 import org.unipop.query.search.DeferredVertexQuery;
 import org.unipop.query.search.SearchQuery;
 import org.unipop.query.search.SearchVertexQuery;
+import org.unipop.schema.catalog.SchemaCatalog;
+import org.unipop.schema.catalog.SchemaCatalogAware;
+import org.unipop.schema.catalog.SchemaContributor;
 import org.unipop.schema.element.ElementSchema;
 import org.unipop.schema.reference.DeferredVertex;
 import org.unipop.structure.UniEdge;
@@ -38,7 +41,7 @@ import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 
-public class DocumentController implements SimpleController {
+public class DocumentController implements SimpleController, SchemaContributor, SchemaCatalogAware {
     private static final Logger logger = LoggerFactory.getLogger(DocumentController.class);
 
     private final ElasticClient client;
@@ -50,6 +53,7 @@ public class DocumentController implements SimpleController {
     private Set<? extends DocumentEdgeSchema> edgeSchemas = new HashSet<>();
 
     private TraversalFilter traversalFilter;
+    private SchemaCatalog schemaCatalog;
 
     public DocumentController(Set<DocumentSchema> schemas, ElasticClient client, UniGraph graph, TraversalFilter traversalFilter) {
         this.client = client;
@@ -64,6 +68,24 @@ public class DocumentController implements SimpleController {
                 .map(schema -> ((DocumentEdgeSchema) schema)).collect(Collectors.toSet());
 
         logger.debug("Instantiated DocumentController: {}", this);
+    }
+
+    @Override
+    public Set<? extends ElementSchema> contributedSchemas() {
+        Set<ElementSchema> schemas = new HashSet<>();
+        if (vertexSchemas != null) schemas.addAll(vertexSchemas);
+        if (edgeSchemas != null) schemas.addAll(edgeSchemas);
+        return schemas;
+    }
+
+    @Override
+    public void setSchemaCatalog(SchemaCatalog catalog) {
+        this.schemaCatalog = catalog;
+    }
+
+    private <S extends ElementSchema> Collection<? extends S> pruneByLabels(Collection<? extends S> schemas, Set<String> labels) {
+        if (schemaCatalog == null || labels == null || labels.isEmpty() || schemas == null) return schemas;
+        return schemaCatalog.filterByLabels(schemas, labels);
     }
 
     private Set<DocumentSchema> collectSchemas(Set<? extends ElementSchema> schemas) {
@@ -92,8 +114,13 @@ public class DocumentController implements SimpleController {
 
     @Override
     public <E extends Element> Iterator<E> search(SearchQuery<E> uniQuery) {
-        Set<? extends DocumentSchema<E>> schemas = getSchemas(uniQuery.getReturnType())
-                .stream().filter(schema -> this.traversalFilter.filter(schema, uniQuery.getTraversal()))
+        Set<String> labels = SchemaCatalog.extractClosedLabels(uniQuery.getPredicates());
+        Set<? extends DocumentSchema<E>> allSchemas = getSchemas(uniQuery.getReturnType());
+        Collection<? extends DocumentSchema<E>> pruned = (schemaCatalog == null || labels.isEmpty())
+                ? allSchemas
+                : schemaCatalog.filterByLabels(allSchemas, labels);
+        Set<? extends DocumentSchema<E>> schemas = pruned.stream()
+                .filter(schema -> this.traversalFilter.filter(schema, uniQuery.getTraversal()))
                 .map(schema -> ((DocumentSchema<E>) schema))
                 .collect(Collectors.toSet());
         Map<DocumentSchema<E>, Query> searches = schemas.stream()
@@ -103,7 +130,14 @@ public class DocumentController implements SimpleController {
 
     @Override
     public Iterator<Edge> search(SearchVertexQuery uniQuery) {
-        Map<DocumentEdgeSchema, Query> schemas = edgeSchemas.stream()
+        Collection<? extends DocumentEdgeSchema> edgeCandidates = edgeSchemas;
+        if (schemaCatalog != null) {
+            Set<String> srcLabels = SchemaCatalog.labelsOf(uniQuery.getVertices());
+            Set<ElementSchema> byEndpoint = schemaCatalog.edgesFrom(srcLabels, uniQuery.getDirection());
+            edgeCandidates = edgeSchemas.stream().filter(byEndpoint::contains).collect(Collectors.toList());
+        }
+        edgeCandidates = pruneByLabels(edgeCandidates, SchemaCatalog.extractClosedLabels(uniQuery.getPredicates()));
+        Map<DocumentEdgeSchema, Query> schemas = edgeCandidates.stream()
                 .filter(schema -> this.traversalFilter.filter(schema, uniQuery.getTraversal()))
                 .collect(new SearchCollector<>((schema) -> schema.getSearch(uniQuery)));
         return search(uniQuery, schemas);
@@ -111,7 +145,9 @@ public class DocumentController implements SimpleController {
 
     @Override
     public void fetchProperties(DeferredVertexQuery uniQuery) {
-        Map<DocumentVertexSchema, Query> schemas = vertexSchemas.stream()
+        Set<String> labels = SchemaCatalog.labelsOf(uniQuery.getVertices());
+        labels.addAll(SchemaCatalog.extractClosedLabels(uniQuery.getPredicates()));
+        Map<DocumentVertexSchema, Query> schemas = pruneByLabels(vertexSchemas, labels).stream()
                 .filter(schema -> this.traversalFilter.filter(schema, uniQuery.getTraversal()))
                 .collect(new SearchCollector<>((schema) -> schema.getSearch(uniQuery)));
         Iterator<Vertex> search = search(uniQuery, schemas);

--- a/unipop-elastic/src/org/unipop/elastic/document/schema/DocEdgeSchema.java
+++ b/unipop-elastic/src/org/unipop/elastic/document/schema/DocEdgeSchema.java
@@ -33,6 +33,16 @@ public class DocEdgeSchema extends AbstractDocSchema<Edge> implements DocumentEd
         this.inVertexSchema = createVertexSchema("inVertex");
     }
 
+    @Override
+    public VertexSchema getOutVertexSchema() {
+        return outVertexSchema;
+    }
+
+    @Override
+    public VertexSchema getInVertexSchema() {
+        return inVertexSchema;
+    }
+
     protected VertexSchema createVertexSchema(String key) throws JSONException {
         JSONObject vertexConfiguration = this.json.optJSONObject(key);
         if(vertexConfiguration == null) return null;

--- a/unipop-jdbc/src/org/unipop/jdbc/JdbcSourceProvider.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/JdbcSourceProvider.java
@@ -13,6 +13,7 @@ import org.unipop.jdbc.schemas.property.JsonbPropertySchema;
 import org.unipop.jdbc.schemas.property.TimestamptzPropertySchema;
 import org.unipop.jdbc.schemas.property.UuidPropertySchema;
 import org.unipop.jdbc.utils.ContextManager;
+import org.unipop.jdbc.utils.EnumDomainLoader;
 import org.unipop.jdbc.utils.JdbcPredicatesTranslator;
 import org.unipop.query.controller.SourceProvider;
 import org.unipop.query.controller.UniQueryController;
@@ -54,6 +55,10 @@ public class JdbcSourceProvider implements SourceProvider {
 
         getList(configuration, "vertices").forEach(vertexJson -> schemas.add(createVertexSchema(vertexJson)));
         getList(configuration, "edges").forEach(edgeJson -> schemas.add(createEdgeSchema(edgeJson)));
+
+        // Fill EnumPropertySchema.knownValues() from pg_enum so the schema catalog can close
+        // label/property domains without config-side value lists. Runs before controllers/catalog.
+        EnumDomainLoader.hydrate(contextManager, schemas);
 
         return createControllers(schemas, traversalFilter);
     }

--- a/unipop-jdbc/src/org/unipop/jdbc/controller/simple/RowController.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/controller/simple/RowController.java
@@ -118,6 +118,12 @@ public class RowController implements SimpleController, SchemaContributor, Schem
         for (MultiHopQuery.HopSpec h : query.getHops()) {
             if (h.getDirection() == null || h.getDirection() == Direction.BOTH) return null;
         }
+        // Edge-final multi-join only when explicitly enabled and a limit is folded onto the step.
+        // Unbounded out().outE() multi-joins are slower than sequential hop joins in practice.
+        if (!query.isReturnsVertex()) {
+            if (!graph.configuration().getBoolean("jdbc.multiHopEdgeFinal", false)) return null;
+            if (query.getFinalLimit() < 0) return null;
+        }
 
         List<Hop> catalogHops = new ArrayList<>();
         for (int i = 0; i < query.getHops().size(); i++) {

--- a/unipop-jdbc/src/org/unipop/jdbc/controller/simple/RowController.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/controller/simple/RowController.java
@@ -15,6 +15,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.unipop.common.util.PredicatesTranslator;
 import org.javatuples.Pair;
+import org.unipop.jdbc.schemas.MultiHopJoinBuilder;
 import org.unipop.jdbc.schemas.RowEdgeSchema;
 import org.unipop.jdbc.schemas.RowVertexSchema;
 import org.unipop.jdbc.schemas.jdbc.JdbcEdgeSchema;
@@ -30,8 +31,15 @@ import org.unipop.query.mutation.PropertyQuery;
 import org.unipop.query.mutation.RemoveQuery;
 import org.unipop.query.predicates.PredicatesHolder;
 import org.unipop.query.predicates.PredicatesHolderFactory;
+import org.unipop.schema.catalog.Hop;
+import org.unipop.schema.catalog.PathHop;
+import org.unipop.schema.catalog.PathPlan;
+import org.unipop.schema.catalog.SchemaCatalog;
+import org.unipop.schema.catalog.SchemaCatalogAware;
+import org.unipop.schema.catalog.SchemaContributor;
 import org.unipop.schema.element.VertexSchema;
 import org.unipop.query.search.DeferredVertexQuery;
+import org.unipop.query.search.MultiHopQuery;
 import org.unipop.query.search.SearchQuery;
 import org.unipop.query.search.SearchVertexQuery;
 import org.unipop.schema.element.ElementSchema;
@@ -56,7 +64,8 @@ import static org.jooq.impl.DSL.table;
  * @author Gur Ronen
  * @since 6/12/2016
  */
-public class RowController implements SimpleController {
+public class RowController implements SimpleController, SchemaContributor, SchemaCatalogAware,
+        MultiHopQuery.MultiHopController {
     protected final static Logger logger = LoggerFactory.getLogger(RowController.class);
 
     private final ContextManager contextManager;
@@ -69,6 +78,7 @@ public class RowController implements SimpleController {
     private final PredicatesTranslator<Condition> predicatesTranslator;
 
     private TraversalFilter traversalFilter;
+    private SchemaCatalog schemaCatalog;
 
     public <E extends Element> RowController(UniGraph graph, ContextManager contextManager, Set<JdbcSchema> schemaSet, PredicatesTranslator<Condition> predicatesTranslator, TraversalFilter traversalFilter) {
         this.graph = graph;
@@ -82,6 +92,93 @@ public class RowController implements SimpleController {
     }
 
     @Override
+    public Set<? extends ElementSchema> contributedSchemas() {
+        Set<ElementSchema> schemas = new HashSet<>();
+        if (vertexSchemas != null) schemas.addAll(vertexSchemas);
+        if (edgeSchemas != null) schemas.addAll(edgeSchemas);
+        return schemas;
+    }
+
+    @Override
+    public boolean supportsJoin(ElementSchema schema) {
+        // Exact-class: InnerRowEdgeSchema extends RowEdgeSchema but is not joinable.
+        return schema != null && schema.getClass() == RowEdgeSchema.class;
+    }
+
+    @Override
+    public void setSchemaCatalog(SchemaCatalog catalog) {
+        this.schemaCatalog = catalog;
+    }
+
+    @Override
+    public Iterator<Edge> search(MultiHopQuery query) {
+        if (!graph.configuration().getBoolean("jdbc.multiHopPushdown", true)) return null;
+        if (schemaCatalog == null) return null;
+        if (query.getHops() == null || query.getHops().size() != 2) return null;
+        for (MultiHopQuery.HopSpec h : query.getHops()) {
+            if (h.getDirection() == null || h.getDirection() == Direction.BOTH) return null;
+        }
+
+        List<Hop> catalogHops = new ArrayList<>();
+        for (int i = 0; i < query.getHops().size(); i++) {
+            MultiHopQuery.HopSpec hs = query.getHops().get(i);
+            Set<String> edgeLabels = SchemaCatalog.extractClosedLabels(hs.getEdgePredicates());
+            Set<String> targetLabels = (i == query.getHops().size() - 1)
+                    ? SchemaCatalog.extractClosedLabels(query.getFinalTargetPredicates())
+                    : Collections.emptySet();
+            catalogHops.add(new Hop(hs.getDirection(), edgeLabels, targetLabels));
+        }
+
+        Set<String> startLabels = SchemaCatalog.labelsOf(query.getStarts());
+        List<PathPlan> plans = schemaCatalog.findPaths(startLabels, catalogHops, 32);
+        if (plans.isEmpty()) {
+            // Closed topology miss — nothing to return (not a fallback signal)
+            return Collections.emptyIterator();
+        }
+
+        // If any plan uses a non-joinable edge, fall back to sequential single hops.
+        for (PathPlan plan : plans) {
+            for (PathHop ph : plan.getHops()) {
+                if (!schemaCatalog.canJoin(ph.getEdgeSchema())
+                        || ph.getEdgeSchema().getClass() != RowEdgeSchema.class) {
+                    return null;
+                }
+            }
+        }
+
+        Set<Edge> out = new HashSet<>();
+        try {
+            for (PathPlan plan : plans) {
+                Select sel = MultiHopJoinBuilder.buildTwoHop(query, plan);
+                if (sel == null) continue;
+                JdbcVertexSchema midVs = (JdbcVertexSchema) plan.getHops().get(0).getTargetVertexSchema();
+                for (Map<String, Object> row : this.getContextManager().fetch(sel)) {
+                    Edge edge;
+                    if (query.isReturnsVertex()) {
+                        JdbcVertexSchema finalVs = (JdbcVertexSchema) plan.getHops().get(1).getTargetVertexSchema();
+                        edge = MultiHopJoinBuilder.fromTwoHopRow(row, midVs, finalVs, graph);
+                    } else {
+                        RowEdgeSchema e1 = (RowEdgeSchema) plan.getHops().get(1).getEdgeSchema();
+                        edge = MultiHopJoinBuilder.fromTwoHopEdgeRow(row, e1, midVs, graph);
+                    }
+                    if (edge != null) out.add(edge);
+                }
+            }
+        } catch (RowEdgeSchema.OrderNotPushableException e) {
+            return null; // all-or-nothing order+limit
+        }
+        // If every plan aborted (null select) and we produced nothing, fall back rather than
+        // claim empty — open schemas may still match via sequential path.
+        if (out.isEmpty() && !plans.isEmpty()) {
+            // Could be genuinely empty result; sequential fallback is still correct.
+            // Prefer returning empty when plans were joinable (selects ran).
+            // Heuristic: if we attempted at least one fetch, empty is authoritative.
+            return out.iterator();
+        }
+        return out.iterator();
+    }
+
+    @Override
     public <E extends Element> Iterator<E> search(SearchQuery<E> uniQuery) {
 
         SelectCollector<JdbcSchema<E>, Select, E> collector = new SelectCollector<>(
@@ -89,7 +186,11 @@ public class RowController implements SimpleController {
                         schema.toPredicates(uniQuery.getPredicates())),
                 (schema, results) -> schema.parseResults(results, uniQuery)
         );
-        Set<? extends JdbcSchema<E>> schemas = this.getSchemas(uniQuery.getReturnType());
+        Set<String> labels = SchemaCatalog.extractClosedLabels(uniQuery.getPredicates());
+        Set<? extends JdbcSchema<E>> allSchemas = this.getSchemas(uniQuery.getReturnType());
+        Collection<? extends JdbcSchema<E>> schemas = (schemaCatalog == null || labels.isEmpty())
+                ? allSchemas
+                : schemaCatalog.filterByLabels(allSchemas, labels);
 
         Map<JdbcSchema<E>, Select> selects = schemas.stream()
                 .filter(schema -> this.traversalFilter.filter(schema, uniQuery.getTraversal())).collect(collector);
@@ -115,7 +216,12 @@ public class RowController implements SimpleController {
                 (schema, results) -> schema.parseResults(results, uniQuery)
         );
 
-        Map<JdbcSchema<Vertex>, Select> selects = vertexSchemas.stream()
+        Set<String> labels = SchemaCatalog.labelsOf(uniQuery.getVertices());
+        // Also honor has() predicates folded into the deferred query
+        labels.addAll(SchemaCatalog.extractClosedLabels(uniQuery.getPredicates()));
+        Collection<? extends RowVertexSchema> candidates = pruneByLabels(vertexSchemas, labels);
+
+        Map<JdbcSchema<Vertex>, Select> selects = candidates.stream()
                 .filter(schema -> this.traversalFilter.filter(schema, uniQuery.getTraversal())).collect(collector);
         Iterator<Vertex> searchIterator = this.search(uniQuery, selects, collector);
 
@@ -135,14 +241,24 @@ public class RowController implements SimpleController {
             Iterator<Edge> joined = searchJoin(uniQuery);
             if (joined != null) return joined;
         }
-        // Fallback: existing id-only edge path (unchanged).
+        // Fallback: existing id-only edge path (catalog prunes by source labels + edge labels).
         SelectCollector<JdbcSchema<Edge>, Select, Edge> collector = new SelectCollector<>(
                 schema -> schema.getSearch(uniQuery,
                         ((JdbcEdgeSchema) schema).toPredicates(uniQuery.getVertices(), uniQuery.getDirection(), uniQuery.getPredicates())),
                 (schema, results) -> schema.parseResults(results, uniQuery)
         );
 
-        Map<JdbcSchema<Edge>, Select> selects = edgeSchemas.stream()
+        Collection<? extends RowEdgeSchema> edgeCandidates = edgeSchemas;
+        if (schemaCatalog != null) {
+            Set<String> srcLabels = SchemaCatalog.labelsOf(uniQuery.getVertices());
+            Set<ElementSchema> byEndpoint = schemaCatalog.edgesFrom(srcLabels, uniQuery.getDirection());
+            edgeCandidates = edgeSchemas.stream()
+                    .filter(byEndpoint::contains)
+                    .collect(Collectors.toList());
+        }
+        edgeCandidates = pruneByLabels(edgeCandidates, SchemaCatalog.extractClosedLabels(uniQuery.getPredicates()));
+
+        Map<JdbcSchema<Edge>, Select> selects = edgeCandidates.stream()
                 .filter(schema -> this.traversalFilter.filter(schema, uniQuery.getTraversal())).collect(collector);
 
         return this.search(uniQuery, selects, collector);
@@ -158,15 +274,20 @@ public class RowController implements SimpleController {
     }
 
     /**
-     * Join fan-out over (edge schema x surviving vertex schema x direction). BOTH runs as two
+     * Join fan-out over (edge schema x candidate vertex schema x direction). BOTH runs as two
      * directed joins (OUT and IN); each produced edge is flagged adjacencyJoinDirected so the vertex
      * step maps it by its own source only (see UniGraphVertexStep), avoiding the double-count that
      * would otherwise come from edge.vertices(BOTH) fanning into both endpoints. Returns null to fall back.
+     * <p>
+     * When a {@link SchemaCatalog} is present, vertex candidates are pruned via type topology
+     * (closed labels / endpoint links). Open endpoints keep today's same-source full fan-out.
      */
     private Iterator<Edge> searchJoin(SearchVertexQuery uniQuery) {
         List<Direction> dirs = uniQuery.getDirection().equals(Direction.BOTH)
                 ? Arrays.asList(Direction.OUT, Direction.IN)
                 : Collections.singletonList(uniQuery.getDirection());
+
+        Set<String> targetLabels = SchemaCatalog.extractClosedLabels(uniQuery.getTargetPredicates());
 
         // Keyed by (edgeSchema, vertexSchema, direction) -- BOTH runs the same (edgeSchema, vs) pair
         // once per direction, so direction must be part of the key or one direction's select clobbers
@@ -179,10 +300,12 @@ public class RowController implements SimpleController {
                 // edge table -- an `instanceof` check here would wrongly let it through this join path.
                 if (es.getClass() != org.unipop.jdbc.schemas.RowEdgeSchema.class) return null; // inner/other edge schemas -> fall back
                 if (!this.traversalFilter.filter(es, uniQuery.getTraversal())) continue;
+                if (schemaCatalog != null && !schemaCatalog.canJoin(es)) continue;
                 RowEdgeSchema edgeSchema = (RowEdgeSchema) es;
-                for (JdbcSchema<Vertex> vs : vertexSchemas) {
-                    for (Direction dir : dirs) {
-                        Select sel = edgeSchema.getJoinSearch(uniQuery, (JdbcVertexSchema) vs, dir);
+                for (Direction dir : dirs) {
+                    for (JdbcVertexSchema vs : joinVertexCandidates(edgeSchema, dir, targetLabels)) {
+                        if (!this.traversalFilter.filter(vs, uniQuery.getTraversal())) continue;
+                        Select sel = edgeSchema.getJoinSearch(uniQuery, vs, dir);
                         if (sel != null) selects.put(new Pair<>(new Pair<>(edgeSchema, vs), dir), sel);
                     }
                 }
@@ -401,6 +524,32 @@ public class RowController implements SimpleController {
                                 .flatMap(m -> m.stream().map(es -> new HasContainer(es.getKey(), P.within(es.getValue()))))
                                 .collect(Collectors.toList()), Collections.emptyList()));
 
+    }
+
+    /**
+     * Vertex schemas to probe for a join in {@code dir}. Uses the schema catalog when present;
+     * otherwise the full controller vertex set (legacy cartesian fan-out).
+     */
+    private Collection<JdbcVertexSchema> joinVertexCandidates(RowEdgeSchema edgeSchema, Direction dir, Set<String> targetLabels) {
+        if (schemaCatalog == null) {
+            return vertexSchemas.stream().map(vs -> (JdbcVertexSchema) vs).collect(Collectors.toList());
+        }
+        Set<ElementSchema> targets = schemaCatalog.joinTargets(edgeSchema, dir, targetLabels);
+        List<JdbcVertexSchema> out = new ArrayList<>();
+        for (ElementSchema s : targets) {
+            if (s instanceof JdbcVertexSchema) out.add((JdbcVertexSchema) s);
+        }
+        return out;
+    }
+
+    /**
+     * Drop schemas whose closed label set cannot match {@code labels}. No catalog → no pruning.
+     */
+    private <S extends ElementSchema> Collection<? extends S> pruneByLabels(Collection<? extends S> schemas, Set<String> labels) {
+        if (schemaCatalog == null || labels == null || labels.isEmpty() || schemas == null) {
+            return schemas;
+        }
+        return schemaCatalog.filterByLabels(schemas, labels);
     }
 
     private <E extends Element> void extractRowSchemas(Set<JdbcSchema> schemas) {

--- a/unipop-jdbc/src/org/unipop/jdbc/controller/simple/RowController.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/controller/simple/RowController.java
@@ -130,10 +130,16 @@ public class RowController implements SimpleController, SchemaContributor, Schem
         }
 
         Set<String> startLabels = SchemaCatalog.labelsOf(query.getStarts());
-        List<PathPlan> plans = schemaCatalog.findPaths(startLabels, catalogHops, 32);
+        // Low cap: many open-endpoint schemas explode plan count; sequential 2-hop is faster then.
+        int planCap = graph.configuration().getInt("jdbc.multiHopMaxPlans", 8);
+        List<PathPlan> plans = schemaCatalog.findPaths(startLabels, catalogHops, planCap);
         if (plans.isEmpty()) {
-            // Closed topology miss — nothing to return (not a fallback signal)
-            return Collections.emptyIterator();
+            // Not a hard miss when topology is open — fall back so sequential can still hit data.
+            return null;
+        }
+        // If we hit the cap, planning was truncated → sequential is safer/faster.
+        if (plans.size() >= planCap) {
+            return null;
         }
 
         // If any plan uses a non-joinable edge, fall back to sequential single hops.
@@ -146,20 +152,29 @@ public class RowController implements SimpleController, SchemaContributor, Schem
             }
         }
 
+        // Edge-final: plans only differ by mid/final vertex types; SQL joins e0⋈e1 and does not
+        // use those. Dedup by (e0, e1, dirs) so we run one query per edge-schema pair.
+        List<PathPlan> toRun = query.isReturnsVertex() ? plans : dedupeEdgeFinalPlans(plans);
+        if (!query.isReturnsVertex() && toRun.size() > planCap) {
+            return null;
+        }
+
         Set<Edge> out = new HashSet<>();
+        int ran = 0;
         try {
-            for (PathPlan plan : plans) {
+            for (PathPlan plan : toRun) {
                 Select sel = MultiHopJoinBuilder.buildTwoHop(query, plan);
                 if (sel == null) continue;
-                JdbcVertexSchema midVs = (JdbcVertexSchema) plan.getHops().get(0).getTargetVertexSchema();
+                ran++;
                 for (Map<String, Object> row : this.getContextManager().fetch(sel)) {
                     Edge edge;
                     if (query.isReturnsVertex()) {
+                        JdbcVertexSchema midVs = (JdbcVertexSchema) plan.getHops().get(0).getTargetVertexSchema();
                         JdbcVertexSchema finalVs = (JdbcVertexSchema) plan.getHops().get(1).getTargetVertexSchema();
                         edge = MultiHopJoinBuilder.fromTwoHopRow(row, midVs, finalVs, graph);
                     } else {
                         RowEdgeSchema e1 = (RowEdgeSchema) plan.getHops().get(1).getEdgeSchema();
-                        edge = MultiHopJoinBuilder.fromTwoHopEdgeRow(row, e1, midVs, graph);
+                        edge = MultiHopJoinBuilder.fromTwoHopEdgeRow(row, e1, graph);
                     }
                     if (edge != null) out.add(edge);
                 }
@@ -167,15 +182,22 @@ public class RowController implements SimpleController, SchemaContributor, Schem
         } catch (RowEdgeSchema.OrderNotPushableException e) {
             return null; // all-or-nothing order+limit
         }
-        // If every plan aborted (null select) and we produced nothing, fall back rather than
-        // claim empty — open schemas may still match via sequential path.
-        if (out.isEmpty() && !plans.isEmpty()) {
-            // Could be genuinely empty result; sequential fallback is still correct.
-            // Prefer returning empty when plans were joinable (selects ran).
-            // Heuristic: if we attempted at least one fetch, empty is authoritative.
-            return out.iterator();
-        }
+        if (ran == 0) return null; // no expressible plan → sequential fallback
         return out.iterator();
+    }
+
+    /** Collapse edge-final plans that share the same two edge schemas + directions. */
+    private static List<PathPlan> dedupeEdgeFinalPlans(List<PathPlan> plans) {
+        Map<String, PathPlan> unique = new LinkedHashMap<>();
+        for (PathPlan plan : plans) {
+            if (plan.size() != 2) continue;
+            PathHop h0 = plan.getHops().get(0);
+            PathHop h1 = plan.getHops().get(1);
+            String key = System.identityHashCode(h0.getEdgeSchema()) + "|" + h0.getDirection()
+                    + "|" + System.identityHashCode(h1.getEdgeSchema()) + "|" + h1.getDirection();
+            unique.putIfAbsent(key, plan);
+        }
+        return new ArrayList<>(unique.values());
     }
 
     @Override

--- a/unipop-jdbc/src/org/unipop/jdbc/controller/simple/RowController.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/controller/simple/RowController.java
@@ -118,12 +118,6 @@ public class RowController implements SimpleController, SchemaContributor, Schem
         for (MultiHopQuery.HopSpec h : query.getHops()) {
             if (h.getDirection() == null || h.getDirection() == Direction.BOTH) return null;
         }
-        // Edge-final multi-join only when explicitly enabled and a limit is folded onto the step.
-        // Unbounded out().outE() multi-joins are slower than sequential hop joins in practice.
-        if (!query.isReturnsVertex()) {
-            if (!graph.configuration().getBoolean("jdbc.multiHopEdgeFinal", false)) return null;
-            if (query.getFinalLimit() < 0) return null;
-        }
 
         List<Hop> catalogHops = new ArrayList<>();
         for (int i = 0; i < query.getHops().size(); i++) {
@@ -158,30 +152,21 @@ public class RowController implements SimpleController, SchemaContributor, Schem
             }
         }
 
-        // Edge-final: plans only differ by mid/final vertex types; SQL joins e0⋈e1 and does not
-        // use those. Dedup by (e0, e1, dirs) so we run one query per edge-schema pair.
-        List<PathPlan> toRun = query.isReturnsVertex() ? plans : dedupeEdgeFinalPlans(plans);
-        if (!query.isReturnsVertex() && toRun.size() > planCap) {
-            return null;
-        }
-
-        Set<Edge> out = new HashSet<>();
+        // Random per-carrier edge ids (see fromTwoHopRow) already keep distinct fan-out paths apart,
+        // so a List preserves multiset cardinality; a join over unique PKs emits no duplicate rows.
+        List<Edge> out = new ArrayList<>();
         int ran = 0;
         try {
-            for (PathPlan plan : toRun) {
+            for (PathPlan plan : plans) {
                 Select sel = MultiHopJoinBuilder.buildTwoHop(query, plan);
-                if (sel == null) continue;
+                // A plan we can't express as SQL (e.g. a cross-provider vertex target) must not be
+                // silently dropped — that returns a partial result. Fall back to sequential wholesale.
+                if (sel == null) return null;
                 ran++;
                 for (Map<String, Object> row : this.getContextManager().fetch(sel)) {
-                    Edge edge;
-                    if (query.isReturnsVertex()) {
-                        JdbcVertexSchema midVs = (JdbcVertexSchema) plan.getHops().get(0).getTargetVertexSchema();
-                        JdbcVertexSchema finalVs = (JdbcVertexSchema) plan.getHops().get(1).getTargetVertexSchema();
-                        edge = MultiHopJoinBuilder.fromTwoHopRow(row, midVs, finalVs, graph);
-                    } else {
-                        RowEdgeSchema e1 = (RowEdgeSchema) plan.getHops().get(1).getEdgeSchema();
-                        edge = MultiHopJoinBuilder.fromTwoHopEdgeRow(row, e1, graph);
-                    }
+                    JdbcVertexSchema midVs = (JdbcVertexSchema) plan.getHops().get(0).getTargetVertexSchema();
+                    JdbcVertexSchema finalVs = (JdbcVertexSchema) plan.getHops().get(1).getTargetVertexSchema();
+                    Edge edge = MultiHopJoinBuilder.fromTwoHopRow(row, midVs, finalVs, graph);
                     if (edge != null) out.add(edge);
                 }
             }
@@ -190,20 +175,6 @@ public class RowController implements SimpleController, SchemaContributor, Schem
         }
         if (ran == 0) return null; // no expressible plan → sequential fallback
         return out.iterator();
-    }
-
-    /** Collapse edge-final plans that share the same two edge schemas + directions. */
-    private static List<PathPlan> dedupeEdgeFinalPlans(List<PathPlan> plans) {
-        Map<String, PathPlan> unique = new LinkedHashMap<>();
-        for (PathPlan plan : plans) {
-            if (plan.size() != 2) continue;
-            PathHop h0 = plan.getHops().get(0);
-            PathHop h1 = plan.getHops().get(1);
-            String key = System.identityHashCode(h0.getEdgeSchema()) + "|" + h0.getDirection()
-                    + "|" + System.identityHashCode(h1.getEdgeSchema()) + "|" + h1.getDirection();
-            unique.putIfAbsent(key, plan);
-        }
-        return new ArrayList<>(unique.values());
     }
 
     @Override

--- a/unipop-jdbc/src/org/unipop/jdbc/schemas/MultiHopJoinBuilder.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/schemas/MultiHopJoinBuilder.java
@@ -38,32 +38,27 @@ import static org.jooq.impl.DSL.name;
 import static org.jooq.impl.DSL.table;
 
 /**
- * Builds a 2-hop adjacency JOIN for exact {@link RowEdgeSchema} path plans.
- * <ul>
- *   <li>Vertex-final ({@code out}/{@code in}): projects final vertex + mid + start id.</li>
- *   <li>Edge-final ({@code outE}/{@code inE}): projects final edge row + mid + start id (no final vertex join).</li>
- * </ul>
+ * Builds a 2-hop adjacency JOIN for exact {@link RowEdgeSchema} path plans:
+ * {@code out}/{@code in} → {@code out}/{@code in}, projecting final vertex + mid + start id.
  */
 public final class MultiHopJoinBuilder {
 
     public static final String MID_PREFIX = "__unipop_mid_";
     public static final String MID_PROP = "__unipop_mid";
-    /** Edge-final: mid vertex id taken from hop-0 edge target column (no mid-table join). */
-    public static final String MID_ID_ALIAS = "__unipop_mid_id";
-    public static final String EDGE_PREFIX = "__unipop_e1_";
 
     private MultiHopJoinBuilder() {}
 
     /**
-     * Vertex-final 2-hop join (final hop returns vertices).
+     * 2-hop vertex-final join (final hop returns vertices).
+     * <p>The mid and final vertex tables are INNER-joined, so a path is emitted only when the mid
+     * and final vertex rows physically exist. Sequential {@code out().out()} instead builds those
+     * as id-only shell vertices and returns even dangling edges whose target row is absent; on a
+     * referentially-clean graph the two agree. If shell semantics ever need preserving here, LEFT
+     * JOIN the vertex tables when no predicate constrains them.
      * @throws RowEdgeSchema.OrderNotPushableException when final order column missing
      */
     public static Select buildTwoHop(MultiHopQuery query, PathPlan plan) {
-        return query.isReturnsVertex() ? buildTwoHopVertexFinal(query, plan) : buildTwoHopEdgeFinal(query, plan);
-    }
-
-    private static Select buildTwoHopVertexFinal(MultiHopQuery query, PathPlan plan) {
-        Ctx ctx = ctx(query, plan, true);
+        Ctx ctx = ctx(query, plan);
         if (ctx == null) return null;
 
         PredicatesHolder tgtHolder = ctx.fin.toPredicates(query.getFinalTargetPredicates());
@@ -90,32 +85,6 @@ public final class MultiHopJoinBuilder {
         return orderLimit(where, query, ctx.finSchema, "v");
     }
 
-    /**
-     * Edge-final 2-hop join ({@code out().outE()}): join edge tables directly
-     * {@code e0.tgt = e1.src} — <b>no mid vertex table</b>. Avoids fan-out across every mid
-     * schema when endpoints are open (the regression that made multi-hop slower than sequential).
-     * Mid id for path is projected from {@code e0.tgt}.
-     */
-    private static Select buildTwoHopEdgeFinal(MultiHopQuery query, PathPlan plan) {
-        Ctx ctx = ctx(query, plan, false);
-        if (ctx == null) return null;
-
-        List<SelectFieldOrAsterisk> projection = new ArrayList<>();
-        for (String col : edgeRowColumns(ctx.e1)) {
-            projection.add(field(name("e1", col)).as(EDGE_PREFIX + col));
-        }
-        projection.add(field(name("e0", ctx.e0SrcCol)).as(RowEdgeSchema.SRC_ALIAS));
-        // Mid is the hop-0 target id on e0 (same value as e1.src) — enough for path identity
-        projection.add(field(name("e0", ctx.e0TgtCol)).as(MID_ID_ALIAS));
-
-        SelectConditionStep<Record> where = DSL.select(projection)
-                .from(ctx.te0)
-                .join(ctx.te1).on(field(name("e0", ctx.e0TgtCol)).eq(field(name("e1", ctx.e1SrcCol))))
-                .where(ctx.c0.and(ctx.c1));
-
-        return orderLimitOnEdge(where, query, ctx.e1, "e1");
-    }
-
     private static class Ctx {
         RowEdgeSchema e0, e1;
         JdbcVertexSchema mid, fin;
@@ -125,24 +94,20 @@ public final class MultiHopJoinBuilder {
         Table<Record> te0, tm, te1;
     }
 
-    private static Ctx ctx(MultiHopQuery query, PathPlan plan, boolean needFinalVertex) {
+    private static Ctx ctx(MultiHopQuery query, PathPlan plan) {
         if (plan == null || plan.size() != 2) return null;
         PathHop h0 = plan.getHops().get(0);
         PathHop h1 = plan.getHops().get(1);
         if (h0.getEdgeSchema().getClass() != RowEdgeSchema.class
                 || h1.getEdgeSchema().getClass() != RowEdgeSchema.class) return null;
-        // Edge-final does not require a mid vertex schema (joins e0.tgt = e1.src directly).
-        if (needFinalVertex) {
-            if (!(h0.getTargetVertexSchema() instanceof JdbcVertexSchema)) return null;
-            if (!(h1.getTargetVertexSchema() instanceof JdbcVertexSchema)) return null;
-        }
+        if (!(h0.getTargetVertexSchema() instanceof JdbcVertexSchema)) return null;
+        if (!(h1.getTargetVertexSchema() instanceof JdbcVertexSchema)) return null;
 
         Ctx c = new Ctx();
         c.e0 = (RowEdgeSchema) h0.getEdgeSchema();
         c.e1 = (RowEdgeSchema) h1.getEdgeSchema();
-        c.mid = h0.getTargetVertexSchema() instanceof JdbcVertexSchema
-                ? (JdbcVertexSchema) h0.getTargetVertexSchema() : null;
-        c.fin = needFinalVertex ? (JdbcVertexSchema) h1.getTargetVertexSchema() : null;
+        c.mid = (JdbcVertexSchema) h0.getTargetVertexSchema();
+        c.fin = (JdbcVertexSchema) h1.getTargetVertexSchema();
         Direction d0 = h0.getDirection();
         Direction d1 = h1.getDirection();
 
@@ -155,14 +120,10 @@ public final class MultiHopJoinBuilder {
         c.e0TgtCol = e0tgt.getFieldByPropertyKey(T.id.getAccessor());
         c.e1SrcCol = e1src.getFieldByPropertyKey(T.id.getAccessor());
         c.e1TgtCol = e1tgt.getFieldByPropertyKey(T.id.getAccessor());
-        if (c.mid != null) {
-            c.midSchema = (AbstractRowSchema<?>) c.mid;
-            c.midId = c.midSchema.getFieldByPropertyKey(T.id.getAccessor());
-        }
-        if (c.fin != null) {
-            c.finSchema = (AbstractRowSchema<?>) c.fin;
-            c.finId = c.finSchema.getFieldByPropertyKey(T.id.getAccessor());
-        }
+        c.midSchema = (AbstractRowSchema<?>) c.mid;
+        c.midId = c.midSchema.getFieldByPropertyKey(T.id.getAccessor());
+        c.finSchema = (AbstractRowSchema<?>) c.fin;
+        c.finId = c.finSchema.getFieldByPropertyKey(T.id.getAccessor());
 
         MultiHopQuery.HopSpec hop0 = query.getHops().get(0);
         MultiHopQuery.HopSpec hop1 = query.getHops().get(1);
@@ -174,7 +135,7 @@ public final class MultiHopJoinBuilder {
         c.c0 = c.e0.buildTranslator("e0").translate(edge0Holder);
         c.c1 = c.e1.buildTranslator("e1").translate(edge1Holder);
         c.te0 = table(name(c.e0.getTable())).as("e0");
-        if (c.mid != null) c.tm = table(name(c.mid.getTable())).as("m");
+        c.tm = table(name(c.mid.getTable())).as("m");
         c.te1 = table(name(c.e1.getTable())).as("e1");
         return c;
     }
@@ -192,39 +153,6 @@ public final class MultiHopJoinBuilder {
         }
         int lim = query.getFinalLimit() < 0 ? Integer.MAX_VALUE : query.getFinalLimit();
         return sorts.isEmpty() ? where.limit(lim) : where.orderBy(sorts).limit(lim);
-    }
-
-    private static Select orderLimitOnEdge(SelectConditionStep<Record> where, MultiHopQuery query,
-                                           RowEdgeSchema edge, String alias) {
-        List<SortField<Object>> sorts = new ArrayList<>();
-        if (query.getFinalOrders() != null) {
-            for (Pair<String, Order> o : query.getFinalOrders()) {
-                String col = edge.getFieldByPropertyKey(o.getValue0());
-                if (col == null) throw new RowEdgeSchema.OrderNotPushableException();
-                Field<Object> f = field(name(alias, col));
-                sorts.add(o.getValue1().equals(Order.desc) ? f.desc() : f.asc());
-            }
-        }
-        int lim = query.getFinalLimit() < 0 ? Integer.MAX_VALUE : query.getFinalLimit();
-        return sorts.isEmpty() ? where.limit(lim) : where.orderBy(sorts).limit(lim);
-    }
-
-    private static Set<String> edgeRowColumns(RowEdgeSchema edge) {
-        Set<String> cols = schemaColumns(edge);
-        // Endpoint ref columns (out/in id/label fields) required by fromFields
-        if (edge.getOutVertexSchema() != null) {
-            String oid = edge.getOutVertexSchema().getFieldByPropertyKey(T.id.getAccessor());
-            if (oid != null) cols.add(oid);
-            String ol = edge.getOutVertexSchema().getFieldByPropertyKey(T.label.getAccessor());
-            if (ol != null) cols.add(ol);
-        }
-        if (edge.getInVertexSchema() != null) {
-            String iid = edge.getInVertexSchema().getFieldByPropertyKey(T.id.getAccessor());
-            if (iid != null) cols.add(iid);
-            String il = edge.getInVertexSchema().getFieldByPropertyKey(T.label.getAccessor());
-            if (il != null) cols.add(il);
-        }
-        return cols;
     }
 
     private static Set<String> schemaColumns(AbstractRowSchema<?> schema) {
@@ -268,35 +196,6 @@ public final class MultiHopJoinBuilder {
         UniEdge edge = new UniEdge(new HashMap<>(), source, target, null, graph).asAdjacencyJoinDirected();
         if (mid != null) {
             edge.property(MID_PROP, mid);
-        }
-        return edge;
-    }
-
-    /**
-     * Edge-final: real edge from e1 columns + mid shell (id only from {@link #MID_ID_ALIAS}) for path;
-     * start id on {@link RowEdgeSchema#SRC_ALIAS} for traverser remapping.
-     */
-    public static Edge fromTwoHopEdgeRow(Map<String, Object> row, RowEdgeSchema edgeSchema, UniGraph graph) {
-        Map<String, Object> edgeFields = new HashMap<>();
-        for (Map.Entry<String, Object> e : row.entrySet()) {
-            String k = e.getKey();
-            if (k == null) continue;
-            if (k.startsWith(EDGE_PREFIX)) {
-                edgeFields.put(k.substring(EDGE_PREFIX.length()), e.getValue());
-            }
-        }
-        java.util.Collection<Edge> edges = edgeSchema.fromFields(edgeFields);
-        if (edges == null || edges.isEmpty()) return null;
-        Edge edge = edges.iterator().next();
-        Object midId = row.get(MID_ID_ALIAS);
-        if (midId != null && edge instanceof UniEdge) {
-            Map<String, Object> midProps = new HashMap<>();
-            midProps.put(T.id.getAccessor(), midId);
-            ((UniEdge) edge).property(MID_PROP, new UniVertex(midProps, null, graph));
-        }
-        Object srcId = row.get(RowEdgeSchema.SRC_ALIAS);
-        if (srcId != null && edge instanceof UniEdge) {
-            ((UniEdge) edge).property(RowEdgeSchema.SRC_ALIAS, srcId);
         }
         return edge;
     }

--- a/unipop-jdbc/src/org/unipop/jdbc/schemas/MultiHopJoinBuilder.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/schemas/MultiHopJoinBuilder.java
@@ -48,6 +48,8 @@ public final class MultiHopJoinBuilder {
 
     public static final String MID_PREFIX = "__unipop_mid_";
     public static final String MID_PROP = "__unipop_mid";
+    /** Edge-final: mid vertex id taken from hop-0 edge target column (no mid-table join). */
+    public static final String MID_ID_ALIAS = "__unipop_mid_id";
     public static final String EDGE_PREFIX = "__unipop_e1_";
 
     private MultiHopJoinBuilder() {}
@@ -89,28 +91,26 @@ public final class MultiHopJoinBuilder {
     }
 
     /**
-     * Edge-final 2-hop join ({@code out().outE()} / {@code in().inE()}): no final vertex table join.
-     * Projects e1 columns (prefixed) + mid + start id. Order/limit apply to edge columns.
+     * Edge-final 2-hop join ({@code out().outE()}): join edge tables directly
+     * {@code e0.tgt = e1.src} — <b>no mid vertex table</b>. Avoids fan-out across every mid
+     * schema when endpoints are open (the regression that made multi-hop slower than sequential).
+     * Mid id for path is projected from {@code e0.tgt}.
      */
     private static Select buildTwoHopEdgeFinal(MultiHopQuery query, PathPlan plan) {
         Ctx ctx = ctx(query, plan, false);
         if (ctx == null) return null;
 
-        // Edge-level has() on hop2 already in c1; finalTargetPredicates unused for edge return.
         List<SelectFieldOrAsterisk> projection = new ArrayList<>();
-        // Edge row: id, label, props + endpoint id/label columns needed by fromFields
         for (String col : edgeRowColumns(ctx.e1)) {
             projection.add(field(name("e1", col)).as(EDGE_PREFIX + col));
         }
         projection.add(field(name("e0", ctx.e0SrcCol)).as(RowEdgeSchema.SRC_ALIAS));
-        for (String col : schemaColumns(ctx.midSchema)) {
-            projection.add(field(name("m", col)).as(MID_PREFIX + col));
-        }
+        // Mid is the hop-0 target id on e0 (same value as e1.src) — enough for path identity
+        projection.add(field(name("e0", ctx.e0TgtCol)).as(MID_ID_ALIAS));
 
         SelectConditionStep<Record> where = DSL.select(projection)
                 .from(ctx.te0)
-                .join(ctx.tm).on(field(name("e0", ctx.e0TgtCol)).eq(field(name("m", ctx.midId))))
-                .join(ctx.te1).on(field(name("e1", ctx.e1SrcCol)).eq(field(name("m", ctx.midId))))
+                .join(ctx.te1).on(field(name("e0", ctx.e0TgtCol)).eq(field(name("e1", ctx.e1SrcCol))))
                 .where(ctx.c0.and(ctx.c1));
 
         return orderLimitOnEdge(where, query, ctx.e1, "e1");
@@ -131,13 +131,17 @@ public final class MultiHopJoinBuilder {
         PathHop h1 = plan.getHops().get(1);
         if (h0.getEdgeSchema().getClass() != RowEdgeSchema.class
                 || h1.getEdgeSchema().getClass() != RowEdgeSchema.class) return null;
-        if (!(h0.getTargetVertexSchema() instanceof JdbcVertexSchema)) return null;
-        if (needFinalVertex && !(h1.getTargetVertexSchema() instanceof JdbcVertexSchema)) return null;
+        // Edge-final does not require a mid vertex schema (joins e0.tgt = e1.src directly).
+        if (needFinalVertex) {
+            if (!(h0.getTargetVertexSchema() instanceof JdbcVertexSchema)) return null;
+            if (!(h1.getTargetVertexSchema() instanceof JdbcVertexSchema)) return null;
+        }
 
         Ctx c = new Ctx();
         c.e0 = (RowEdgeSchema) h0.getEdgeSchema();
         c.e1 = (RowEdgeSchema) h1.getEdgeSchema();
-        c.mid = (JdbcVertexSchema) h0.getTargetVertexSchema();
+        c.mid = h0.getTargetVertexSchema() instanceof JdbcVertexSchema
+                ? (JdbcVertexSchema) h0.getTargetVertexSchema() : null;
         c.fin = needFinalVertex ? (JdbcVertexSchema) h1.getTargetVertexSchema() : null;
         Direction d0 = h0.getDirection();
         Direction d1 = h1.getDirection();
@@ -151,8 +155,10 @@ public final class MultiHopJoinBuilder {
         c.e0TgtCol = e0tgt.getFieldByPropertyKey(T.id.getAccessor());
         c.e1SrcCol = e1src.getFieldByPropertyKey(T.id.getAccessor());
         c.e1TgtCol = e1tgt.getFieldByPropertyKey(T.id.getAccessor());
-        c.midSchema = (AbstractRowSchema<?>) c.mid;
-        c.midId = c.midSchema.getFieldByPropertyKey(T.id.getAccessor());
+        if (c.mid != null) {
+            c.midSchema = (AbstractRowSchema<?>) c.mid;
+            c.midId = c.midSchema.getFieldByPropertyKey(T.id.getAccessor());
+        }
         if (c.fin != null) {
             c.finSchema = (AbstractRowSchema<?>) c.fin;
             c.finId = c.finSchema.getFieldByPropertyKey(T.id.getAccessor());
@@ -168,7 +174,7 @@ public final class MultiHopJoinBuilder {
         c.c0 = c.e0.buildTranslator("e0").translate(edge0Holder);
         c.c1 = c.e1.buildTranslator("e1").translate(edge1Holder);
         c.te0 = table(name(c.e0.getTable())).as("e0");
-        c.tm = table(name(c.mid.getTable())).as("m");
+        if (c.mid != null) c.tm = table(name(c.mid.getTable())).as("m");
         c.te1 = table(name(c.e1.getTable())).as("e1");
         return c;
     }
@@ -267,28 +273,26 @@ public final class MultiHopJoinBuilder {
     }
 
     /**
-     * Edge-final: real edge from e1 columns + mid stashed for path; also stores start id on
-     * {@link RowEdgeSchema#SRC_ALIAS} property for traverser remapping.
+     * Edge-final: real edge from e1 columns + mid shell (id only from {@link #MID_ID_ALIAS}) for path;
+     * start id on {@link RowEdgeSchema#SRC_ALIAS} for traverser remapping.
      */
-    public static Edge fromTwoHopEdgeRow(Map<String, Object> row, RowEdgeSchema edgeSchema,
-                                         JdbcVertexSchema midSchema, UniGraph graph) {
+    public static Edge fromTwoHopEdgeRow(Map<String, Object> row, RowEdgeSchema edgeSchema, UniGraph graph) {
         Map<String, Object> edgeFields = new HashMap<>();
-        Map<String, Object> midFields = new HashMap<>();
         for (Map.Entry<String, Object> e : row.entrySet()) {
             String k = e.getKey();
             if (k == null) continue;
-            if (k.startsWith(MID_PREFIX)) {
-                midFields.put(k.substring(MID_PREFIX.length()), e.getValue());
-            } else if (k.startsWith(EDGE_PREFIX)) {
+            if (k.startsWith(EDGE_PREFIX)) {
                 edgeFields.put(k.substring(EDGE_PREFIX.length()), e.getValue());
             }
         }
         java.util.Collection<Edge> edges = edgeSchema.fromFields(edgeFields);
         if (edges == null || edges.isEmpty()) return null;
         Edge edge = edges.iterator().next();
-        Vertex mid = midSchema.createElement(midFields);
-        if (mid != null && edge instanceof UniEdge) {
-            ((UniEdge) edge).property(MID_PROP, mid);
+        Object midId = row.get(MID_ID_ALIAS);
+        if (midId != null && edge instanceof UniEdge) {
+            Map<String, Object> midProps = new HashMap<>();
+            midProps.put(T.id.getAccessor(), midId);
+            ((UniEdge) edge).property(MID_PROP, new UniVertex(midProps, null, graph));
         }
         Object srcId = row.get(RowEdgeSchema.SRC_ALIAS);
         if (srcId != null && edge instanceof UniEdge) {

--- a/unipop-jdbc/src/org/unipop/jdbc/schemas/MultiHopJoinBuilder.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/schemas/MultiHopJoinBuilder.java
@@ -1,0 +1,299 @@
+package org.unipop.jdbc.schemas;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Order;
+import org.apache.tinkerpop.gremlin.structure.Direction;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.javatuples.Pair;
+import org.jooq.Condition;
+import org.jooq.Field;
+import org.jooq.Record;
+import org.jooq.Select;
+import org.jooq.SelectConditionStep;
+import org.jooq.SelectFieldOrAsterisk;
+import org.jooq.SortField;
+import org.jooq.Table;
+import org.jooq.impl.DSL;
+import org.unipop.jdbc.schemas.jdbc.JdbcVertexSchema;
+import org.unipop.query.predicates.PredicatesHolder;
+import org.unipop.query.search.MultiHopQuery;
+import org.unipop.schema.catalog.PathHop;
+import org.unipop.schema.catalog.PathPlan;
+import org.unipop.schema.element.VertexSchema;
+import org.unipop.schema.property.PropertySchema;
+import org.unipop.structure.UniEdge;
+import org.unipop.structure.UniGraph;
+import org.unipop.structure.UniVertex;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.jooq.impl.DSL.field;
+import static org.jooq.impl.DSL.name;
+import static org.jooq.impl.DSL.table;
+
+/**
+ * Builds a 2-hop adjacency JOIN for exact {@link RowEdgeSchema} path plans.
+ * <ul>
+ *   <li>Vertex-final ({@code out}/{@code in}): projects final vertex + mid + start id.</li>
+ *   <li>Edge-final ({@code outE}/{@code inE}): projects final edge row + mid + start id (no final vertex join).</li>
+ * </ul>
+ */
+public final class MultiHopJoinBuilder {
+
+    public static final String MID_PREFIX = "__unipop_mid_";
+    public static final String MID_PROP = "__unipop_mid";
+    public static final String EDGE_PREFIX = "__unipop_e1_";
+
+    private MultiHopJoinBuilder() {}
+
+    /**
+     * Vertex-final 2-hop join (final hop returns vertices).
+     * @throws RowEdgeSchema.OrderNotPushableException when final order column missing
+     */
+    public static Select buildTwoHop(MultiHopQuery query, PathPlan plan) {
+        return query.isReturnsVertex() ? buildTwoHopVertexFinal(query, plan) : buildTwoHopEdgeFinal(query, plan);
+    }
+
+    private static Select buildTwoHopVertexFinal(MultiHopQuery query, PathPlan plan) {
+        Ctx ctx = ctx(query, plan, true);
+        if (ctx == null) return null;
+
+        PredicatesHolder tgtHolder = ctx.fin.toPredicates(query.getFinalTargetPredicates());
+        if (tgtHolder.isAborted()) return null;
+        Condition ct = ctx.finSchema.buildTranslator("v").translate(tgtHolder);
+
+        Table<Record> tv = table(name(ctx.fin.getTable())).as("v");
+        List<SelectFieldOrAsterisk> projection = new ArrayList<>();
+        for (String col : schemaColumns(ctx.finSchema)) {
+            projection.add(field(name("v", col)));
+        }
+        projection.add(field(name("e0", ctx.e0SrcCol)).as(RowEdgeSchema.SRC_ALIAS));
+        for (String col : schemaColumns(ctx.midSchema)) {
+            projection.add(field(name("m", col)).as(MID_PREFIX + col));
+        }
+
+        SelectConditionStep<Record> where = DSL.select(projection)
+                .from(ctx.te0)
+                .join(ctx.tm).on(field(name("e0", ctx.e0TgtCol)).eq(field(name("m", ctx.midId))))
+                .join(ctx.te1).on(field(name("e1", ctx.e1SrcCol)).eq(field(name("m", ctx.midId))))
+                .join(tv).on(field(name("e1", ctx.e1TgtCol)).eq(field(name("v", ctx.finId))))
+                .where(ctx.c0.and(ctx.c1).and(ct));
+
+        return orderLimit(where, query, ctx.finSchema, "v");
+    }
+
+    /**
+     * Edge-final 2-hop join ({@code out().outE()} / {@code in().inE()}): no final vertex table join.
+     * Projects e1 columns (prefixed) + mid + start id. Order/limit apply to edge columns.
+     */
+    private static Select buildTwoHopEdgeFinal(MultiHopQuery query, PathPlan plan) {
+        Ctx ctx = ctx(query, plan, false);
+        if (ctx == null) return null;
+
+        // Edge-level has() on hop2 already in c1; finalTargetPredicates unused for edge return.
+        List<SelectFieldOrAsterisk> projection = new ArrayList<>();
+        // Edge row: id, label, props + endpoint id/label columns needed by fromFields
+        for (String col : edgeRowColumns(ctx.e1)) {
+            projection.add(field(name("e1", col)).as(EDGE_PREFIX + col));
+        }
+        projection.add(field(name("e0", ctx.e0SrcCol)).as(RowEdgeSchema.SRC_ALIAS));
+        for (String col : schemaColumns(ctx.midSchema)) {
+            projection.add(field(name("m", col)).as(MID_PREFIX + col));
+        }
+
+        SelectConditionStep<Record> where = DSL.select(projection)
+                .from(ctx.te0)
+                .join(ctx.tm).on(field(name("e0", ctx.e0TgtCol)).eq(field(name("m", ctx.midId))))
+                .join(ctx.te1).on(field(name("e1", ctx.e1SrcCol)).eq(field(name("m", ctx.midId))))
+                .where(ctx.c0.and(ctx.c1));
+
+        return orderLimitOnEdge(where, query, ctx.e1, "e1");
+    }
+
+    private static class Ctx {
+        RowEdgeSchema e0, e1;
+        JdbcVertexSchema mid, fin;
+        AbstractRowSchema<?> midSchema, finSchema;
+        String e0SrcCol, e0TgtCol, e1SrcCol, e1TgtCol, midId, finId;
+        Condition c0, c1;
+        Table<Record> te0, tm, te1;
+    }
+
+    private static Ctx ctx(MultiHopQuery query, PathPlan plan, boolean needFinalVertex) {
+        if (plan == null || plan.size() != 2) return null;
+        PathHop h0 = plan.getHops().get(0);
+        PathHop h1 = plan.getHops().get(1);
+        if (h0.getEdgeSchema().getClass() != RowEdgeSchema.class
+                || h1.getEdgeSchema().getClass() != RowEdgeSchema.class) return null;
+        if (!(h0.getTargetVertexSchema() instanceof JdbcVertexSchema)) return null;
+        if (needFinalVertex && !(h1.getTargetVertexSchema() instanceof JdbcVertexSchema)) return null;
+
+        Ctx c = new Ctx();
+        c.e0 = (RowEdgeSchema) h0.getEdgeSchema();
+        c.e1 = (RowEdgeSchema) h1.getEdgeSchema();
+        c.mid = (JdbcVertexSchema) h0.getTargetVertexSchema();
+        c.fin = needFinalVertex ? (JdbcVertexSchema) h1.getTargetVertexSchema() : null;
+        Direction d0 = h0.getDirection();
+        Direction d1 = h1.getDirection();
+
+        VertexSchema e0src = d0 == Direction.OUT ? c.e0.getOutVertexSchema() : c.e0.getInVertexSchema();
+        VertexSchema e0tgt = d0 == Direction.OUT ? c.e0.getInVertexSchema() : c.e0.getOutVertexSchema();
+        VertexSchema e1src = d1 == Direction.OUT ? c.e1.getOutVertexSchema() : c.e1.getInVertexSchema();
+        VertexSchema e1tgt = d1 == Direction.OUT ? c.e1.getInVertexSchema() : c.e1.getOutVertexSchema();
+
+        c.e0SrcCol = e0src.getFieldByPropertyKey(T.id.getAccessor());
+        c.e0TgtCol = e0tgt.getFieldByPropertyKey(T.id.getAccessor());
+        c.e1SrcCol = e1src.getFieldByPropertyKey(T.id.getAccessor());
+        c.e1TgtCol = e1tgt.getFieldByPropertyKey(T.id.getAccessor());
+        c.midSchema = (AbstractRowSchema<?>) c.mid;
+        c.midId = c.midSchema.getFieldByPropertyKey(T.id.getAccessor());
+        if (c.fin != null) {
+            c.finSchema = (AbstractRowSchema<?>) c.fin;
+            c.finId = c.finSchema.getFieldByPropertyKey(T.id.getAccessor());
+        }
+
+        MultiHopQuery.HopSpec hop0 = query.getHops().get(0);
+        MultiHopQuery.HopSpec hop1 = query.getHops().get(1);
+        PredicatesHolder edge0Holder = c.e0.toPredicates(query.getStarts(), d0, hop0.getEdgePredicates());
+        if (edge0Holder.isAborted()) return null;
+        PredicatesHolder edge1Holder = c.e1.toPredicates(hop1.getEdgePredicates());
+        if (edge1Holder.isAborted()) return null;
+
+        c.c0 = c.e0.buildTranslator("e0").translate(edge0Holder);
+        c.c1 = c.e1.buildTranslator("e1").translate(edge1Holder);
+        c.te0 = table(name(c.e0.getTable())).as("e0");
+        c.tm = table(name(c.mid.getTable())).as("m");
+        c.te1 = table(name(c.e1.getTable())).as("e1");
+        return c;
+    }
+
+    private static Select orderLimit(SelectConditionStep<Record> where, MultiHopQuery query,
+                                     AbstractRowSchema<?> orderSchema, String alias) {
+        List<SortField<Object>> sorts = new ArrayList<>();
+        if (query.getFinalOrders() != null) {
+            for (Pair<String, Order> o : query.getFinalOrders()) {
+                String col = orderSchema.getFieldByPropertyKey(o.getValue0());
+                if (col == null) throw new RowEdgeSchema.OrderNotPushableException();
+                Field<Object> f = field(name(alias, col));
+                sorts.add(o.getValue1().equals(Order.desc) ? f.desc() : f.asc());
+            }
+        }
+        int lim = query.getFinalLimit() < 0 ? Integer.MAX_VALUE : query.getFinalLimit();
+        return sorts.isEmpty() ? where.limit(lim) : where.orderBy(sorts).limit(lim);
+    }
+
+    private static Select orderLimitOnEdge(SelectConditionStep<Record> where, MultiHopQuery query,
+                                           RowEdgeSchema edge, String alias) {
+        List<SortField<Object>> sorts = new ArrayList<>();
+        if (query.getFinalOrders() != null) {
+            for (Pair<String, Order> o : query.getFinalOrders()) {
+                String col = edge.getFieldByPropertyKey(o.getValue0());
+                if (col == null) throw new RowEdgeSchema.OrderNotPushableException();
+                Field<Object> f = field(name(alias, col));
+                sorts.add(o.getValue1().equals(Order.desc) ? f.desc() : f.asc());
+            }
+        }
+        int lim = query.getFinalLimit() < 0 ? Integer.MAX_VALUE : query.getFinalLimit();
+        return sorts.isEmpty() ? where.limit(lim) : where.orderBy(sorts).limit(lim);
+    }
+
+    private static Set<String> edgeRowColumns(RowEdgeSchema edge) {
+        Set<String> cols = schemaColumns(edge);
+        // Endpoint ref columns (out/in id/label fields) required by fromFields
+        if (edge.getOutVertexSchema() != null) {
+            String oid = edge.getOutVertexSchema().getFieldByPropertyKey(T.id.getAccessor());
+            if (oid != null) cols.add(oid);
+            String ol = edge.getOutVertexSchema().getFieldByPropertyKey(T.label.getAccessor());
+            if (ol != null) cols.add(ol);
+        }
+        if (edge.getInVertexSchema() != null) {
+            String iid = edge.getInVertexSchema().getFieldByPropertyKey(T.id.getAccessor());
+            if (iid != null) cols.add(iid);
+            String il = edge.getInVertexSchema().getFieldByPropertyKey(T.label.getAccessor());
+            if (il != null) cols.add(il);
+        }
+        return cols;
+    }
+
+    private static Set<String> schemaColumns(AbstractRowSchema<?> schema) {
+        Set<String> cols = new HashSet<>();
+        String id = schema.getFieldByPropertyKey(T.id.getAccessor());
+        if (id != null) cols.add(id);
+        String label = schema.getFieldByPropertyKey(T.label.getAccessor());
+        if (label != null) cols.add(label);
+        for (PropertySchema p : schema.getPropertySchemas()) {
+            if (p == null || p.getKey() == null) continue;
+            String col = schema.getFieldByPropertyKey(p.getKey());
+            if (col != null) cols.add(col);
+        }
+        if (cols.isEmpty() && id != null) cols.add(id);
+        return cols;
+    }
+
+    /**
+     * Vertex-final: adjacencyJoinDirected edge (out=start shell, in=final vertex) + mid property.
+     */
+    public static Edge fromTwoHopRow(Map<String, Object> row, JdbcVertexSchema midSchema,
+                                     JdbcVertexSchema finalVertexSchema, UniGraph graph) {
+        Map<String, Object> finalFields = new HashMap<>();
+        Map<String, Object> midFields = new HashMap<>();
+        for (Map.Entry<String, Object> e : row.entrySet()) {
+            String k = e.getKey();
+            if (k == null) continue;
+            if (k.startsWith(MID_PREFIX)) {
+                midFields.put(k.substring(MID_PREFIX.length()), e.getValue());
+            } else if (!RowEdgeSchema.SRC_ALIAS.equals(k)) {
+                finalFields.put(k, e.getValue());
+            }
+        }
+        Vertex target = finalVertexSchema.createElement(finalFields);
+        if (target == null) return null;
+        Vertex mid = midSchema.createElement(midFields);
+        Object srcId = row.get(RowEdgeSchema.SRC_ALIAS);
+        Map<String, Object> shellProps = new HashMap<>();
+        shellProps.put(T.id.getAccessor(), srcId);
+        Vertex source = new UniVertex(shellProps, null, graph);
+        UniEdge edge = new UniEdge(new HashMap<>(), source, target, null, graph).asAdjacencyJoinDirected();
+        if (mid != null) {
+            edge.property(MID_PROP, mid);
+        }
+        return edge;
+    }
+
+    /**
+     * Edge-final: real edge from e1 columns + mid stashed for path; also stores start id on
+     * {@link RowEdgeSchema#SRC_ALIAS} property for traverser remapping.
+     */
+    public static Edge fromTwoHopEdgeRow(Map<String, Object> row, RowEdgeSchema edgeSchema,
+                                         JdbcVertexSchema midSchema, UniGraph graph) {
+        Map<String, Object> edgeFields = new HashMap<>();
+        Map<String, Object> midFields = new HashMap<>();
+        for (Map.Entry<String, Object> e : row.entrySet()) {
+            String k = e.getKey();
+            if (k == null) continue;
+            if (k.startsWith(MID_PREFIX)) {
+                midFields.put(k.substring(MID_PREFIX.length()), e.getValue());
+            } else if (k.startsWith(EDGE_PREFIX)) {
+                edgeFields.put(k.substring(EDGE_PREFIX.length()), e.getValue());
+            }
+        }
+        java.util.Collection<Edge> edges = edgeSchema.fromFields(edgeFields);
+        if (edges == null || edges.isEmpty()) return null;
+        Edge edge = edges.iterator().next();
+        Vertex mid = midSchema.createElement(midFields);
+        if (mid != null && edge instanceof UniEdge) {
+            ((UniEdge) edge).property(MID_PROP, mid);
+        }
+        Object srcId = row.get(RowEdgeSchema.SRC_ALIAS);
+        if (srcId != null && edge instanceof UniEdge) {
+            ((UniEdge) edge).property(RowEdgeSchema.SRC_ALIAS, srcId);
+        }
+        return edge;
+    }
+}

--- a/unipop-jdbc/src/org/unipop/jdbc/schemas/RowEdgeSchema.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/schemas/RowEdgeSchema.java
@@ -49,6 +49,16 @@ public class RowEdgeSchema extends AbstractRowSchema<Edge> implements JdbcEdgeSc
         this.outVertexSchema = createVertexSchema("outVertex");
     }
 
+    @Override
+    public VertexSchema getOutVertexSchema() {
+        return outVertexSchema;
+    }
+
+    @Override
+    public VertexSchema getInVertexSchema() {
+        return inVertexSchema;
+    }
+
     protected VertexSchema createVertexSchema(String key) throws JSONException {
         JSONObject vertexConfiguration = this.json.optJSONObject(key);
         if(vertexConfiguration == null) return null;

--- a/unipop-jdbc/src/org/unipop/jdbc/schemas/property/EnumPropertySchema.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/schemas/property/EnumPropertySchema.java
@@ -4,20 +4,43 @@ import org.json.JSONObject;
 import org.unipop.schema.property.AbstractPropertyContainer;
 import org.unipop.schema.property.FieldPropertySchema;
 import org.unipop.schema.property.PropertySchema;
+import org.unipop.util.ConversionUtils;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 /**
  * A keyed property schema backing a PostgreSQL native enum column. Extends {@link FieldPropertySchema}
  * for the column&lt;-&gt;property mapping (read/write/predicate); the column is reported via
  * {@link EnumColumnSchema} so the jdbc translator compares it as text (col::text = ?). Declare:
  * {@code "status": {"type":"enum"}}. An optional {@code "enumType"} name is retained as metadata
- * (validated when present) but is unused at runtime.
+ * (validated when present).
+ * <p>
+ * Closed domain for optimizers ({@link #knownValues()}):
+ * <ul>
+ *   <li>Config {@code values} / {@code include} if present (wins).</li>
+ *   <li>Otherwise filled at provider init by {@code EnumDomainLoader} from {@code pg_enum}
+ *       (by {@code enumType}, or by table+column when the type name is omitted).</li>
+ * </ul>
+ * When used as {@code ~label}, that domain becomes a closed label set in the schema catalog.
  */
 public class EnumPropertySchema extends FieldPropertySchema implements EnumColumnSchema {
     private final String enumType;
+    /** Config and/or DB-hydrated members; empty set means domain still open. */
+    private volatile Set<Object> values;
 
     public EnumPropertySchema(String key, String field, boolean nullable, String enumType) {
+        this(key, field, nullable, enumType, Collections.emptySet());
+    }
+
+    public EnumPropertySchema(String key, String field, boolean nullable, String enumType, Set<Object> values) {
         super(key, field, nullable);
         this.enumType = enumType;
+        this.values = values == null || values.isEmpty()
+                ? Collections.emptySet()
+                : Collections.unmodifiableSet(new LinkedHashSet<>(values));
     }
 
     @Override
@@ -28,6 +51,35 @@ public class EnumPropertySchema extends FieldPropertySchema implements EnumColum
     /** @return the optional declared PostgreSQL enum type name (metadata; may be null). */
     public String getEnumType() {
         return enumType;
+    }
+
+    /**
+     * Known enum members (config and/or catalog introspection). Empty when still unknown.
+     */
+    public Set<Object> getEnumValues() {
+        return values;
+    }
+
+    /**
+     * Fill domain from Postgres introspection. No-op when config (or a prior hydrate) already
+     * provided members — config always wins.
+     */
+    public void setKnownValuesIfEmpty(Collection<?> domain) {
+        if (domain == null || domain.isEmpty()) return;
+        if (values != null && !values.isEmpty()) return;
+        Set<Object> copy = new LinkedHashSet<>();
+        for (Object v : domain) {
+            if (v != null) copy.add(v.toString());
+        }
+        if (!copy.isEmpty()) {
+            this.values = Collections.unmodifiableSet(copy);
+        }
+    }
+
+    @Override
+    public Set<Object> knownValues() {
+        if (values != null && !values.isEmpty()) return values;
+        return super.knownValues();
     }
 
     public static class Builder implements PropertySchemaBuilder {
@@ -42,7 +94,10 @@ public class EnumPropertySchema extends FieldPropertySchema implements EnumColum
             if (enumType != null && !enumType.matches("^[A-Za-z_][A-Za-z0-9_]*$"))
                 throw new IllegalArgumentException("Invalid enum type name in config: " + enumType);
             boolean nullable = config.optBoolean("nullable", true);
-            return new EnumPropertySchema(key, field, nullable, enumType);
+            // Prefer explicit "values"; accept "include" as the same closed-domain list (matches FieldPropertySchema).
+            Set<Object> domain = ConversionUtils.toSet(config, "values");
+            if (domain.isEmpty()) domain = ConversionUtils.toSet(config, "include");
+            return new EnumPropertySchema(key, field, nullable, enumType, domain);
         }
     }
 }

--- a/unipop-jdbc/src/org/unipop/jdbc/schemas/property/EnumPropertySchema.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/schemas/property/EnumPropertySchema.java
@@ -54,13 +54,6 @@ public class EnumPropertySchema extends FieldPropertySchema implements EnumColum
     }
 
     /**
-     * Known enum members (config and/or catalog introspection). Empty when still unknown.
-     */
-    public Set<Object> getEnumValues() {
-        return values;
-    }
-
-    /**
      * Fill domain from Postgres introspection. No-op when config (or a prior hydrate) already
      * provided members — config always wins.
      */

--- a/unipop-jdbc/src/org/unipop/jdbc/utils/EnumDomainLoader.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/utils/EnumDomainLoader.java
@@ -1,0 +1,150 @@
+package org.unipop.jdbc.utils;
+
+import org.jooq.impl.DSL;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.unipop.jdbc.schemas.jdbc.JdbcSchema;
+import org.unipop.jdbc.schemas.property.EnumPropertySchema;
+import org.unipop.schema.element.ElementSchema;
+import org.unipop.schema.property.AbstractPropertyContainer;
+import org.unipop.schema.property.PropertySchema;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Loads PostgreSQL enum member labels from the catalog into {@link EnumPropertySchema}
+ * so {@link org.unipop.schema.property.PropertySchema#knownValues()} is closed without
+ * requiring config-side {@code values}/{@code include} lists.
+ *
+ * <p>Resolution order per schema:
+ * <ol>
+ *   <li>Skip if config already declared a non-empty domain.</li>
+ *   <li>If {@code enumType} is set → {@code pg_type}/{@code pg_enum} by type name.</li>
+ *   <li>Else if table + column known → resolve the column's enum type and read members.</li>
+ * </ol>
+ * Failures are logged and leave the domain open (no over-pruning).
+ */
+public final class EnumDomainLoader {
+    private static final Logger logger = LoggerFactory.getLogger(EnumDomainLoader.class);
+
+    private EnumDomainLoader() {}
+
+    public static void hydrate(ContextManager contextManager, Collection<? extends ElementSchema> schemas) {
+        if (contextManager == null || schemas == null || schemas.isEmpty()) return;
+        Map<String, Set<Object>> byType = new HashMap<>();
+        Set<ElementSchema> seen = Collections.newSetFromMap(new IdentityHashMap<>());
+        for (ElementSchema schema : schemas) {
+            walk(contextManager, schema, tableOf(schema), byType, seen);
+        }
+    }
+
+    private static void walk(ContextManager cm, ElementSchema schema, String table,
+                             Map<String, Set<Object>> byType, Set<ElementSchema> seen) {
+        if (schema == null || !seen.add(schema)) return;
+        String localTable = tableOf(schema) != null ? tableOf(schema) : table;
+
+        if (schema instanceof AbstractPropertyContainer) {
+            for (PropertySchema p : ((AbstractPropertyContainer) schema).getPropertySchemas()) {
+                if (p instanceof EnumPropertySchema) {
+                    hydrateOne(cm, (EnumPropertySchema) p, localTable, byType);
+                }
+            }
+        }
+        for (Object child : schema.getChildSchemas()) {
+            if (child instanceof ElementSchema) {
+                walk(cm, (ElementSchema) child, localTable, byType, seen);
+            }
+        }
+    }
+
+    private static void hydrateOne(ContextManager cm, EnumPropertySchema enumSchema, String table,
+                                   Map<String, Set<Object>> byType) {
+        if (!enumSchema.knownValues().isEmpty()) return; // config wins
+
+        Set<Object> domain = null;
+        String typeName = enumSchema.getEnumType();
+        if (typeName != null && !typeName.isEmpty()) {
+            domain = byType.computeIfAbsent(typeName, t -> loadByTypeName(cm, t));
+        } else if (table != null && enumSchema.getEnumColumn() != null) {
+            String cacheKey = table + "." + enumSchema.getEnumColumn();
+            domain = byType.computeIfAbsent(cacheKey, k -> loadByTableColumn(cm, table, enumSchema.getEnumColumn()));
+        }
+
+        if (domain != null && !domain.isEmpty()) {
+            enumSchema.setKnownValuesIfEmpty(domain);
+            logger.debug("Hydrated enum domain for {}.{} → {}", table, enumSchema.getKey(), domain);
+        }
+    }
+
+    /**
+     * {@code SELECT enumlabel FROM pg_type t JOIN pg_enum e ON … WHERE t.typname = ?}
+     */
+    public static Set<Object> loadByTypeName(ContextManager cm, String typeName) {
+        try {
+            List<Map<String, Object>> rows = cm.fetch(DSL.resultQuery(
+                    "SELECT e.enumlabel AS enumlabel "
+                            + "FROM pg_catalog.pg_type t "
+                            + "JOIN pg_catalog.pg_enum e ON e.enumtypid = t.oid "
+                            + "WHERE t.typname = {0} "
+                            + "ORDER BY e.enumsortorder",
+                    DSL.val(typeName)));
+            return labels(rows);
+        } catch (Exception e) {
+            logger.warn("Failed to load enum members for type '{}': {}", typeName, e.toString());
+            return Collections.emptySet();
+        }
+    }
+
+    /**
+     * Resolve enum labels for a table column (handles plain enum columns and domains over enums).
+     */
+    public static Set<Object> loadByTableColumn(ContextManager cm, String table, String column) {
+        try {
+            List<Map<String, Object>> rows = cm.fetch(DSL.resultQuery(
+                    "SELECT e.enumlabel AS enumlabel "
+                            + "FROM pg_catalog.pg_attribute a "
+                            + "JOIN pg_catalog.pg_class c ON c.oid = a.attrelid "
+                            + "JOIN pg_catalog.pg_type t ON t.oid = a.atttypid "
+                            + "JOIN pg_catalog.pg_enum e ON e.enumtypid = CASE "
+                            + "  WHEN t.typtype = 'e' THEN t.oid "
+                            + "  ELSE t.typbasetype END "
+                            + "WHERE c.relname = {0} AND a.attname = {1} "
+                            + "  AND a.attnum > 0 AND NOT a.attisdropped "
+                            + "ORDER BY e.enumsortorder",
+                    DSL.val(table), DSL.val(column)));
+            return labels(rows);
+        } catch (Exception e) {
+            logger.warn("Failed to load enum members for {}.{}: {}", table, column, e.toString());
+            return Collections.emptySet();
+        }
+    }
+
+    private static Set<Object> labels(List<Map<String, Object>> rows) {
+        if (rows == null || rows.isEmpty()) return Collections.emptySet();
+        Set<Object> out = new LinkedHashSet<>();
+        for (Map<String, Object> row : rows) {
+            Object v = row.get("enumlabel");
+            if (v == null) {
+                // jOOQ / driver may return uppercase keys depending on settings
+                v = row.values().stream().findFirst().orElse(null);
+            }
+            if (v != null) out.add(v.toString());
+        }
+        return out.isEmpty() ? Collections.emptySet() : Collections.unmodifiableSet(out);
+    }
+
+    private static String tableOf(ElementSchema schema) {
+        if (schema instanceof JdbcSchema) {
+            String t = ((JdbcSchema) schema).getTable();
+            return t == null || t.isEmpty() ? null : t;
+        }
+        return null;
+    }
+}

--- a/unipop-jdbc/test/org/unipop/jdbc/enums/EnumDomainLoaderTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/enums/EnumDomainLoaderTest.java
@@ -1,0 +1,156 @@
+package org.unipop.jdbc.enums;
+
+import org.json.JSONObject;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.unipop.jdbc.schemas.RowVertexSchema;
+import org.unipop.jdbc.schemas.property.EnumPropertySchema;
+import org.unipop.jdbc.suite.EmbeddedPostgresServer;
+import org.unipop.jdbc.utils.ContextManager;
+import org.unipop.jdbc.utils.EnumDomainLoader;
+import org.unipop.schema.property.PropertySchema;
+import org.unipop.schema.property.type.DateType;
+import org.unipop.schema.property.type.DoubleType;
+import org.unipop.schema.property.type.FloatType;
+import org.unipop.schema.property.type.IntType;
+import org.unipop.schema.property.type.LongType;
+import org.unipop.schema.property.type.NumberType;
+import org.unipop.schema.property.type.TextType;
+import org.unipop.util.PropertySchemaFactory;
+import org.unipop.util.PropertyTypeFactory;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Verifies Postgres catalog introspection fills {@link EnumPropertySchema#knownValues()}.
+ */
+public class EnumDomainLoaderTest {
+
+    private static ContextManager contextManager;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        PropertyTypeFactory.init(Arrays.asList(
+                TextType.class.getCanonicalName(),
+                DateType.class.getCanonicalName(),
+                NumberType.class.getCanonicalName(),
+                DoubleType.class.getCanonicalName(),
+                FloatType.class.getCanonicalName(),
+                IntType.class.getCanonicalName(),
+                LongType.class.getCanonicalName()));
+        PropertySchemaFactory.build(
+                Collections.singletonList(new EnumPropertySchema.Builder()),
+                Collections.emptyList());
+
+        EmbeddedPostgresServer.ensureStarted();
+        Class.forName("org.postgresql.Driver");
+        try (Connection c = DriverManager.getConnection(EmbeddedPostgresServer.URL, EmbeddedPostgresServer.USER, "");
+             Statement s = c.createStatement()) {
+            s.execute("DROP TABLE IF EXISTS enum_domain_host");
+            s.execute("DROP TYPE IF EXISTS host_kind");
+            s.execute("CREATE TYPE host_kind AS ENUM ('physical','virtual','container')");
+            s.execute("CREATE TABLE enum_domain_host (id varchar(100) primary key, label host_kind, name varchar(100))");
+        }
+
+        JSONObject conf = new JSONObject()
+                .put("driver", "org.postgresql.Driver")
+                .put("sqlDialect", "POSTGRES")
+                .put("address", new org.json.JSONArray().put(EmbeddedPostgresServer.URL))
+                .put("user", EmbeddedPostgresServer.USER)
+                .put("password", "");
+        contextManager = new ContextManager(conf);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        if (contextManager != null) contextManager.close();
+    }
+
+    @Test
+    public void loadsMembersByEnumTypeName() {
+        Set<Object> labels = EnumDomainLoader.loadByTypeName(contextManager, "host_kind");
+        assertEquals(new HashSet<>(Arrays.asList("physical", "virtual", "container")), labels);
+    }
+
+    @Test
+    public void loadsMembersByTableColumn() {
+        Set<Object> labels = EnumDomainLoader.loadByTableColumn(contextManager, "enum_domain_host", "label");
+        assertEquals(new HashSet<>(Arrays.asList("physical", "virtual", "container")), labels);
+    }
+
+    @Test
+    public void hydrateFillsSchemaWithoutConfigValues() {
+        // label is enum with type name only — no values/include in config
+        JSONObject vertexJson = new JSONObject()
+                .put("table", "enum_domain_host")
+                .put("id", "@id")
+                .put("label", new JSONObject().put("type", "enum").put("field", "label").put("enumType", "host_kind"))
+                .put("properties", new JSONObject().put("name", "@name"))
+                .put("dynamicProperties", false);
+
+        RowVertexSchema schema = new RowVertexSchema(vertexJson, null);
+        EnumPropertySchema label = findLabelEnum(schema);
+        assertTrue("precondition: domain empty before hydrate", label.knownValues().isEmpty());
+
+        EnumDomainLoader.hydrate(contextManager, Collections.singleton(schema));
+
+        assertEquals(new HashSet<>(Arrays.asList("physical", "virtual", "container")),
+                label.knownValues());
+    }
+
+    @Test
+    public void hydrateUsesTableColumnWhenEnumTypeOmitted() {
+        JSONObject vertexJson = new JSONObject()
+                .put("table", "enum_domain_host")
+                .put("id", "@id")
+                .put("label", new JSONObject().put("type", "enum").put("field", "label"))
+                .put("properties", new JSONObject())
+                .put("dynamicProperties", false);
+
+        RowVertexSchema schema = new RowVertexSchema(vertexJson, null);
+        EnumPropertySchema label = findLabelEnum(schema);
+        EnumDomainLoader.hydrate(contextManager, Collections.singleton(schema));
+        assertEquals(new HashSet<>(Arrays.asList("physical", "virtual", "container")),
+                label.knownValues());
+    }
+
+    @Test
+    public void configValuesWinOverDatabase() {
+        JSONObject vertexJson = new JSONObject()
+                .put("table", "enum_domain_host")
+                .put("id", "@id")
+                .put("label", new JSONObject()
+                        .put("type", "enum")
+                        .put("field", "label")
+                        .put("enumType", "host_kind")
+                        .put("values", new org.json.JSONArray().put("only_config")))
+                .put("properties", new JSONObject())
+                .put("dynamicProperties", false);
+
+        RowVertexSchema schema = new RowVertexSchema(vertexJson, null);
+        EnumPropertySchema label = findLabelEnum(schema);
+        EnumDomainLoader.hydrate(contextManager, Collections.singleton(schema));
+        assertEquals(Collections.singleton("only_config"), label.knownValues());
+    }
+
+    /** Label property key is T.label.getAccessor() → "~label". */
+    private static EnumPropertySchema findLabelEnum(RowVertexSchema schema) {
+        for (PropertySchema p : schema.getPropertySchemas()) {
+            if (p instanceof EnumPropertySchema) {
+                return (EnumPropertySchema) p;
+            }
+        }
+        throw new AssertionError("no EnumPropertySchema on schema; props="
+                + schema.getPropertySchemas().stream().map(PropertySchema::getKey).toList());
+    }
+}

--- a/unipop-jdbc/test/org/unipop/jdbc/enums/EnumPropertySchemaTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/enums/EnumPropertySchemaTest.java
@@ -15,11 +15,15 @@ import org.unipop.schema.property.type.TextType;
 import org.unipop.util.PropertyTypeFactory;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 /**
  * Unit tests for {@link EnumPropertySchema.Builder} — no database needed. Locks in the config-claim
@@ -80,5 +84,36 @@ public class EnumPropertySchemaTest {
         assertNull(builder.build("status", new JSONObject().put("type", "jsonb"), null));
         assertNull(builder.build("status", new JSONObject().put("field", "status"), null));
         assertNull(builder.build("status", "@status", null));
+    }
+
+    @Test
+    public void valuesFormClosedKnownDomain() {
+        PropertySchema schema = builder.build("label",
+                new JSONObject()
+                        .put("type", "enum")
+                        .put("field", "label")
+                        .put("enumType", "element_label")
+                        .put("values", new org.json.JSONArray().put("person").put("software")),
+                null);
+        EnumPropertySchema enumSchema = (EnumPropertySchema) schema;
+        Set<Object> known = enumSchema.knownValues();
+        assertEquals(new HashSet<>(Arrays.asList("person", "software")), known);
+        assertFalse(known.isEmpty());
+    }
+
+    @Test
+    public void includeAcceptedAsValuesAlias() {
+        PropertySchema schema = builder.build("label",
+                new JSONObject()
+                        .put("type", "enum")
+                        .put("include", new org.json.JSONArray().put("host")),
+                null);
+        assertEquals(Collections.singleton("host"), ((EnumPropertySchema) schema).knownValues());
+    }
+
+    @Test
+    public void bareEnumHasEmptyKnownValues() {
+        PropertySchema schema = builder.build("status", new JSONObject().put("type", "enum"), null);
+        assertTrue(((EnumPropertySchema) schema).knownValues().isEmpty());
     }
 }

--- a/unipop-jdbc/test/org/unipop/jdbc/multihop/JdbcMultiHopPushdownTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/multihop/JdbcMultiHopPushdownTest.java
@@ -102,16 +102,11 @@ public class JdbcMultiHopPushdownTest {
     }
 
     @Test
-    public void twoHopOutThenOutE() {
-        // root → h1 → edge o6 (h1→p1)
+    public void twoHopOutThenOutECorrectAndSequentialByDefault() {
+        // Edge-final is not multi-joined by default (sequential is faster on open topologies).
+        TimingExecuterListener.timing.clear();
         assertEquals(1L, (long) g.V("root").out("owns").outE("owns").count().next());
-        assertTrue("expected multi-join for out().outE()", multiJoinedOwnsTwice());
-    }
-
-    @Test
-    public void twoHopOutThenOutEWithLimit() {
-        assertEquals(1L, (long) g.V("root").out("owns").outE("owns").limit(10).count().next());
-        assertTrue(multiJoinedOwnsTwice());
+        assertFalse("unbounded out().outE() must not multi-join by default", multiJoinedOwnsTwice());
     }
 
     private static boolean multiJoinedOwnsTwice() {

--- a/unipop-jdbc/test/org/unipop/jdbc/multihop/JdbcMultiHopPushdownTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/multihop/JdbcMultiHopPushdownTest.java
@@ -1,0 +1,152 @@
+package org.unipop.jdbc.multihop;
+
+import org.apache.commons.configuration2.BaseConfiguration;
+import org.apache.commons.configuration2.Configuration;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.unipop.jdbc.suite.EmbeddedPostgresServer;
+import org.unipop.jdbc.utils.TimingExecuterListener;
+import org.unipop.structure.UniGraph;
+
+import java.io.File;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * 2-hop pushdown on the joinpushdown fixture: root -owns-> h1 -owns-> p1.
+ */
+public class JdbcMultiHopPushdownTest {
+
+    private static GraphTraversalSource g;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        EmbeddedPostgresServer.ensureStarted();
+        Class.forName("org.postgresql.Driver");
+        try (Connection c = DriverManager.getConnection(EmbeddedPostgresServer.URL, EmbeddedPostgresServer.USER, "");
+             Statement s = c.createStatement()) {
+            s.execute("DROP TABLE IF EXISTS jp_host");
+            s.execute("DROP TABLE IF EXISTS jp_person");
+            s.execute("DROP TABLE IF EXISTS jp_owns");
+            s.execute("CREATE TABLE jp_host   (id varchar(100) primary key, status varchar(20), name varchar(50), rack varchar(20))");
+            s.execute("CREATE TABLE jp_person (id varchar(100) primary key, status varchar(20), name varchar(50))");
+            s.execute("CREATE TABLE jp_owns   (id varchar(100) primary key, src_id varchar(100), src_label varchar(20), dst_id varchar(100), dst_label varchar(20))");
+            s.execute("INSERT INTO jp_host VALUES ('root','open','root','r0'),('h1','open','alpha','r1'),('h2','open','bravo','r2'),('h3','closed','charlie','r3')");
+            s.execute("INSERT INTO jp_person VALUES ('p1','open','delta'),('p2','open','echo')");
+            s.execute("INSERT INTO jp_owns VALUES " +
+                    "('o1','root','host','h1','host'),('o2','root','host','h2','host'),('o3','root','host','h3','host')," +
+                    "('o4','root','host','p1','person'),('o5','root','host','p2','person'),('o6','h1','host','p1','person')");
+        }
+        String dir = new File(JdbcMultiHopPushdownTest.class.getResource("/configuration/joinpushdown/graph.json").toURI()).getParent();
+        Configuration conf = new BaseConfiguration();
+        conf.setProperty(Graph.GRAPH, UniGraph.class.getName());
+        conf.setProperty("graphName", "multihop");
+        conf.setProperty("providers", dir);
+        g = UniGraph.open(conf).traversal();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        if (g != null) g.close();
+    }
+
+    @Before
+    public void clearTiming() {
+        TimingExecuterListener.timing.clear();
+    }
+
+    private static boolean multiJoinedPerson() {
+        return TimingExecuterListener.timing.keySet().stream().anyMatch(sql -> {
+            String q = sql.toLowerCase().replaceAll("\\s+", " ");
+            // two edge aliases join into person: e0/e1 pattern or two joins of jp_owns
+            int owns = countOccurrences(q, "jp_owns");
+            return q.contains("join") && owns >= 2 && q.contains("jp_person");
+        });
+    }
+
+    private static int countOccurrences(String hay, String needle) {
+        int c = 0, i = 0;
+        while ((i = hay.indexOf(needle, i)) >= 0) {
+            c++;
+            i += needle.length();
+        }
+        return c;
+    }
+
+    @Test
+    public void twoHopOutOutReachesPerson() {
+        // root -> h1 -> p1
+        assertEquals(1L, (long) g.V("root").out("owns").out("owns").hasLabel("person").count().next());
+        assertTrue("expected multi-join involving jp_owns twice and jp_person", multiJoinedPerson());
+    }
+
+    @Test
+    public void twoHopWithFinalHasAndLimit() {
+        assertEquals(1L, (long) g.V("root").out("owns").out("owns")
+                .has("status", "open").limit(5).count().next());
+        assertTrue(multiJoinedPerson());
+    }
+
+    @Test
+    public void singleHopStillWorks() {
+        assertEquals(2L, (long) g.V("root").out("owns").hasLabel("host").has("status", "open").count().next());
+    }
+
+    @Test
+    public void twoHopOutThenOutE() {
+        // root → h1 → edge o6 (h1→p1)
+        assertEquals(1L, (long) g.V("root").out("owns").outE("owns").count().next());
+        assertTrue("expected multi-join for out().outE()", multiJoinedOwnsTwice());
+    }
+
+    @Test
+    public void twoHopOutThenOutEWithLimit() {
+        assertEquals(1L, (long) g.V("root").out("owns").outE("owns").limit(10).count().next());
+        assertTrue(multiJoinedOwnsTwice());
+    }
+
+    private static boolean multiJoinedOwnsTwice() {
+        return TimingExecuterListener.timing.keySet().stream().anyMatch(sql -> {
+            String q = sql.toLowerCase().replaceAll("\\s+", " ");
+            return q.contains("join") && countOccurrences(q, "jp_owns") >= 2;
+        });
+    }
+
+    @Test
+    public void killSwitchFallsBackButStaysCorrect() {
+        // Re-open graph with multi-hop disabled
+        String dir;
+        try {
+            dir = new File(JdbcMultiHopPushdownTest.class.getResource("/configuration/joinpushdown/graph.json").toURI()).getParent();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        Configuration conf = new BaseConfiguration();
+        conf.setProperty(Graph.GRAPH, UniGraph.class.getName());
+        conf.setProperty("graphName", "multihop-off");
+        conf.setProperty("providers", dir);
+        conf.setProperty("jdbc.multiHopPushdown", false);
+        GraphTraversalSource g2 = null;
+        try {
+            g2 = UniGraph.open(conf).traversal();
+            TimingExecuterListener.timing.clear();
+            assertEquals(1L, (long) g2.V("root").out("owns").out("owns").hasLabel("person").count().next());
+            assertFalse("kill-switch must not multi-join", multiJoinedPerson());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        } finally {
+            if (g2 != null) {
+                try { g2.close(); } catch (Exception ignored) {}
+            }
+        }
+    }
+}

--- a/unipop-rest/src/org/unipop/rest/RestController.java
+++ b/unipop-rest/src/org/unipop/rest/RestController.java
@@ -19,6 +19,9 @@ import org.unipop.query.mutation.RemoveQuery;
 import org.unipop.query.search.DeferredVertexQuery;
 import org.unipop.query.search.SearchQuery;
 import org.unipop.query.search.SearchVertexQuery;
+import org.unipop.schema.catalog.SchemaCatalog;
+import org.unipop.schema.catalog.SchemaCatalogAware;
+import org.unipop.schema.catalog.SchemaContributor;
 import org.unipop.schema.element.ElementSchema;
 import org.unipop.schema.reference.DeferredVertex;
 import org.unipop.structure.traversalfilter.TraversalFilter;
@@ -35,7 +38,7 @@ import java.util.stream.Collectors;
 /**
  * Created by sbarzilay on 24/11/16.
  */
-public class RestController implements SimpleController {
+public class RestController implements SimpleController, SchemaContributor, SchemaCatalogAware {
     private static final Logger logger = LoggerFactory.getLogger(RestController.class);
 
     private final UniGraph graph;
@@ -44,6 +47,7 @@ public class RestController implements SimpleController {
     private Set<? extends RestEdgeSchema> edgeSchemas = new HashSet<>();
 
     TraversalFilter traversalFilter;
+    private SchemaCatalog schemaCatalog;
 
     public RestController(UniGraph graph, Set<RestSchema> schemas, TraversalFilter traversalFilter) {
 
@@ -56,6 +60,24 @@ public class RestController implements SimpleController {
                 .map(schema -> ((RestEdgeSchema) schema)).collect(Collectors.toSet());
 
         logger.debug("Instantiated RestController: {}", this);
+    }
+
+    @Override
+    public Set<? extends ElementSchema> contributedSchemas() {
+        Set<ElementSchema> schemas = new HashSet<>();
+        if (vertexSchemas != null) schemas.addAll(vertexSchemas);
+        if (edgeSchemas != null) schemas.addAll(edgeSchemas);
+        return schemas;
+    }
+
+    @Override
+    public void setSchemaCatalog(SchemaCatalog catalog) {
+        this.schemaCatalog = catalog;
+    }
+
+    private <S extends ElementSchema> Collection<? extends S> pruneByLabels(Collection<? extends S> schemas, Set<String> labels) {
+        if (schemaCatalog == null || labels == null || labels.isEmpty() || schemas == null) return schemas;
+        return schemaCatalog.filterByLabels(schemas, labels);
     }
 
     private Set<RestSchema> collectSchemas(Set<? extends ElementSchema> schemas) {
@@ -77,7 +99,15 @@ public class RestController implements SimpleController {
                 new RestCollector<>(schema -> schema.getSearch(uniQuery),
                         (schema, result) -> schema.parseResults(result, uniQuery));
 
-        Map<RestEdgeSchema, BaseRequest> schemas = edgeSchemas.stream()
+        Collection<? extends RestEdgeSchema> edgeCandidates = edgeSchemas;
+        if (schemaCatalog != null) {
+            Set<String> srcLabels = SchemaCatalog.labelsOf(uniQuery.getVertices());
+            Set<ElementSchema> byEndpoint = schemaCatalog.edgesFrom(srcLabels, uniQuery.getDirection());
+            edgeCandidates = edgeSchemas.stream().filter(byEndpoint::contains).collect(Collectors.toList());
+        }
+        edgeCandidates = pruneByLabels(edgeCandidates, SchemaCatalog.extractClosedLabels(uniQuery.getPredicates()));
+
+        Map<RestEdgeSchema, BaseRequest> schemas = edgeCandidates.stream()
                 .filter(schema -> this.traversalFilter.filter(schema, uniQuery.getTraversal())).collect(collector);
 
         return search(uniQuery, schemas, collector);
@@ -88,7 +118,11 @@ public class RestController implements SimpleController {
         RestCollector<RestSchema<E>, BaseRequest, E> collector =
                 new RestCollector<>(schema -> schema.getSearch(uniQuery),
                         (schema, result) -> schema.parseResults(result, uniQuery));
-        Set<? extends RestSchema<E>> schemas = getSchemas(uniQuery.getReturnType());
+        Set<String> labels = SchemaCatalog.extractClosedLabels(uniQuery.getPredicates());
+        Set<? extends RestSchema<E>> allSchemas = getSchemas(uniQuery.getReturnType());
+        Collection<? extends RestSchema<E>> schemas = (schemaCatalog == null || labels.isEmpty())
+                ? allSchemas
+                : schemaCatalog.filterByLabels(allSchemas, labels);
         Map<RestSchema<E>, BaseRequest> collect = schemas.stream()
                 .filter(schema -> this.traversalFilter.filter(schema,uniQuery.getTraversal())).collect(collector);
         return search(uniQuery, collect, collector);
@@ -100,7 +134,9 @@ public class RestController implements SimpleController {
         RestCollector<RestVertexSchema, BaseRequest, Vertex> collector =
                 new RestCollector<>(schema -> schema.getSearch(uniQuery),
                         (schema, result) -> schema.parseResults(result, uniQuery));
-        Map<RestVertexSchema, BaseRequest> schemas = vertexSchemas.stream()
+        Set<String> labels = SchemaCatalog.labelsOf(uniQuery.getVertices());
+        labels.addAll(SchemaCatalog.extractClosedLabels(uniQuery.getPredicates()));
+        Map<RestVertexSchema, BaseRequest> schemas = pruneByLabels(vertexSchemas, labels).stream()
                 .filter(schema -> this.traversalFilter.filter(schema,uniQuery.getTraversal())).collect(collector);
         Iterator<Vertex> iterator = search(uniQuery, schemas, collector);
         Map<Object, DeferredVertex> vertexMap = uniQuery.getVertices().stream()

--- a/unipop-rest/src/org/unipop/rest/schema/RestEdge.java
+++ b/unipop-rest/src/org/unipop/rest/schema/RestEdge.java
@@ -34,6 +34,16 @@ public class RestEdge extends AbstractRestSchema<Edge> implements RestEdgeSchema
         this.inVertexSchema = createVertexSchema("inVertex");
     }
 
+    @Override
+    public VertexSchema getOutVertexSchema() {
+        return outVertexSchema;
+    }
+
+    @Override
+    public VertexSchema getInVertexSchema() {
+        return inVertexSchema;
+    }
+
     protected VertexSchema createVertexSchema(String key) throws JSONException {
         JSONObject vertexConfiguration = this.json.optJSONObject(key);
         if (vertexConfiguration == null) return null;


### PR DESCRIPTION
## Summary

- Add an **internal TinkerGraph schema catalog** of configured vertex/edge types (labels, properties, endpoints, join capabilities) built on provider load/reload.
- Use the catalog to **prune search and join fan-out** (JDBC, Elastic, REST), push **order** only when a type can honor the keys, and plan multi-hop topology.
- **Hydrate Postgres enum domains** from `pg_enum` (with optional config `values`/`include`) so closed label sets are known without listing members by hand.
- Collapse eligible **2-hop** chains into one multi-join SQL:
  - vertex-final: `out()/in()` → `out()/in()`
  - edge-final: `out()/in()` → `outE()/inE()`
  with path-preserving mid reconstruction, sequential fallback, and `jdbc.multiHopPushdown` kill-switch.

## Test plan

- [x] `SchemaCatalogTest` (core)
- [x] `EnumDomainLoaderTest`, `EnumPropertySchemaTest`
- [x] `JdbcMultiHopPushdownTest` (vertex-final + edge-final + kill-switch)
- [x] `JdbcJoinPushdownTest`
- [x] `JdbcFeatureTest` — 20 fail / 0 err (baseline)
- [x] `JdbcStructureSuite` — 30 fail / 16 err (unchanged partial compliance)