### PR TITLE
feat(jdbc): single edge→target JOIN for unbounded g.V().out().has() (stacked on #172)

### DIFF
--- a/unipop-core/src/org/unipop/process/vertex/UnboundedVertexAdjacencyStrategy.java
+++ b/unipop-core/src/org/unipop/process/vertex/UnboundedVertexAdjacencyStrategy.java
@@ -20,6 +20,9 @@ import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.unipop.process.edge.EdgeStepsStrategy;
 import org.unipop.process.graph.UniGraphStepStrategy;
+import org.unipop.process.predicate.PredicatesUtil;
+import org.unipop.query.controller.SupportsUnboundedAdjacency;
+import org.unipop.query.search.SearchVertexQuery;
 import org.unipop.structure.UniGraph;
 
 import java.util.Set;
@@ -65,6 +68,13 @@ public class UnboundedVertexAdjacencyStrategy extends AbstractTraversalStrategy<
                 || reqs.contains(TraverserRequirement.LABELED_PATH)
                 || reqs.contains(TraverserRequirement.SACK)) return;
 
+        // If a search controller can honour an unbounded-source SearchVertexQuery, fold the whole
+        // hop into a single edge-JOIN start step; otherwise use the backend-agnostic g.E().<adj>()
+        // rewrite (which reaches the same result via an edge scan + deferred target fetch).
+        boolean joinCapable = uniGraph.getControllerManager()
+                .getControllers(SearchVertexQuery.SearchVertexController.class).stream()
+                .anyMatch(c -> c instanceof SupportsUnboundedAdjacency);
+
         for (GraphStep gs : TraversalHelper.getStepsOfClass(GraphStep.class, traversal)) {
             if (!gs.isStartStep()) continue;
             if (!Vertex.class.isAssignableFrom(gs.getReturnClass())) continue;
@@ -76,7 +86,17 @@ public class UnboundedVertexAdjacencyStrategy extends AbstractTraversalStrategy<
             VertexStep<?> vs = (VertexStep<?>) next;
             if (!vs.returnsVertex()) continue;              // outE()/inE()/bothE() -> keep (v1: vertex hops only)
 
-            // out() neighbour is the edge's IN vertex; in() the OUT; both() -> both.
+            if (joinCapable) {
+                // Single edge-JOIN start step; collectVertexPredicates folds the trailing has() into
+                // its target predicates (edge labels come from the VertexStep in the step's ctor).
+                UniGraphUnboundedAdjacencyStep joinStep = new UniGraphUnboundedAdjacencyStep(vs, uniGraph, uniGraph.getControllerManager());
+                traversal.removeStep(gs);
+                TraversalHelper.replaceStep((Step) vs, (Step) joinStep, traversal);
+                joinStep.setVertexPredicates(PredicatesUtil.collectVertexPredicates(joinStep, traversal));
+                continue;
+            }
+
+            // Backend-agnostic rewrite: out() neighbour is the edge's IN vertex; in() the OUT; both() -> both.
             Direction hop = vs.getDirection();
             Direction edgeVertexDir = hop.equals(Direction.OUT) ? Direction.IN
                     : hop.equals(Direction.IN) ? Direction.OUT : Direction.BOTH;

--- a/unipop-core/src/org/unipop/process/vertex/UniGraphUnboundedAdjacencyStep.java
+++ b/unipop-core/src/org/unipop/process/vertex/UniGraphUnboundedAdjacencyStep.java
@@ -1,0 +1,199 @@
+package org.unipop.process.vertex;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Order;
+import org.apache.tinkerpop.gremlin.process.traversal.P;
+import org.apache.tinkerpop.gremlin.process.traversal.Step;
+import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.step.Profiling;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.AbstractStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer;
+import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
+import org.apache.tinkerpop.gremlin.process.traversal.util.FastNoSuchElementException;
+import org.apache.tinkerpop.gremlin.process.traversal.util.MutableMetrics;
+import org.apache.tinkerpop.gremlin.structure.Direction;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.util.iterator.EmptyIterator;
+import org.javatuples.Pair;
+import org.unipop.process.order.Orderable;
+import org.unipop.process.predicate.ReceivesPredicatesHolder;
+import org.unipop.process.properties.PropertyFetcher;
+import org.unipop.query.StepDescriptor;
+import org.unipop.query.controller.ControllerManager;
+import org.unipop.query.predicates.PredicatesHolder;
+import org.unipop.query.predicates.PredicatesHolderFactory;
+import org.unipop.query.search.DeferredVertexQuery;
+import org.unipop.query.search.SearchVertexQuery;
+import org.unipop.schema.reference.DeferredVertex;
+import org.unipop.structure.UniEdge;
+import org.unipop.structure.UniGraph;
+import org.unipop.util.ConversionUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Start step for an unbounded {@code g.V().out(L)/in(L)/both(L)} adjacency hop: it issues one
+ * unbounded-source {@link SearchVertexQuery} (no source-id bound) against the edge store, so a
+ * JDBC controller can resolve it as a single {@code edges JOIN target WHERE has()} — skipping the
+ * source-vertex scan AND the per-batch id lists — and emits the produced neighbours directly.
+ *
+ * <p>Used by {@link UnboundedVertexAdjacencyStrategy} only when a search controller advertises
+ * {@link org.unipop.query.controller.SupportsUnboundedAdjacency}; other backends keep the
+ * {@code g.E().<adjacency>()} rewrite instead. Because the JOIN can still decline (inner edge
+ * schemas, no join-capable schema), this step also handles the deferred fallback: plain neighbours
+ * are hydrated and filtered by a {@link DeferredVertexQuery}, dropping non-matches while preserving
+ * duplicate-id instances (both()).
+ */
+public class UniGraphUnboundedAdjacencyStep extends AbstractStep<Vertex, Vertex>
+        implements ReceivesPredicatesHolder<Vertex, Vertex>, Orderable, Profiling, PropertyFetcher {
+
+    private final Direction direction;
+    private PredicatesHolder predicates;                 // edge query (edge-label) predicates
+    private PredicatesHolder vertexPredicates = PredicatesHolderFactory.empty(); // target has()
+    private List<Pair<String, Order>> orders;
+    private int limit = -1;
+    private final List<SearchVertexQuery.SearchVertexController> controllers;
+    private final List<DeferredVertexQuery.DeferredVertexController> deferredVertexControllers;
+    private StepDescriptor stepDescriptor;
+    private Iterator<Traverser.Admin<Vertex>> results = EmptyIterator.instance();
+    private boolean queried = false;
+
+    public UniGraphUnboundedAdjacencyStep(VertexStep<?> vertexStep, UniGraph graph, ControllerManager controllerManager) {
+        super(vertexStep.getTraversal());
+        vertexStep.getLabels().forEach(this::addLabel);
+        this.direction = vertexStep.getDirection();
+        if (vertexStep.getEdgeLabels().length > 0) {
+            HasContainer labelsPredicate = new HasContainer(T.label.getAccessor(), P.within(vertexStep.getEdgeLabels()));
+            this.predicates = PredicatesHolderFactory.predicate(labelsPredicate);
+        } else this.predicates = PredicatesHolderFactory.empty();
+        this.controllers = controllerManager.getControllers(SearchVertexQuery.SearchVertexController.class);
+        this.deferredVertexControllers = controllerManager.getControllers(DeferredVertexQuery.DeferredVertexController.class);
+        this.stepDescriptor = new StepDescriptor(this);
+    }
+
+    @Override
+    protected Traverser.Admin<Vertex> processNextStart() {
+        if (!queried) {
+            results = query();
+            queried = true;
+        }
+        if (results.hasNext()) return results.next();
+        throw FastNoSuchElementException.instance();
+    }
+
+    private Iterator<Traverser.Admin<Vertex>> query() {
+        SearchVertexQuery vertexQuery = new SearchVertexQuery(Edge.class, Collections.emptyList(), direction,
+                predicates, /*edgeLimit*/ -1, /*edge propertyKeys*/ null, /*edgeOrders*/ null,
+                /*targetPredicates*/ vertexPredicates, /*targetOrders*/ orders, /*targetLimit*/ limit,
+                /*hydrateTarget*/ true, /*allSources*/ true, stepDescriptor, traversal);
+
+        List<Vertex> targets = controllers.stream().<Iterator<Edge>>map(controller -> controller.search(vertexQuery))
+                .<Edge>flatMap(ConversionUtils::asStream)
+                .<Vertex>flatMap(edge -> targetsOf(edge).stream())
+                .collect(Collectors.toList());
+
+        // Deferred fallback (edges not produced by the JOIN): the neighbours are unhydrated and
+        // unfiltered -- hydrate + filter them by a bounded DeferredVertexQuery, then drop non-matches.
+        List<DeferredVertex> deferred = targets.stream()
+                .filter(v -> v instanceof DeferredVertex).map(v -> (DeferredVertex) v)
+                .filter(DeferredVertex::isDeferred).collect(Collectors.toList());
+        if (!deferred.isEmpty()) {
+            DeferredVertexQuery query = new DeferredVertexQuery(deferred, vertexPredicates, null, orders, stepDescriptor, traversal);
+            deferredVertexControllers.forEach(controller -> controller.fetchProperties(query));
+            if (vertexPredicates.notEmpty()) {
+                // Keep every instance whose id matched (the filtered fetch un-defers one instance per
+                // matched id; both() emits the same id twice, so filter by id -- not by instance).
+                Set<Object> matchedIds = deferred.stream().filter(d -> !d.isDeferred())
+                        .map(DeferredVertex::id).collect(Collectors.toSet());
+                targets = targets.stream()
+                        .filter(v -> !(v instanceof DeferredVertex) || matchedIds.contains(((DeferredVertex) v).id()))
+                        .collect(Collectors.toList());
+            }
+        }
+
+        return targets.stream()
+                .<Traverser.Admin<Vertex>>map(v -> traversal.getTraverserGenerator().generate(v, (Step) this, 1L))
+                .iterator();
+    }
+
+    /** The neighbour(s) an edge contributes. JOIN edges carry the hydrated target as inVertex (a
+     *  uniform convention, see RowEdgeSchema.fromJoinRow); plain edges map by hop direction. */
+    private List<Vertex> targetsOf(Edge edge) {
+        if (edge instanceof UniEdge && ((UniEdge) edge).isAdjacencyJoinDirected())
+            return Collections.singletonList(edge.inVertex());
+        if (direction.equals(Direction.BOTH)) {
+            List<Vertex> both = new ArrayList<>(2);
+            both.add(edge.outVertex());
+            both.add(edge.inVertex());
+            return both;
+        }
+        return Collections.singletonList(direction.equals(Direction.IN) ? edge.outVertex() : edge.inVertex());
+    }
+
+    @Override
+    public void reset() {
+        super.reset();
+        this.queried = false;
+        this.results = EmptyIterator.instance();
+    }
+
+    @Override
+    public Set<TraverserRequirement> getRequirements() {
+        return Collections.singleton(TraverserRequirement.OBJECT);
+    }
+
+    @Override
+    public void addPredicate(PredicatesHolder predicatesHolder) {
+        this.predicates = PredicatesHolderFactory.and(this.predicates, predicatesHolder);
+    }
+
+    @Override
+    public PredicatesHolder getPredicates() {
+        return predicates;
+    }
+
+    public void setVertexPredicates(PredicatesHolder vertexPredicates) {
+        this.vertexPredicates = vertexPredicates == null ? PredicatesHolderFactory.empty() : vertexPredicates;
+    }
+
+    @Override
+    public void setLimit(int limit) {
+        this.limit = limit;
+    }
+
+    @Override
+    public void setOrders(List<Pair<String, Order>> orders) {
+        this.orders = orders;
+    }
+
+    @Override
+    public void setMetrics(MutableMetrics metrics) {
+        this.stepDescriptor = new StepDescriptor(this, metrics);
+    }
+
+    // PropertyFetcher: a vertex-returning adjacency always hydrates all target properties (the JOIN
+    // projects the whole target row; the deferred fetch requests all keys), mirroring
+    // UniGraphVertexStep's fetch-all-for-vertex behaviour. So key registration is a no-op -- the
+    // point of implementing the interface is that UniGraphPropertiesStrategy finds this as the
+    // property fetcher for a following by()/values()/has() instead of tripping over none.
+    @Override
+    public void addPropertyKey(String key) { }
+
+    @Override
+    public void fetchAllKeys() { }
+
+    @Override
+    public Set<String> getKeys() { return null; }
+
+    @Override
+    public String toString() {
+        return org.apache.tinkerpop.gremlin.structure.util.StringFactory.stepString(this, this.direction);
+    }
+}

--- a/unipop-core/src/org/unipop/query/controller/SupportsUnboundedAdjacency.java
+++ b/unipop-core/src/org/unipop/query/controller/SupportsUnboundedAdjacency.java
@@ -1,0 +1,13 @@
+package org.unipop.query.controller;
+
+/**
+ * Marker for a {@link org.unipop.query.search.SearchVertexQuery.SearchVertexController} that can honour
+ * an unbounded-source SearchVertexQuery ({@code isAllSources()}) — i.e. run the adjacency as a direct
+ * edge query with no source-id bound (single JOIN when possible, edge-label-only scan otherwise).
+ *
+ * <p>UnboundedVertexAdjacencyStrategy uses the single-JOIN start step only when at least one search
+ * controller advertises this; otherwise it keeps the backend-agnostic {@code g.E().<adjacency>()}
+ * rewrite, so a controller that does not implement the allSources contract is never handed one.
+ */
+public interface SupportsUnboundedAdjacency {
+}

--- a/unipop-core/src/org/unipop/query/search/SearchVertexQuery.java
+++ b/unipop-core/src/org/unipop/query/search/SearchVertexQuery.java
@@ -24,6 +24,9 @@ public class SearchVertexQuery extends SearchQuery<Edge> implements VertexQuery 
     private final List<Pair<String, Order>> targetOrders;
     private final int targetLimit;
     private final boolean hydrateTarget;
+    // When true the source side is unbounded ("all edges"): the edge query must NOT add a source-id
+    // bound (and must not abort on an empty vertex list) -- it means "match all sources", not "none".
+    private final boolean allSources;
 
     // Backward-compatible: edge-return / callers with no target intent.
     public SearchVertexQuery(Class<Edge> returnType, List<Vertex> vertices, Direction direction, PredicatesHolder predicates, int limit, Set<String> propertyKeys, List<Pair<String, Order>> orders, StepDescriptor stepDescriptor, Traversal traversal) {
@@ -37,6 +40,11 @@ public class SearchVertexQuery extends SearchQuery<Edge> implements VertexQuery 
     }
 
     public SearchVertexQuery(Class<Edge> returnType, List<Vertex> vertices, Direction direction, PredicatesHolder predicates, int limit, Set<String> propertyKeys, List<Pair<String, Order>> orders, PredicatesHolder targetPredicates, List<Pair<String, Order>> targetOrders, int targetLimit, boolean hydrateTarget, StepDescriptor stepDescriptor, Traversal traversal) {
+        this(returnType, vertices, direction, predicates, limit, propertyKeys, orders, targetPredicates, targetOrders, targetLimit, hydrateTarget, false, stepDescriptor, traversal);
+    }
+
+    // Full constructor including the unbounded-source flag.
+    public SearchVertexQuery(Class<Edge> returnType, List<Vertex> vertices, Direction direction, PredicatesHolder predicates, int limit, Set<String> propertyKeys, List<Pair<String, Order>> orders, PredicatesHolder targetPredicates, List<Pair<String, Order>> targetOrders, int targetLimit, boolean hydrateTarget, boolean allSources, StepDescriptor stepDescriptor, Traversal traversal) {
         super(returnType, predicates, limit, propertyKeys, orders, stepDescriptor, traversal);
         this.vertices = vertices;
         this.direction = direction;
@@ -44,6 +52,7 @@ public class SearchVertexQuery extends SearchQuery<Edge> implements VertexQuery 
         this.targetOrders = targetOrders;
         this.targetLimit = targetLimit;
         this.hydrateTarget = hydrateTarget;
+        this.allSources = allSources;
     }
 
     public PredicatesHolder getTargetPredicates() {
@@ -60,6 +69,10 @@ public class SearchVertexQuery extends SearchQuery<Edge> implements VertexQuery 
 
     public boolean isHydrateTarget() {
         return hydrateTarget;
+    }
+
+    public boolean isAllSources() {
+        return allSources;
     }
 
     @Override

--- a/unipop-jdbc/src/org/unipop/jdbc/controller/simple/RowController.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/controller/simple/RowController.java
@@ -24,6 +24,7 @@ import org.unipop.jdbc.utils.ContextManager;
 import org.unipop.jdbc.utils.TimingExecuterListener;
 import org.unipop.query.UniQuery;
 import org.unipop.query.controller.SimpleController;
+import org.unipop.query.controller.SupportsUnboundedAdjacency;
 import org.unipop.query.mutation.AddEdgeQuery;
 import org.unipop.query.mutation.AddVertexQuery;
 import org.unipop.query.mutation.PropertyQuery;
@@ -56,7 +57,7 @@ import static org.jooq.impl.DSL.table;
  * @author Gur Ronen
  * @since 6/12/2016
  */
-public class RowController implements SimpleController {
+public class RowController implements SimpleController, SupportsUnboundedAdjacency {
     protected final static Logger logger = LoggerFactory.getLogger(RowController.class);
 
     private final ContextManager contextManager;
@@ -131,14 +132,26 @@ public class RowController implements SimpleController {
 
     @Override
     public Iterator<Edge> search(SearchVertexQuery uniQuery) {
+        // Flush pending buffered writes before reading. searchJoin() fetches directly (it does not
+        // route through the generic search() that flushes at line ~322), so without this an adjacency
+        // query that runs before any flushing read -- e.g. an unbounded-source start step, the first
+        // step in the traversal -- would read stale data (missing just-added vertices/edges).
+        if (!bulk.isEmpty()) {
+            contextManager.batch(bulk);
+            bulk.clear();
+        }
         if (joinApplicable(uniQuery)) {
             Iterator<Edge> joined = searchJoin(uniQuery);
             if (joined != null) return joined;
         }
-        // Fallback: existing id-only edge path (unchanged).
+        // Fallback: existing id-only edge path. For an unbounded source (allSources) there is no
+        // source-id bound -- use the edge-label predicates only, so the query matches all edges
+        // rather than aborting on the empty vertex list (which means "none", not "all").
         SelectCollector<JdbcSchema<Edge>, Select, Edge> collector = new SelectCollector<>(
                 schema -> schema.getSearch(uniQuery,
-                        ((JdbcEdgeSchema) schema).toPredicates(uniQuery.getVertices(), uniQuery.getDirection(), uniQuery.getPredicates())),
+                        uniQuery.isAllSources()
+                                ? schema.toPredicates(uniQuery.getPredicates())
+                                : ((JdbcEdgeSchema) schema).toPredicates(uniQuery.getVertices(), uniQuery.getDirection(), uniQuery.getPredicates())),
                 (schema, results) -> schema.parseResults(results, uniQuery)
         );
 

--- a/unipop-jdbc/src/org/unipop/jdbc/schemas/RowEdgeSchema.java
+++ b/unipop-jdbc/src/org/unipop/jdbc/schemas/RowEdgeSchema.java
@@ -136,7 +136,11 @@ public class RowEdgeSchema extends AbstractRowSchema<Edge> implements JdbcEdgeSc
 
         PredicatesHolder tgtHolder = vertexSchema.toPredicates(query.getTargetPredicates());
         if (tgtHolder.isAborted()) return null;
-        PredicatesHolder edgeHolder = this.toPredicates(query.getVertices(), directedDir, query.getPredicates());
+        // Unbounded source: no src-id bound, just the edge-label predicates (a single JOIN over the
+        // whole edge table filtered to the matching targets); otherwise bound by the source ids.
+        PredicatesHolder edgeHolder = query.isAllSources()
+                ? this.toPredicates(query.getPredicates())
+                : this.toPredicates(query.getVertices(), directedDir, query.getPredicates());
         if (edgeHolder.isAborted()) return null;
 
         Condition edgeCond = this.buildTranslator("e").translate(edgeHolder);

--- a/unipop-jdbc/test/org/unipop/jdbc/adjacency/JdbcUnboundedAdjacencyTest.java
+++ b/unipop-jdbc/test/org/unipop/jdbc/adjacency/JdbcUnboundedAdjacencyTest.java
@@ -79,6 +79,19 @@ public class JdbcUnboundedAdjacencyTest {
                 .anyMatch(sql -> sql.toLowerCase().contains("from " + table.toLowerCase()));
     }
 
+    /** A single query joined the target vertex table (the single-SQL-join push-down ran). */
+    private static boolean ranJoinOnHost() {
+        return TimingExecuterListener.timing.keySet().stream()
+                .anyMatch(sql -> { String q = sql.toLowerCase(); return q.contains("join") && q.contains("jp_host"); });
+    }
+
+    /** A separate, non-join, id-bounded fetch against a target vertex table (the two-query deferred path). */
+    private static boolean ranSeparateVertexFetch() {
+        return TimingExecuterListener.timing.keySet().stream()
+                .anyMatch(sql -> { String q = sql.toLowerCase().replaceAll("\\s+", " ");
+                    return !q.contains("join") && q.contains("from jp_host") && q.contains(" where ") && q.contains(" in ("); });
+    }
+
     // --- Correctness (results identical to native semantics) ---
 
     @Test
@@ -115,6 +128,21 @@ public class JdbcUnboundedAdjacencyTest {
         assertEquals(2L, (long) g.V().out("owns").hasLabel("host").has("status", "open").count().next());
         assertTrue("edge table must be scanned as the start (g.E())", ranAgainst("jp_owns"));
         assertFalse("person source table must NOT be scanned once g.V() is eliminated", ranAgainst("jp_person"));
+    }
+
+    @Test
+    public void multiHopChainsFromJoinStep() {
+        // The join step is the traversal START; its emitted neighbours must seed a following hop.
+        // root->{h1,h2,h3,p1,p2}, h1->p1 ; g.V().out('owns').out('owns') = p1 (from h1) = 1.
+        assertEquals(1L, (long) g.V().out("owns").out("owns").count().next());
+    }
+
+    @Test
+    public void singleJoinNotTwoQueries() {
+        // The unbounded out().has() must fold into ONE join query, not edge-scan + separate target fetch.
+        assertEquals(2L, (long) g.V().out("owns").hasLabel("host").has("status", "open").count().next());
+        assertTrue("expected a single join on jp_host", ranJoinOnHost());
+        assertFalse("join path must not run a separate deferred host fetch", ranSeparateVertexFetch());
     }
 
     // --- Guards: must fall back (keep source) when source identity is used ---


### PR DESCRIPTION
Stacked on #172 (`feat/unbounded-adjacency-scan`) — **review/merge that first**; this PR's diff is only the delta.

## What

#172 eliminates the source-vertex scan by rewriting unbounded `g.V().out(L).has(k,v)` to `g.E().hasLabel(L).inV().has(k,v)` — an edge scan **plus** a separate deferred target fetch (two query phases). This PR collapses that into **one** SQL JOIN when the backend supports it:

```sql
select v.* from edges e join <target> v on e.<endpoint> = v.id where <target has()>
```

DB-side filtering, a single round-trip, and only matching rows returned/materialized (vs. reading every edge into the app first).

## How

- **`SearchVertexQuery.allSources`** — "match all sources", i.e. no source-id bound. Distinct from an empty vertex list, which *aborts* (= match none).
- **`RowEdgeSchema.getJoinSearch` / `RowController` fallback** honour `allSources` (edge-label predicates only, never abort), reusing the #167 join push-down.
- **`SupportsUnboundedAdjacency`** marks `RowController` as `allSources`-capable. The strategy swaps in the JOIN start step **only** when a controller advertises it; every other backend keeps #172's backend-agnostic `g.E().<adjacency>()` rewrite — **no ES regression**.
- **`UniGraphUnboundedAdjacencyStep`** — a start step implementing `Orderable` / `ReceivesPredicatesHolder` / `PropertyFetcher`, so the order/limit/`has()`/property strategies fold into it exactly as they do for `UniGraphVertexStep`. Handles both the JOIN result and a deferred fallback (inner edge schemas, where `searchJoin` declines) that hydrates+filters neighbours and preserves duplicate ids (`both()`).

## Two latent bugs surfaced + fixed

Both were only reachable once an adjacency query can be the **first** query in a traversal — which this start step makes possible:

1. **`RowController.search(SearchVertexQuery)` never flushed the write buffer** before `searchJoin`'s direct fetch (only the generic `search()` flushes). A first-query join read stale data — this caused 56 feature-suite failures until fixed. Now flushes up front.
2. **`UniGraphPropertiesStrategy` `GroupCountStep` branch** dereferences `propertyFetchers` without the null-guard its sibling branches have. Worked around by making the step a `PropertyFetcher` (so the lookup is non-null); the unguarded line is noted for a follow-up hardening.

## Testing

- `JdbcUnboundedAdjacencyTest` (11): single-join-not-two-queries, multi-hop chaining from the join step, `out/in/both`, `has()` push-down, guards, flag gate.
- `JdbcJoinPushdownTest` (11), `JdbcAdjacencyFilterTest` (9): unchanged.
- **Full feature + structure suites run with the flag ON** produce a failing set **byte-identical** to flag-off and to master (65 failures, same names) — verified by diffing failure names. Zero regressions, zero new errors.

## Follow-ups

- Null-guard `UniGraphPropertiesStrategy` GroupCountStep branch (independent latent bug).
- `outE()/inE()/bothE()` and an ES `allSources` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)