### PR TITLE
feat(core): skip source-vertex scan for unbounded g.V().out()/in()/both() via edge-scan rewrite

### DIFF
--- a/unipop-core/src/org/unipop/process/strategyregistrar/StandardStrategyProvider.java
+++ b/unipop-core/src/org/unipop/process/strategyregistrar/StandardStrategyProvider.java
@@ -12,6 +12,7 @@ import org.unipop.process.repeat.UniGraphRepeatStepStrategy;
 import org.unipop.process.graph.UniGraphStepStrategy;
 import org.unipop.process.union.UniGraphUnionStepStrategy;
 import org.unipop.process.vertex.UniGraphVertexStepStrategy;
+import org.unipop.process.vertex.UnboundedVertexAdjacencyStrategy;
 import org.unipop.process.where.UniGraphWhereStepStrategy;
 
 public class StandardStrategyProvider implements StrategyProvider {
@@ -19,6 +20,7 @@ public class StandardStrategyProvider implements StrategyProvider {
     public TraversalStrategies get() {
         DefaultTraversalStrategies traversalStrategies = new DefaultTraversalStrategies();
         traversalStrategies.addStrategies(
+                new UnboundedVertexAdjacencyStrategy(),
                 new UniGraphStepStrategy(),
                 new UniGraphVertexStepStrategy(),
                 new EdgeStepsStrategy(),

--- a/unipop-core/src/org/unipop/process/vertex/UnboundedVertexAdjacencyStrategy.java
+++ b/unipop-core/src/org/unipop/process/vertex/UnboundedVertexAdjacencyStrategy.java
@@ -1,0 +1,97 @@
+package org.unipop.process.vertex;
+
+import com.google.common.collect.Sets;
+import org.apache.tinkerpop.gremlin.process.traversal.P;
+import org.apache.tinkerpop.gremlin.process.traversal.Step;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.HasStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.EdgeVertexStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.GraphStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
+import org.apache.tinkerpop.gremlin.structure.Direction;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.unipop.process.edge.EdgeStepsStrategy;
+import org.unipop.process.graph.UniGraphStepStrategy;
+import org.unipop.structure.UniGraph;
+
+import java.util.Set;
+
+/**
+ * Rewrites an unbounded {@code g.V().out(L)} / {@code in(L)} / {@code both(L)} into the equivalent
+ * {@code g.E().hasLabel(L).inV()} / {@code outV()} / {@code bothV()} so the traversal starts by
+ * scanning the edge store directly instead of enumerating every source vertex only to use its id as
+ * an adjacency seed. The rewrite is a pure step-shape transformation on the native TinkerPop steps;
+ * it runs before {@link UniGraphStepStrategy} / {@link UniGraphVertexStepStrategy} /
+ * {@link EdgeStepsStrategy}, which then convert the injected {@code E()} + edge-vertex step to the
+ * Uni steps and fold the trailing {@code has()} into the produced-vertex fetch as usual. The result
+ * multiset is identical to the original (each edge contributes its neighbour exactly as {@code out()}
+ * over all vertices does).
+ *
+ * <p>Opt-in via {@code unipop.unboundedAdjacencyScan} (default off). It only fires when the source
+ * vertex is a pure seed — no ids ({@code g.V()} is unbounded), no step label on the source, and the
+ * traversal needs neither PATH, LABELED_PATH nor SACK — because those would reference the source
+ * vertex the rewrite discards. Any miss falls back to the unchanged path.
+ */
+public class UnboundedVertexAdjacencyStrategy extends AbstractTraversalStrategy<TraversalStrategy.ProviderOptimizationStrategy> implements TraversalStrategy.ProviderOptimizationStrategy {
+
+    @Override
+    public Set<Class<? extends ProviderOptimizationStrategy>> applyPost() {
+        // Must run before these so they adopt the E() + edge-vertex step we inject
+        // (applyPost = strategies that run AFTER this one).
+        return Sets.newHashSet(UniGraphStepStrategy.class, UniGraphVertexStepStrategy.class, EdgeStepsStrategy.class);
+    }
+
+    @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public void apply(Traversal.Admin<?, ?> traversal) {
+        if (TraversalHelper.onGraphComputer(traversal)) return;
+
+        Graph graph = traversal.getGraph().orElse(null);
+        if (!(graph instanceof UniGraph)) return;
+        UniGraph uniGraph = (UniGraph) graph;
+        if (!uniGraph.configuration().getBoolean("unipop.unboundedAdjacencyScan", false)) return;
+
+        // The source vertex would leak through any of these; if so, keep it (fall back entirely).
+        Set<TraverserRequirement> reqs = traversal.getTraverserRequirements();
+        if (reqs.contains(TraverserRequirement.PATH)
+                || reqs.contains(TraverserRequirement.LABELED_PATH)
+                || reqs.contains(TraverserRequirement.SACK)) return;
+
+        for (GraphStep gs : TraversalHelper.getStepsOfClass(GraphStep.class, traversal)) {
+            if (!gs.isStartStep()) continue;
+            if (!Vertex.class.isAssignableFrom(gs.getReturnClass())) continue;
+            if (gs.getIds().length != 0) continue;          // bounded g.V(id...) -> keep
+            if (!gs.getLabels().isEmpty()) continue;        // labeled source (as()) may be select()ed -> keep
+
+            Step<?, ?> next = gs.getNextStep();
+            if (!(next instanceof VertexStep)) continue;    // a has()/other step between V() and the hop -> keep
+            VertexStep<?> vs = (VertexStep<?>) next;
+            if (!vs.returnsVertex()) continue;              // outE()/inE()/bothE() -> keep (v1: vertex hops only)
+
+            // out() neighbour is the edge's IN vertex; in() the OUT; both() -> both.
+            Direction hop = vs.getDirection();
+            Direction edgeVertexDir = hop.equals(Direction.OUT) ? Direction.IN
+                    : hop.equals(Direction.IN) ? Direction.OUT : Direction.BOTH;
+            String[] edgeLabels = vs.getEdgeLabels();
+
+            GraphStep edgeStep = new GraphStep(traversal, Edge.class, true);
+            EdgeVertexStep edgeVertexStep = new EdgeVertexStep(traversal, edgeVertexDir);
+            vs.getLabels().forEach(edgeVertexStep::addLabel);
+
+            TraversalHelper.replaceStep((Step) gs, (Step) edgeStep, traversal);
+            TraversalHelper.replaceStep((Step) vs, (Step) edgeVertexStep, traversal);
+            if (edgeLabels.length > 0) {
+                HasStep labelHas = new HasStep(traversal, new HasContainer(T.label.getAccessor(), P.within(edgeLabels)));
+                TraversalHelper.insertAfterStep(labelHas, edgeStep, traversal);
+            }
+        }
+    }
+}

--- a/unipop-jdbc/test/org/unipop/jdbc/adjacency/JdbcUnboundedAdjacencyTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/adjacency/JdbcUnboundedAdjacencyTest.java
@@ -1,0 +1,160 @@
+package org.unipop.jdbc.adjacency;
+
+import org.apache.commons.configuration2.BaseConfiguration;
+import org.apache.commons.configuration2.Configuration;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.Path;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.unipop.jdbc.suite.EmbeddedPostgresServer;
+import org.unipop.jdbc.utils.TimingExecuterListener;
+import org.unipop.structure.UniGraph;
+
+import java.io.File;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unbounded g.V().out(L)/in(L)/both(L) is rewritten to g.E().hasLabel(L).inV()/outV()/bothV(),
+ * eliminating the source-vertex scan while preserving results (including the trailing has() push-down).
+ * Gated by the unipop.unboundedAdjacencyScan flag. Uses the joinpushdown schema (jp_host/jp_person/jp_owns).
+ */
+public class JdbcUnboundedAdjacencyTest {
+
+    private static GraphTraversalSource g;
+
+    private static void createData() throws Exception {
+        Class.forName("org.postgresql.Driver");
+        try (Connection c = DriverManager.getConnection(EmbeddedPostgresServer.URL, EmbeddedPostgresServer.USER, "");
+             Statement s = c.createStatement()) {
+            s.execute("DROP TABLE IF EXISTS jp_host");
+            s.execute("DROP TABLE IF EXISTS jp_person");
+            s.execute("DROP TABLE IF EXISTS jp_owns");
+            s.execute("CREATE TABLE jp_host   (id varchar(100) primary key, status varchar(20), name varchar(50), rack varchar(20))");
+            s.execute("CREATE TABLE jp_person (id varchar(100) primary key, status varchar(20), name varchar(50))");
+            s.execute("CREATE TABLE jp_owns   (id varchar(100) primary key, src_id varchar(100), src_label varchar(20), dst_id varchar(100), dst_label varchar(20))");
+            s.execute("INSERT INTO jp_host VALUES ('root','open','root','r0'),('h1','open','alpha','r1'),('h2','open','bravo','r2'),('h3','closed','charlie','r3')");
+            s.execute("INSERT INTO jp_person VALUES ('p1','open','delta'),('p2','open','echo')");
+            s.execute("INSERT INTO jp_owns VALUES " +
+                    "('o1','root','host','h1','host'),('o2','root','host','h2','host'),('o3','root','host','h3','host')," +
+                    "('o4','root','host','p1','person'),('o5','root','host','p2','person'),('o6','h1','host','p1','person')");
+        }
+    }
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        EmbeddedPostgresServer.ensureStarted();
+        createData();
+        String dir = new File(JdbcUnboundedAdjacencyTest.class.getResource("/configuration/joinpushdown/graph.json").toURI()).getParent();
+        Configuration conf = new BaseConfiguration();
+        conf.setProperty(Graph.GRAPH, UniGraph.class.getName());
+        conf.setProperty("graphName", "joinpushdown");
+        conf.setProperty("providers", dir);
+        conf.setProperty("unipop.unboundedAdjacencyScan", true);
+        g = UniGraph.open(conf).traversal();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        if (g != null) g.close();
+    }
+
+    @Before
+    public void clearTiming() {
+        TimingExecuterListener.timing.clear();
+    }
+
+    private static boolean ranAgainst(String table) {
+        return TimingExecuterListener.timing.keySet().stream()
+                .anyMatch(sql -> sql.toLowerCase().contains("from " + table.toLowerCase()));
+    }
+
+    // --- Correctness (results identical to native semantics) ---
+
+    @Test
+    public void outAllNeighbours() {
+        // 6 owns edges -> 6 in-vertices (h1,h2,h3,p1,p2,p1)
+        assertEquals(6L, (long) g.V().out("owns").count().next());
+    }
+
+    @Test
+    public void outHasFiltersTarget() {
+        // hosts with status open reachable via owns: h1,h2 (h3 closed; persons excluded)
+        assertEquals(2L, (long) g.V().out("owns").hasLabel("host").has("status", "open").count().next());
+        assertEquals(3L, (long) g.V().out("owns").hasLabel("host").count().next());
+    }
+
+    @Test
+    public void inNeighbours() {
+        // out-vertices of all owns edges: root x5, h1 x1 = 6 (all hosts)
+        assertEquals(6L, (long) g.V().in("owns").count().next());
+        assertEquals(6L, (long) g.V().in("owns").hasLabel("host").count().next());
+    }
+
+    @Test
+    public void bothNeighboursNoDoubleCount() {
+        // 6 edges x 2 endpoints = 12; person endpoints = p1,p2,p1 = 3
+        assertEquals(12L, (long) g.V().both("owns").count().next());
+        assertEquals(3L, (long) g.V().both("owns").hasLabel("person").count().next());
+    }
+
+    // --- The optimization: source-vertex scan eliminated ---
+
+    @Test
+    public void eliminatesSourceScan() {
+        assertEquals(2L, (long) g.V().out("owns").hasLabel("host").has("status", "open").count().next());
+        assertTrue("edge table must be scanned as the start (g.E())", ranAgainst("jp_owns"));
+        assertFalse("person source table must NOT be scanned once g.V() is eliminated", ranAgainst("jp_person"));
+    }
+
+    // --- Guards: must fall back (keep source) when source identity is used ---
+
+    @Test
+    public void pathKeepsSource() {
+        // g.V().out().path() = [sourceV, targetV]; rewrite would drop sourceV, so it must fall back.
+        List<Path> paths = g.V().out("owns").path().toList();
+        assertEquals(6, paths.size());
+        paths.forEach(p -> assertEquals(2, p.size()));
+    }
+
+    @Test
+    public void labeledSourceKeptForSelect() {
+        // select('a') returns the SOURCE vertices; rewrite must fall back so 'a' still resolves.
+        List<Vertex> sources = g.V().as("a").out("owns").<Vertex>select("a").toList();
+        assertEquals(6, sources.size());
+    }
+
+    @Test
+    public void boundedSourceNotRewritten() {
+        // g.V("root") is bounded; must keep normal semantics (root owns 5: h1,h2,h3,p1,p2) not scan all edges.
+        assertEquals(5L, (long) g.V("root").out("owns").count().next());
+    }
+
+    // --- Flag gate (control): flag off => old path, source scanned ---
+
+    @Test
+    public void flagOffScansSource() throws Exception {
+        String dir = new File(getClass().getResource("/configuration/joinpushdown/graph.json").toURI()).getParent();
+        Configuration conf = new BaseConfiguration();
+        conf.setProperty(Graph.GRAPH, UniGraph.class.getName());
+        conf.setProperty("graphName", "joinpushdown");
+        conf.setProperty("providers", dir);
+        // no unipop.unboundedAdjacencyScan -> defaults off
+        try (Graph off = UniGraph.open(conf)) {
+            GraphTraversalSource gOff = off.traversal();
+            TimingExecuterListener.timing.clear();
+            assertEquals(2L, (long) gOff.V().out("owns").hasLabel("host").has("status", "open").count().next());
+            assertTrue("flag off => g.V() enumerates all vertices, incl. jp_person", ranAgainst("jp_person"));
+        }
+    }
+}


### PR DESCRIPTION
## Problem

An unbounded `g.V().out(L).has(k,v)` enumerates **every** source vertex just to use its id as an adjacency seed, then fetches edges in `⌈N/bulk⌉` per-batch id-listed queries. Because `out()` over *all* vertices is identical to expanding every edge to its target, that whole source-vertex scan is pure overhead.

## Change

`UnboundedVertexAdjacencyStrategy` rewrites the native steps early (before `UniGraphStep`/`UniGraphVertexStep`/`EdgeSteps` strategies, via `applyPost`) into the equivalent edge-first form:

| From | To |
|---|---|
| `g.V().out(L)`  | `g.E().hasLabel(L).inV()` |
| `g.V().in(L)`   | `g.E().hasLabel(L).outV()` |
| `g.V().both(L)` | `g.E().hasLabel(L).bothV()` |

`g.E()` is an edge start-scan — **no vertex source scan** — and the trailing `has()` folds into the produced-vertex fetch through the *existing* `EdgeStepsStrategy` push-down. No new step, no query/schema changes — just a step-shape rewrite that reuses the proven machinery. The result multiset is identical (each edge contributes its neighbour exactly as `out()` over all vertices does).

Example — `g.V().out('owns').hasLabel('host').has('status','open')` now runs:
```
[UniGraphStep(edge,[]), UniGraphEdgeVertexStep(IN), CountGlobalStep]
  select * from jp_owns where true                                    -- edge start scan
  select * from jp_host where id in (...) and status='open'           -- bounded, has() pushed
```
The former full scans of `jp_host` **and** `jp_person` for `g.V()` are gone.

## Gating & guards

- **Opt-in:** `unipop.unboundedAdjacencyScan` (default **off**). Off ⇒ early-return before touching any traversal.
- **Guards (else fall back unchanged):** `g.V()` unbounded (no ids), no step label on the source (`as()`), and the traversal needs none of `PATH`/`LABELED_PATH`/`SACK` — anything that would reference the source vertex the rewrite discards.

## Testing

- **New** `JdbcUnboundedAdjacencyTest` (9): source-scan elimination, `has()` push-down, `out()/in()/both()` correctness incl. no-double-count, and guard fallbacks (`path()`, `as().select()`, bounded `g.V(id)`), plus a flag-off control.
- **No regressions:** `JdbcJoinPushdownTest` 11/11, `JdbcAdjacencyFilterTest` 9/9.
- **Full compliance suites:** feature + structure run **with the flag on** produce a byte-identical failing set to flag-off and to plain master (65 failures, same test names) — verified by diffing failure names, not just counts. The pre-existing 20 feature / 30+16 structure failures are the partial-federation gaps, unchanged.

## Follow-ups (not included)

- Single-SQL-join variant (`edges JOIN target WHERE has()`) for DB-side target filtering when edge-read volume dominates.
- `outE()/inE()/bothE()` and the Elasticsearch backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)